### PR TITLE
Script for key CI steps to run in CloudFlare

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# This script is used to run the CloudFlare pages CI build.
+# CloudFlare will automatically install the NPM dependencies.
+
+set -euxo pipefail
+
+# This lint step fails so disabled for now. Does it work upstream?
+npm run check || echo "Temporarily allowed to fail"
+
+# This is very close to passing. Two files need fixing to enable it.
+npx prettier --check src || echo "Temporarily allowed to fail"
+
+npm run test
+npm run build


### PR DESCRIPTION
We're planning to use CloudFlare pages as a way to get main and branch/PR deployments up and running quickly ahead of deploying to Micro:bit Educational Foundation infrastructure. It's [working now](https://ml-trainer.pages.dev/) but it's only running `npm run build`. This PR adds a script with the key CI steps because CloudFlare's build config requires a single command.

Note that 

`npm run check`
and
`npx prettier --check src`

both fail but seem worth considering fixing. Certainly Prettier is very close to passing.

The GHA pipeline build has an additional step. It runs:

```bash
cp -f ./src/__viteBuildVariants__/ml-machine/windi.config.js ./windi.config.js
```

I think this swaps in some brand colours. We can add this to the script if needed.

Tagging @microbit-carlos to check I've raised this PR in the right place and consider reviewing it or passing it on to someone else.