### PR TITLE
Fix z-indexes so dialogs appear over all UI

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -61,7 +61,7 @@
           </div>
         </ControlBar>
 
-        <div class="relative z-1 flex-1 flex-row">
+        <div class="relative flex-1 flex-row">
           <PageContentView />
         </div>
 

--- a/src/components/connection-prompt/radio/StartRadioDialog.svelte
+++ b/src/components/connection-prompt/radio/StartRadioDialog.svelte
@@ -1,6 +1,6 @@
 <!--
   (c) 2023, Center for Computational Thinking and Design at Aarhus University and contributors
- 
+
   SPDX-License-Identifier: MIT
  -->
 

--- a/src/components/control-bar/ControlBar.svelte
+++ b/src/components/control-bar/ControlBar.svelte
@@ -10,7 +10,7 @@
     color: white;
     position: sticky;
     top: 0;
-    z-index: 5;
+    z-index: 4;
   }
 </style>
 


### PR DESCRIPTION
Fix z-indexes of elements so dialogs always appear above UI.

## Before:
![Screenshot 2023-12-05 at 11 18 10](https://github.com/microbit-foundation/cctd-ml-machine/assets/11059840/872db559-cd18-491d-a8ba-b3d62d872424)

![Screenshot 2023-12-05 at 11 17 30](https://github.com/microbit-foundation/cctd-ml-machine/assets/11059840/9b1ec9e8-0770-4478-bd4c-99de1087d133)

## After:
![Screenshot 2023-12-05 at 11 15 36](https://github.com/microbit-foundation/cctd-ml-machine/assets/11059840/1b543409-4aa1-4050-a0f0-d4ce184e73ab)

![Screenshot 2023-12-05 at 11 17 17](https://github.com/microbit-foundation/cctd-ml-machine/assets/11059840/71981a6d-4cfd-4928-af6c-0faed532e308)
