### PR TITLE
Add webusb-serial device

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -17,6 +17,14 @@ module.exports = {
     project: ['./tsconfig.json'],
     extraFileExtensions: ['.svelte'],
   },
+  rules: {
+    "@typescript-eslint/no-unused-vars": [
+        warn,
+        {
+            argsIgnorePattern: "^_"
+        }
+    ],
+  },
   env: {
     es6: true,
     browser: true,

--- a/src/__tests__/license-identifiers.test.ts
+++ b/src/__tests__/license-identifiers.test.ts
@@ -15,9 +15,6 @@ import * as path from 'path';
 const ignoredFiles: string[] = ['.DS_Store'];
 const directoriesToScan = ['./src/', './microbit/v2/source/', './microbit/v1/source/'];
 
-const licenseIdentifierStringContributors =
-  'Center for Computational Thinking and Design at Aarhus University and contributors';
-
 const licenseIdentifierStringSPDX = 'SPDX-License-Identifier:';
 
 const readFile = (fileLocation: string, expect: string) => {
@@ -83,10 +80,7 @@ describe('License identifier tests', () => {
         return acc.concat(flattenDirectory(current));
       }, []);
 
-      const faultyFiles = filesMissingIdentifier(flatten, [
-        licenseIdentifierStringContributors,
-        licenseIdentifierStringSPDX,
-      ]);
+      const faultyFiles = filesMissingIdentifier(flatten, [licenseIdentifierStringSPDX]);
       expect(
         faultyFiles.length,
         'Some files do not contain identifier! ' +

--- a/src/components/connection-prompt/ConnectDialogContainer.svelte
+++ b/src/components/connection-prompt/ConnectDialogContainer.svelte
@@ -1,6 +1,6 @@
 <!--
   (c) 2023, Center for Computational Thinking and Design at Aarhus University and contributors
- 
+
   SPDX-License-Identifier: MIT
  -->
 
@@ -60,8 +60,7 @@
               $connectionDialogState.connectionState =
                 ConnectDialogStates.CONNECT_BATTERY;
             } else if (currentStage === 'usb2') {
-              $connectionDialogState.connectionState =
-                ConnectDialogStates.CONNECT_TUTORIAL_SERIAL;
+              onConnectingSerial();
             }
           })
           .catch(() => {
@@ -85,13 +84,10 @@
   }
 
   function onConnectingSerial(): void {
-    MicrobitSerial.connect(Microbits.getLinked())
-      .then(() => {
-        $connectionDialogState.connectionState = ConnectDialogStates.NONE;
-      })
-      .catch(() => {
-        // Errors to consider: microbit is disconnected, some sort of connection error
-      });
+    $connectionDialogState.connectionState = ConnectDialogStates.NONE;
+    MicrobitSerial.connect(Microbits.getLinked()).catch(() => {
+      // Errors to consider: microbit is disconnected, some sort of connection error
+    });
   }
 
   function connectSame() {
@@ -223,13 +219,6 @@
           $connectionDialogState.connectionState = ConnectDialogStates.NONE;
         }}
         deviceState={$connectionDialogState.deviceState} />
-    {:else if $connectionDialogState.connectionState === ConnectDialogStates.CONNECT_TUTORIAL_SERIAL}
-      CONNECT TUTORIAL SERIAL
-      <SelectMicrobitDialogSerial
-        onBackClick={() =>
-          ($connectionDialogState.connectionState =
-            ConnectDialogStates.CONNECT_TUTORIAL_USB)}
-        onNextClick={onConnectingSerial} />
     {:else if $connectionDialogState.connectionState === ConnectDialogStates.CONNECTING_MICROBITS}
       CONNECTING_MICROBITS
     {:else if $connectionDialogState.connectionState === ConnectDialogStates.USB_START}

--- a/src/components/connection-prompt/ConnectDialogContainer.svelte
+++ b/src/components/connection-prompt/ConnectDialogContainer.svelte
@@ -86,12 +86,12 @@
 
   function onConnectingSerial(): void {
     MicrobitSerial.connect(Microbits.getLinked())
-    .then(() => {
-      $connectionDialogState.connectionState = ConnectDialogStates.NONE;
+      .then(() => {
+        $connectionDialogState.connectionState = ConnectDialogStates.NONE;
       })
-    .catch(() => {
-      // Errors to consider: microbit is disconnected, some sort of connection error
-    })
+      .catch(() => {
+        // Errors to consider: microbit is disconnected, some sort of connection error
+      });
   }
 
   function connectSame() {

--- a/src/components/connection-prompt/ConnectDialogContainer.svelte
+++ b/src/components/connection-prompt/ConnectDialogContainer.svelte
@@ -85,7 +85,7 @@
   }
 
   function onConnectingSerial(): void {
-    MicrobitSerial.connect()
+    MicrobitSerial.connect(Microbits.getLinked())
     .then(() => {
       $connectionDialogState.connectionState = ConnectDialogStates.NONE;
       })

--- a/src/script/microbit-interfacing/MicrobitBluetooth.ts
+++ b/src/script/microbit-interfacing/MicrobitBluetooth.ts
@@ -304,7 +304,8 @@ export class MicrobitBluetooth {
    * @param {Event} event The disconnect event
    * @private
    */
-  private disconnectListener(event: Event): void {
+  private disconnectListener(): void {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     this.device
       .gatt!.connect()
       .then(() => {

--- a/src/script/microbit-interfacing/MicrobitSerial.ts
+++ b/src/script/microbit-interfacing/MicrobitSerial.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const serialNavigator = navigator && navigator.serial;
+import MicrobitUSB from './MicrobitUSB';
 
 const baudRate = 115200;
 
@@ -64,9 +64,8 @@ const processMessage = (message: string) => {
 };
 
 class MicrobitSerial {
-  public static async connect(): Promise<void> {
-    const serialPort = await serialNavigator.requestPort({ filters: [] });
-    await MicrobitSerial.streamData(serialPort, { baudRate });
+  public static async connect(usb: MicrobitUSB): Promise<void> {
+    await MicrobitSerial.streamData(usb.serialPort, { baudRate });
   }
 
   private static async streamData(

--- a/src/script/microbit-interfacing/MicrobitUSB.ts
+++ b/src/script/microbit-interfacing/MicrobitUSB.ts
@@ -5,6 +5,7 @@
  */
 
 import { CortexM, DAPLink, WebUSB } from 'dapjs';
+import { WebUSBSerialDevice } from './WebUSBSerial';
 import MBSpecs from './MBSpecs';
 
 /**
@@ -119,6 +120,10 @@ class MicrobitUSB extends CortexM {
       return Promise.reject(error);
     }
     return Promise.resolve();
+  }
+
+  public get serialPort(): SerialPort {
+    return new WebUSBSerialDevice(this.transport);
   }
 }
 

--- a/src/script/microbit-interfacing/WebUSBSerial.ts
+++ b/src/script/microbit-interfacing/WebUSBSerial.ts
@@ -1,5 +1,7 @@
 /*
- * Copyright (c) 2023 Arm Limited
+ * (c), 2023 Arm Limited
+ *
+ *  SPDX-License-Identifier: MIT
  */
 
 import { WebUSB } from 'dapjs';
@@ -8,243 +10,268 @@ const DEFAULT_SERIAL_DELAY = 100;
 const DAP_WRITE_ABORT = 0x08;
 
 enum AbortMask {
-    /**
-     * Generates a DAP abort, that aborts the current AP transaction
-     */
-    DAPABORT = (1 << 0),
-    /**
-     * Reserved
-     */
-    STKCMPCLR = (1 << 1),
-    /**
-     * Sets the STICKYERR sticky error flag to 0
-     */
-    STKERRCLR = (1 << 2),
-    /**
-     * Sets the WDATAERR write data error flag to 0
-     */
-    WDERRCLR = (1 << 3),
-    /**
-     * Sets the STICKYORUN overrun error flag to 0
-     */
-    ORUNERRCLR = (1 << 4)
+  /**
+   * Generates a DAP abort, that aborts the current AP transaction
+   */
+  DAPABORT = 1 << 0,
+  /**
+   * Reserved
+   */
+  STKCMPCLR = 1 << 1,
+  /**
+   * Sets the STICKYERR sticky error flag to 0
+   */
+  STKERRCLR = 1 << 2,
+  /**
+   * Sets the WDATAERR write data error flag to 0
+   */
+  WDERRCLR = 1 << 3,
+  /**
+   * Sets the STICKYORUN overrun error flag to 0
+   */
+  ORUNERRCLR = 1 << 4,
 }
 
 enum DAPLinkSerial {
-    READ_SETTINGS = 0x81,
-    WRITE_SETTINGS = 0x82,
-    READ = 0x83,
-    WRITE = 0x84
+  READ_SETTINGS = 0x81,
+  WRITE_SETTINGS = 0x82,
+  READ = 0x83,
+  WRITE = 0x84,
 }
 
 export class TypedEventTarget<T extends { [key: string]: Event }> {
-    protected listeners: { [key: string]: Array<(event: T[keyof T]) => void> } = {};
+  protected listeners: { [key: string]: Array<(event: T[keyof T]) => void> } = {};
 
-    public addEventListener(type: keyof T, listener: (this: this, event: T[keyof T]) => void): void {
-        const key = type as string;
-        if (!this.listeners[key]) {
-            this.listeners[key] = [];
-        }
-        this.listeners[key].push(listener);
+  public addEventListener(
+    type: keyof T,
+    listener: (this: this, event: T[keyof T]) => void,
+  ): void {
+    const key = type as string;
+    if (!this.listeners[key]) {
+      this.listeners[key] = [];
+    }
+    this.listeners[key].push(listener);
+  }
+
+  public removeEventListener(
+    type: keyof T,
+    listener: (this: this, event: T[keyof T]) => void,
+  ): void {
+    const key = type as string;
+    if (!this.listeners[key]) {
+      return;
     }
 
-    public removeEventListener(type: keyof T, listener: (this: this, event: T[keyof T]) => void): void {
-        const key = type as string;
-        if (!this.listeners[key]) {
-            return;
-        }
+    this.listeners[key] = this.listeners[key].filter(item => item !== listener);
+  }
 
-        this.listeners[key] = this.listeners[key].filter(item => item !== listener);
+  public dispatchEvent(event: T[keyof T]): boolean {
+    const toDispatch = this.listeners[event.type];
+
+    if (toDispatch) {
+      toDispatch.forEach(dispatch => dispatch(event));
     }
 
-    public dispatchEvent(event: T[keyof T]): boolean {
-        const toDispatch = this.listeners[event.type];
-
-        if (toDispatch) {
-            toDispatch.forEach(dispatch => dispatch(event));
-        }
-
-        return true;
-    }
+    return true;
+  }
 }
 
 export type SerialEvents = {
-    connect: Event;
-    disconnect: Event;
+  connect: Event;
+  disconnect: Event;
 };
 
-export class WebUSBSerialDevice extends TypedEventTarget<SerialEvents> implements SerialPort {
+export class WebUSBSerialDevice
+  extends TypedEventTarget<SerialEvents>
+  implements SerialPort
+{
+  public readable: ReadableStream<Uint8Array> | null = null;
+  public writable: WritableStream<Uint8Array> | null = null;
 
-    public readable: ReadableStream<Uint8Array> | null = null;
-    public writable: WritableStream<Uint8Array> | null = null;
+  protected toWrite: Uint8Array | undefined;
+  protected connected = false;
 
-    protected toWrite: Uint8Array | undefined;
-    protected connected = false;
+  constructor(protected device: WebUSB, protected serialDelay = DEFAULT_SERIAL_DELAY) {
+    super();
+  }
 
-    constructor(protected device: WebUSB, protected serialDelay = DEFAULT_SERIAL_DELAY) {
-        super();
+  public set onconnect(listener: (ev: Event) => void) {
+    this.addEventListener('connect', listener);
+  }
+
+  public set ondisconnect(listener: (ev: Event) => void) {
+    this.addEventListener('disconnect', listener);
+  }
+
+  public getInfo(): SerialPortInfo {
+    // TODO get this from the USB Device?
+    return {
+      usbVendorId: 1, //this.device.vendorId,
+      usbProductId: 1, //this.device.productId
+    };
+  }
+
+  public async open(options: SerialOptions): Promise<void> {
+    await this.connect();
+
+    try {
+      const view = new DataView(new ArrayBuffer(5));
+      view.setUint8(0, DAPLinkSerial.WRITE_SETTINGS);
+      view.setUint32(1, options.baudRate, true);
+      await this.send(new Uint8Array(view.buffer));
+
+      const result = await this.send(new Uint8Array([DAPLinkSerial.READ_SETTINGS]));
+      if (!result) {
+        throw new Error('No result for DAPLinkSerial.READ_SETTINGS');
+      }
+
+      const baudRate = result.getUint32(1, true);
+      if (baudRate !== options.baudRate) {
+        throw new Error(`Failed to set baudrate to ${options.baudRate}`);
+      }
+    } catch (error) {
+      await this.clearAbort();
+      throw error;
     }
 
-    public set onconnect(listener: (ev: Event) => any) {
-        this.addEventListener('connect', listener);
+    this.readable = new ReadableStream<Uint8Array>({
+      start: this.start.bind(this),
+    });
+
+    this.writable = new WritableStream<Uint8Array>({
+      write: this.write.bind(this),
+    });
+  }
+
+  public async close(): Promise<void> {
+    if (this.readable && !this.readable.locked) {
+      await this.readable.cancel();
     }
 
-    public set ondisconnect(listener: (ev: Event) => any) {
-        this.addEventListener('disconnect', listener);
+    if (this.writable) {
+      await this.writable.abort();
     }
 
-    public getInfo(): SerialPortInfo {
-        // TODO get this from the USB Device?
-        return {
-            usbVendorId: 1, //this.device.vendorId,
-            usbProductId: 1 //this.device.productId
-        }
+    await this.disconnect();
+  }
+
+  public async setSignals(_signals: SerialOutputSignals): Promise<void> {
+    // empty method
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  public async getSignals(): Promise<SerialInputSignals> {
+    return {
+      dataCarrierDetect: false,
+      clearToSend: false,
+      ringIndicator: false,
+      dataSetReady: false,
+    };
+  }
+
+  public async forget(): Promise<void> {
+    // Do nothing
+  }
+
+  protected async start(
+    controller: ReadableStreamDefaultController<Uint8Array>,
+  ): Promise<void> {
+    while (this.connected) {
+      const serialData = await this.transfer();
+      if (this.connected && serialData !== undefined) {
+        controller.enqueue(new Uint8Array(serialData));
+      }
+
+      await new Promise(resolve => setTimeout(resolve, this.serialDelay));
+    }
+  }
+
+  protected async write(
+    chunk: Uint8Array,
+    _controller: WritableStreamDefaultController,
+  ): Promise<void> {
+    this.toWrite = chunk;
+    while (this.toWrite !== undefined) {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    }
+  }
+
+  protected async transfer(): Promise<ArrayBuffer | undefined> {
+    try {
+      if (this.toWrite) {
+        // Write chunk to DAPLink
+        const writeArray = new Uint8Array(this.toWrite.byteLength + 2);
+        writeArray.set([DAPLinkSerial.WRITE, this.toWrite.byteLength]);
+        writeArray.set(this.toWrite, 2);
+        await this.send(writeArray);
+      }
+
+      const view = await this.send(new Uint8Array([DAPLinkSerial.READ]));
+      if (!view) {
+        return undefined;
+      }
+
+      // Check if there is any data returned from the device
+      if (view.byteLength === 0) {
+        return undefined;
+      }
+
+      // Second byte contains the actual length of data read from the device
+      const dataLength = view.getUint8(1);
+      if (dataLength === 0) {
+        return undefined;
+      }
+
+      const resultOffset = 2;
+      return view.buffer.slice(resultOffset, resultOffset + dataLength);
+    } catch (error) {
+      await this.clearAbort();
+      throw error;
+    } finally {
+      this.toWrite = undefined;
+    }
+  }
+
+  protected async connect(): Promise<void> {
+    await this.device.open();
+    this.connected = true;
+  }
+
+  protected async disconnect(): Promise<void> {
+    await this.device.close();
+    this.connected = false;
+  }
+
+  protected async send(buffer: Uint8Array): Promise<DataView | undefined> {
+    await this.device.write(buffer);
+    const result = await this.device.read();
+
+    if (result && result.getUint8(0) !== buffer[0]) {
+      throw new Error(`Bad response for ${buffer[0]} -> ${result.getUint8(0)}`);
     }
 
-    public async open(options: SerialOptions): Promise<void> {
-        await this.connect();
+    return result;
+  }
 
-        try {
-            const view = new DataView(new ArrayBuffer(5));
-            view.setUint8(0, DAPLinkSerial.WRITE_SETTINGS);
-            view.setUint32(1, options.baudRate, true);
-            await this.send(new Uint8Array(view.buffer));
-
-            const result = await this.send(new Uint8Array([DAPLinkSerial.READ_SETTINGS]));
-            if (!result) {
-                throw new Error('No result for DAPLinkSerial.READ_SETTINGS');
-            }
-
-            const baudRate = result.getUint32(1, true);
-            if (baudRate !== options.baudRate) {
-                throw new Error(`Failed to set baudrate to ${options.baudRate}`);
-            }
-        } catch (error) {
-            await this.clearAbort();
-            throw error;
-        }
-
-        this.readable = new ReadableStream<Uint8Array>({
-            start: this.start.bind(this)
-        });
-
-        this.writable = new WritableStream<Uint8Array>({
-            write: this.write.bind(this)
-        });
-    }
-
-    public async close(): Promise<void> {
-        if (this.readable && !this.readable.locked) {
-            this.readable.cancel();
-        }
-
-        if (this.writable) {
-            this.writable.abort();
-        }
-
-        await this.disconnect();
-    }
-
-    public async setSignals(_signals: SerialOutputSignals): Promise<void> {
-    }
-
-    public async getSignals(): Promise<SerialInputSignals> {
-        return {
-            dataCarrierDetect: false,
-            clearToSend: false,
-            ringIndicator: false,
-            dataSetReady: false
-        };
-    }
-
-    public async forget(): Promise<void> {
-        // Do nothing
-    }
-
-    protected async start(controller: ReadableStreamDefaultController<Uint8Array>): Promise<void> {
-        while (this.connected) {
-            const serialData = await this.transfer();
-            if (this.connected && serialData !== undefined) {
-                controller.enqueue(new Uint8Array(serialData));
-            }
-
-            await new Promise(resolve => setTimeout(resolve, this.serialDelay));
-        }
-    }
-
-    protected async write(chunk: Uint8Array, _controller: WritableStreamDefaultController): Promise<void> {
-        this.toWrite = chunk;
-        while (this.toWrite !== undefined) {
-            await new Promise(resolve => setTimeout(resolve, 0));
-        }
-    }
-
-    protected async transfer(): Promise<ArrayBuffer | undefined> {
-        try {
-            if (this.toWrite) {
-                // Write chunk to DAPLink
-                const writeArray = new Uint8Array(this.toWrite.byteLength + 2);
-                writeArray.set([DAPLinkSerial.WRITE, this.toWrite.byteLength]);
-                writeArray.set(this.toWrite, 2);
-                await this.send(writeArray);
-            }
-
-            const view = await this.send(new Uint8Array([DAPLinkSerial.READ]));
-            if (!view) {
-                return undefined;
-            }
-
-            // Check if there is any data returned from the device
-            if (view.byteLength === 0) {
-                return undefined;
-            }
-
-            // Second byte contains the actual length of data read from the device
-            const dataLength = view.getUint8(1);
-            if (dataLength === 0) {
-                return undefined;
-            }
-
-            const resultOffset = 2;
-            return view.buffer.slice(resultOffset, resultOffset + dataLength);
-        } catch (error) {
-            await this.clearAbort();
-            throw error;
-        } finally {
-            this.toWrite = undefined;
-        }
-    }
-
-    protected async connect(): Promise<void> {
-        await this.device.open();
-        this.connected = true;
-    }
-
-    protected async disconnect(): Promise<void> {
-        await this.device.close();
-        this.connected = false;
-    }
-
-    protected async send(buffer: Uint8Array): Promise<DataView | undefined> {
-        await this.device.write(buffer);
-        const result = await this.device.read();
-
-        if (result && result.getUint8(0) !== buffer[0]) {
-            throw new Error(`Bad response for ${buffer[0]} -> ${result.getUint8(0)}`);
-        }
-
-        return result;
-    }
-
-    /**
-     * Clears the abort register of all error flags
-     * @param abortMask Optional AbortMask to use, otherwise clears all flags
-     */
-    public async clearAbort(abortMask: number = AbortMask.WDERRCLR | AbortMask.STKERRCLR | AbortMask.STKCMPCLR | AbortMask.ORUNERRCLR): Promise<void> {
-        await this.send(new Uint8Array([DAP_WRITE_ABORT, 0,
-            abortMask & 0xFF,
-            (abortMask >> 8) & 0xFF,
-            (abortMask >> 16) & 0xFF,
-            (abortMask >> 24) & 0xFF]));
-    }
+  /**
+   * Clears the abort register of all error flags
+   * @param abortMask Optional AbortMask to use, otherwise clears all flags
+   */
+  public async clearAbort(
+    abortMask: number = AbortMask.WDERRCLR |
+      AbortMask.STKERRCLR |
+      AbortMask.STKCMPCLR |
+      AbortMask.ORUNERRCLR,
+  ): Promise<void> {
+    await this.send(
+      new Uint8Array([
+        DAP_WRITE_ABORT,
+        0,
+        abortMask & 0xff,
+        (abortMask >> 8) & 0xff,
+        (abortMask >> 16) & 0xff,
+        (abortMask >> 24) & 0xff,
+      ]),
+    );
+  }
 }

--- a/src/script/microbit-interfacing/WebUSBSerial.ts
+++ b/src/script/microbit-interfacing/WebUSBSerial.ts
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2023 Arm Limited
+ */
+
+import { WebUSB } from 'dapjs';
+
+const DEFAULT_SERIAL_DELAY = 100;
+const DAP_WRITE_ABORT = 0x08;
+
+enum AbortMask {
+    /**
+     * Generates a DAP abort, that aborts the current AP transaction
+     */
+    DAPABORT = (1 << 0),
+    /**
+     * Reserved
+     */
+    STKCMPCLR = (1 << 1),
+    /**
+     * Sets the STICKYERR sticky error flag to 0
+     */
+    STKERRCLR = (1 << 2),
+    /**
+     * Sets the WDATAERR write data error flag to 0
+     */
+    WDERRCLR = (1 << 3),
+    /**
+     * Sets the STICKYORUN overrun error flag to 0
+     */
+    ORUNERRCLR = (1 << 4)
+}
+
+enum DAPLinkSerial {
+    READ_SETTINGS = 0x81,
+    WRITE_SETTINGS = 0x82,
+    READ = 0x83,
+    WRITE = 0x84
+}
+
+export class TypedEventTarget<T extends { [key: string]: Event }> {
+    protected listeners: { [key: string]: Array<(event: T[keyof T]) => void> } = {};
+
+    public addEventListener(type: keyof T, listener: (this: this, event: T[keyof T]) => void): void {
+        const key = type as string;
+        if (!this.listeners[key]) {
+            this.listeners[key] = [];
+        }
+        this.listeners[key].push(listener);
+    }
+
+    public removeEventListener(type: keyof T, listener: (this: this, event: T[keyof T]) => void): void {
+        const key = type as string;
+        if (!this.listeners[key]) {
+            return;
+        }
+
+        this.listeners[key] = this.listeners[key].filter(item => item !== listener);
+    }
+
+    public dispatchEvent(event: T[keyof T]): boolean {
+        const toDispatch = this.listeners[event.type];
+
+        if (toDispatch) {
+            toDispatch.forEach(dispatch => dispatch(event));
+        }
+
+        return true;
+    }
+}
+
+export type SerialEvents = {
+    connect: Event;
+    disconnect: Event;
+};
+
+export class WebUSBSerialDevice extends TypedEventTarget<SerialEvents> implements SerialPort {
+
+    public readable: ReadableStream<Uint8Array> | null = null;
+    public writable: WritableStream<Uint8Array> | null = null;
+
+    protected toWrite: Uint8Array | undefined;
+    protected connected = false;
+
+    constructor(protected device: WebUSB, protected serialDelay = DEFAULT_SERIAL_DELAY) {
+        super();
+    }
+
+    public set onconnect(listener: (ev: Event) => any) {
+        this.addEventListener('connect', listener);
+    }
+
+    public set ondisconnect(listener: (ev: Event) => any) {
+        this.addEventListener('disconnect', listener);
+    }
+
+    public getInfo(): SerialPortInfo {
+        // TODO get this from the USB Device?
+        return {
+            usbVendorId: 1, //this.device.vendorId,
+            usbProductId: 1 //this.device.productId
+        }
+    }
+
+    public async open(options: SerialOptions): Promise<void> {
+        await this.connect();
+
+        try {
+            const view = new DataView(new ArrayBuffer(5));
+            view.setUint8(0, DAPLinkSerial.WRITE_SETTINGS);
+            view.setUint32(1, options.baudRate, true);
+            await this.send(new Uint8Array(view.buffer));
+
+            const result = await this.send(new Uint8Array([DAPLinkSerial.READ_SETTINGS]));
+            if (!result) {
+                throw new Error('No result for DAPLinkSerial.READ_SETTINGS');
+            }
+
+            const baudRate = result.getUint32(1, true);
+            if (baudRate !== options.baudRate) {
+                throw new Error(`Failed to set baudrate to ${options.baudRate}`);
+            }
+        } catch (error) {
+            await this.clearAbort();
+            throw error;
+        }
+
+        this.readable = new ReadableStream<Uint8Array>({
+            start: this.start.bind(this)
+        });
+
+        this.writable = new WritableStream<Uint8Array>({
+            write: this.write.bind(this)
+        });
+    }
+
+    public async close(): Promise<void> {
+        if (this.readable && !this.readable.locked) {
+            this.readable.cancel();
+        }
+
+        if (this.writable) {
+            this.writable.abort();
+        }
+
+        await this.disconnect();
+    }
+
+    public async setSignals(_signals: SerialOutputSignals): Promise<void> {
+    }
+
+    public async getSignals(): Promise<SerialInputSignals> {
+        return {
+            dataCarrierDetect: false,
+            clearToSend: false,
+            ringIndicator: false,
+            dataSetReady: false
+        };
+    }
+
+    public async forget(): Promise<void> {
+        // Do nothing
+    }
+
+    protected async start(controller: ReadableStreamDefaultController<Uint8Array>): Promise<void> {
+        while (this.connected) {
+            const serialData = await this.transfer();
+            if (this.connected && serialData !== undefined) {
+                controller.enqueue(new Uint8Array(serialData));
+            }
+
+            await new Promise(resolve => setTimeout(resolve, this.serialDelay));
+        }
+    }
+
+    protected async write(chunk: Uint8Array, _controller: WritableStreamDefaultController): Promise<void> {
+        this.toWrite = chunk;
+        while (this.toWrite !== undefined) {
+            await new Promise(resolve => setTimeout(resolve, 0));
+        }
+    }
+
+    protected async transfer(): Promise<ArrayBuffer | undefined> {
+        try {
+            if (this.toWrite) {
+                // Write chunk to DAPLink
+                const writeArray = new Uint8Array(this.toWrite.byteLength + 2);
+                writeArray.set([DAPLinkSerial.WRITE, this.toWrite.byteLength]);
+                writeArray.set(this.toWrite, 2);
+                await this.send(writeArray);
+            }
+
+            const view = await this.send(new Uint8Array([DAPLinkSerial.READ]));
+            if (!view) {
+                return undefined;
+            }
+
+            // Check if there is any data returned from the device
+            if (view.byteLength === 0) {
+                return undefined;
+            }
+
+            // Second byte contains the actual length of data read from the device
+            const dataLength = view.getUint8(1);
+            if (dataLength === 0) {
+                return undefined;
+            }
+
+            const resultOffset = 2;
+            return view.buffer.slice(resultOffset, resultOffset + dataLength);
+        } catch (error) {
+            await this.clearAbort();
+            throw error;
+        } finally {
+            this.toWrite = undefined;
+        }
+    }
+
+    protected async connect(): Promise<void> {
+        await this.device.open();
+        this.connected = true;
+    }
+
+    protected async disconnect(): Promise<void> {
+        await this.device.close();
+        this.connected = false;
+    }
+
+    protected async send(buffer: Uint8Array): Promise<DataView | undefined> {
+        await this.device.write(buffer);
+        const result = await this.device.read();
+
+        if (result && result.getUint8(0) !== buffer[0]) {
+            throw new Error(`Bad response for ${buffer[0]} -> ${result.getUint8(0)}`);
+        }
+
+        return result;
+    }
+
+    /**
+     * Clears the abort register of all error flags
+     * @param abortMask Optional AbortMask to use, otherwise clears all flags
+     */
+    public async clearAbort(abortMask: number = AbortMask.WDERRCLR | AbortMask.STKERRCLR | AbortMask.STKCMPCLR | AbortMask.ORUNERRCLR): Promise<void> {
+        await this.send(new Uint8Array([DAP_WRITE_ABORT, 0,
+            abortMask & 0xFF,
+            (abortMask >> 8) & 0xFF,
+            (abortMask >> 16) & 0xFF,
+            (abortMask >> 24) & 0xFF]));
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,7 +34,8 @@
     "noFallthroughCasesInSwitch": true,
     "types": [
       "jest",
-      "svelte"
+      "svelte",
+      "w3c-web-serial"
     ]
   },
   "files": [


### PR DESCRIPTION
Add WebUSB Serial device and remove serial dialog.

cc @Marisa-Jenkins @micque01 

FYI, I've used our wrapper class which makes a DAPLink WebUSB device look like a webserial (SerialPort) device.

This has the benefit that it plugs straight into the existing code. However, this could also be implemented by leveraging the serial support in the dapjs library already included (see https://github.com/ARMmbed/dapjs/blob/master/examples/daplink-serial/common.js). This is already included in the project but doesn't look like a serial device and would require changes to wherever it is used.