### PR TITLE
Remove bluetooth connecting progress bar

### DIFF
--- a/src/components/connection-prompt/bluetooth/BluetoothConnectingDialog.svelte
+++ b/src/components/connection-prompt/bluetooth/BluetoothConnectingDialog.svelte
@@ -115,11 +115,6 @@
     <div class="w-650px flex flex-col justify-center items-center">
       <p>{$t('connectMB.bluetooth.connecting')}</p>
       <img alt="loading" src="/imgs/loadingspinner.gif" width="100px" />
-      <div class="bg-primary rounded w-full h-5">
-        <div
-          style="width: {`${timeoutProgress * 100}%`};"
-          class="bg-secondary rounded h-full" />
-      </div>
     </div>
   {/if}
 </main>


### PR DESCRIPTION
Removes the timeout bar when connecting the bluetooth

Previously:
![image](https://github.com/microbit-foundation/cctd-ml-machine/assets/138705536/5c216651-a449-4295-9c99-a07969b42a88)


Current:
![image](https://github.com/microbit-foundation/cctd-ml-machine/assets/138705536/98f6d0dc-e52a-47ea-aae6-c11f8a2a7461)

