### PR TITLE
Add computer icon and alt texts provided for the V2 design

### DIFF
--- a/public/imgs/stylised_computer.svg
+++ b/public/imgs/stylised_computer.svg
@@ -1,0 +1,17 @@
+<svg id="Group_311" data-name="Group 311" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="173.082" height="120" viewBox="0 0 173.082 120">
+  <defs>
+    <clipPath id="clip-path">
+      <rect id="Rectangle_466" data-name="Rectangle 466" width="173.082" height="120" fill="none"/>
+    </clipPath>
+  </defs>
+  <g id="Group_310" data-name="Group 310" clip-path="url(#clip-path)">
+    <path id="Path_813" data-name="Path 813" d="M143.059,4a4,4,0,0,1,4,4V97.666H26.023V8a4,4,0,0,1,4-4Zm0-4H30.023a8.024,8.024,0,0,0-8,8v93.666H151.059V8a8.024,8.024,0,0,0-8-8"/>
+    <path id="Path_814" data-name="Path 814" d="M169.082,101.871V112a4,4,0,0,1-4,4H8a4,4,0,0,1-4-4V101.871Zm0-4H4a4,4,0,0,0-4,4V112a8,8,0,0,0,8,8H165.082a8,8,0,0,0,8-8V101.871a4,4,0,0,0-4-4"/>
+    <path id="Path_815" data-name="Path 815" d="M78.146,44.261A5.961,5.961,0,1,1,72.187,38.3,5.961,5.961,0,0,1,78.146,44.261Z" fill="none" stroke="#48ac34" stroke-miterlimit="10" stroke-width="3"/>
+    <path id="Path_816" data-name="Path 816" d="M92.157,74.846A5.96,5.96,0,1,1,86.2,68.885,5.961,5.961,0,0,1,92.157,74.846Z" fill="none" stroke="#48ac34" stroke-miterlimit="10" stroke-width="3"/>
+    <rect id="Rectangle_465" data-name="Rectangle 465" width="10.96" height="10.959" transform="translate(94.743 35.757)" fill="none" stroke="#48ac34" stroke-linejoin="round" stroke-width="3"/>
+    <path id="Path_817" data-name="Path 817" d="M78.458,28.675l7.752-7.747,7.748,7.75" fill="none" stroke="#48ac34" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
+    <line id="Line_86" data-name="Line 86" x1="0.011" y2="43.834" transform="translate(86.198 24.286)" fill="none" stroke="#48ac34" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
+    <path id="Path_818" data-name="Path 818" d="M72.184,50.22v5.289a3.179,3.179,0,0,0,3.178,3.18l21.424,0a3.179,3.179,0,0,0,3.18-3.178l0-8.544" fill="none" stroke="#48ac34" stroke-linejoin="round" stroke-width="3"/>
+  </g>
+</svg>

--- a/src/components/connection-prompt/bluetooth/ConnectBatteryDialog.svelte
+++ b/src/components/connection-prompt/bluetooth/ConnectBatteryDialog.svelte
@@ -20,7 +20,7 @@
     <p>{$t('connectMB.connectBattery.subtitle')}</p>
     <img
       src="/imgs/stylised-microbit-connected.svg"
-      alt="Battery connection diagram"
+      alt="Showing the batteries need to go into the battery pack and the battery pack should be connected at the top left of the micro:bit."
       class="px-40 pt-5" />
   </div>
   <div class="justify-end gap-x-5 flex pt-10">

--- a/src/components/connection-prompt/bluetooth/ConnectCableDialog.svelte
+++ b/src/components/connection-prompt/bluetooth/ConnectCableDialog.svelte
@@ -36,7 +36,7 @@
     </p>
     <img
       src="imgs/connect-cable.gif"
-      alt="GIF of connecting micro:bit"
+      alt="USB cable being connected at the top, centre of the micro:bit."
       class="px-55 py-5" />
   </div>
   <div class="flex">

--- a/src/components/connection-prompt/bluetooth/StartBluetoothDialog.svelte
+++ b/src/components/connection-prompt/bluetooth/StartBluetoothDialog.svelte
@@ -30,7 +30,7 @@
         </p>
       </div>
       <div>
-        <img src="" alt="PLACEHOLDER" />
+        <img src="../public/imgs/stylised_computer.svg" alt="PLACEHOLDER" />
         <p class="pt-10 text-center font-bold">
           {$t('connectMB.bluetoothStart.requirements3')}
         </p>

--- a/src/components/connection-prompt/bluetooth/StartBluetoothDialog.svelte
+++ b/src/components/connection-prompt/bluetooth/StartBluetoothDialog.svelte
@@ -30,7 +30,7 @@
         </p>
       </div>
       <div>
-        <img src="../public/imgs/stylised_computer.svg" alt="PLACEHOLDER" />
+        <img src="/imgs/stylised_computer.svg" alt="PLACEHOLDER" />
         <p class="pt-10 text-center font-bold">
           {$t('connectMB.bluetoothStart.requirements3')}
         </p>

--- a/src/components/connection-prompt/radio/StartRadioDialog.svelte
+++ b/src/components/connection-prompt/radio/StartRadioDialog.svelte
@@ -29,7 +29,7 @@
         </p>
       </div>
       <div>
-        <img src="" alt="PLACEHOLDER" />
+        <img src="../public/imgs/stylised_computer.svg" alt="PLACEHOLDER" />
         <p class="pt-10 text-center font-bold">
           {$t('connectMB.radioStart.requirements3')}
         </p>

--- a/src/components/connection-prompt/radio/StartRadioDialog.svelte
+++ b/src/components/connection-prompt/radio/StartRadioDialog.svelte
@@ -29,7 +29,7 @@
         </p>
       </div>
       <div>
-        <img src="../public/imgs/stylised_computer.svg" alt="PLACEHOLDER" />
+        <img src="/imgs/stylised_computer.svg" alt="PLACEHOLDER" />
         <p class="pt-10 text-center font-bold">
           {$t('connectMB.radioStart.requirements3')}
         </p>

--- a/src/components/connection-prompt/usb/SelectMicrobitDialogUsb.svelte
+++ b/src/components/connection-prompt/usb/SelectMicrobitDialogUsb.svelte
@@ -30,7 +30,7 @@
     </p>
     <img
       src="/imgs/select-microbit.png"
-      alt="Instructions on how to choose microbit from web popup using usb"
+      alt="Screenshot of the browser window that will appear next.  Your connected micro:bit will be listed. Choose your micro:bit then select the Connect button."
       class="left-0 pt-5" />
     <p class="absolute left-3/4 transform -translate-x-1/2 top-1/2 -translate-y-28">
       {$t('connectMB.webPopup.instruction1')}


### PR DESCRIPTION
Added missing alt texts that were provided for the V2 design.

Added missing image for the first dialog for the bluetooth and the radio connection:
![image](https://github.com/microbit-foundation/cctd-ml-machine/assets/138705536/cce9ac3f-7e5a-41a5-ad6a-4a50e28874d9)

![image](https://github.com/microbit-foundation/cctd-ml-machine/assets/138705536/21ceb82a-66d4-4629-a068-8b4e5e21ac6d)