### PR TITLE
Model page remove output panels

### DIFF
--- a/src/components/output/OutputGesture.svelte
+++ b/src/components/output/OutputGesture.svelte
@@ -1,6 +1,6 @@
 <!--
   (c) 2023, Center for Computational Thinking and Design at Aarhus University and contributors
- 
+
   SPDX-License-Identifier: MIT
  -->
 <script lang="ts">
@@ -11,9 +11,6 @@
   import { state } from '../../script/stores/uiStore';
   import OutputGestureStack from './OutputGestureStack.svelte';
   import OutputGestureTile from './OutputGestureTile.svelte';
-
-  // Bool flag that determines the visibility of the output gesture panels
-  export let enableOutputGestures = false;
 
   export let gesture: GestureData;
   let wasTriggered = false;
@@ -59,7 +56,7 @@
 </script>
 
 {#if variant === 'stack'}
-  <OutputGestureStack {gesture} {onUserInteraction} {enableOutputGestures} />
+  <OutputGestureStack {gesture} {onUserInteraction} />
 {/if}
 
 {#if variant === 'tile'}

--- a/src/components/output/OutputGesture.svelte
+++ b/src/components/output/OutputGesture.svelte
@@ -4,7 +4,6 @@
   SPDX-License-Identifier: MIT
  -->
 <script lang="ts">
-  import CookieManager from '../../script/CookieManager';
   import Gestures from '../../script/Gestures';
   import ConnectionBehaviours from '../../script/connection-behaviours/ConnectionBehaviours';
   import Microbits from '../../script/microbit-interfacing/Microbits';
@@ -12,6 +11,9 @@
   import { state } from '../../script/stores/uiStore';
   import OutputGestureStack from './OutputGestureStack.svelte';
   import OutputGestureTile from './OutputGestureTile.svelte';
+
+  // Bool flag that determines the visibility of the output gesture panels
+  export let enableOutputGestures = false;
 
   export let gesture: GestureData;
   let wasTriggered = false;
@@ -57,7 +59,7 @@
 </script>
 
 {#if variant === 'stack'}
-  <OutputGestureStack {gesture} {onUserInteraction} />
+  <OutputGestureStack {gesture} {onUserInteraction} enableOutputGestures={enableOutputGestures} />
 {/if}
 
 {#if variant === 'tile'}

--- a/src/components/output/OutputGesture.svelte
+++ b/src/components/output/OutputGesture.svelte
@@ -59,7 +59,7 @@
 </script>
 
 {#if variant === 'stack'}
-  <OutputGestureStack {gesture} {onUserInteraction} enableOutputGestures={enableOutputGestures} />
+  <OutputGestureStack {gesture} {onUserInteraction} {enableOutputGestures} />
 {/if}
 
 {#if variant === 'tile'}

--- a/src/components/output/OutputGestureStack.svelte
+++ b/src/components/output/OutputGestureStack.svelte
@@ -38,6 +38,8 @@
 
   type TriggerAction = 'turnOn' | 'turnOff' | 'none';
 
+  const enableOutputGestures = false;
+
   // Variables for component
   export let gesture: GestureData;
   export let onUserInteraction: () => void = () => {
@@ -262,33 +264,35 @@
       width="30px" />
   </div>
 
-  <!-- OUTPUT SETTINGS -->
-  <div class="relative flex items-center">
-    <div
-      class="w-177px relative rounded-xl bg-transparent h-full border-1 border-primaryborder">
-      <ImageSkeleton
-        src="imgs/blank_microbit.svg"
-        alt="microbit guide"
-        width={177}
-        height={144}
-        loadingColorSecondary="#818181"
-        loadingColorPrimary="#4A4A4A"
-        onLoaded={() => (hasLoadedMicrobitImage = true)} />
+  {#if enableOutputGestures}
+    <!-- OUTPUT SETTINGS -->
+    <div class="relative flex items-center">
       <div
-        class="bg-black p-0 m-0 absolute top-9 left-12.7"
-        class:hidden={!hasLoadedMicrobitImage}
-        on:click={onUserInteraction}>
-        <OutputMatrix bind:trigger={triggerFunctions[0]} {gesture} />
+        class="w-177px relative rounded-xl bg-transparent h-full border-1 border-primaryborder">
+        <ImageSkeleton
+          src="imgs/blank_microbit.svg"
+          alt="microbit guide"
+          width={177}
+          height={144}
+          loadingColorSecondary="#818181"
+          loadingColorPrimary="#4A4A4A"
+          onLoaded={() => (hasLoadedMicrobitImage = true)} />
+        <div
+          class="bg-black p-0 m-0 absolute top-9 left-12.7"
+          class:hidden={!hasLoadedMicrobitImage}
+          on:click={onUserInteraction}>
+          <OutputMatrix bind:trigger={triggerFunctions[0]} {gesture} />
+        </div>
       </div>
+      <OutputSoundSelector onSoundSelection={onSoundSelected} {selectedSound} />
     </div>
-    <OutputSoundSelector onSoundSelection={onSoundSelected} {selectedSound} />
-  </div>
-  <div class="ml-4">
-    <PinSelector
-      selectedPin={pinIOEnabled ? selectedPin : undefined}
-      {turnOnState}
-      {turnOnTime}
-      {onPinSelect}
-      {onTurnOnTimeSelect} />
-  </div>
+    <div class="ml-4">
+      <PinSelector
+        selectedPin={pinIOEnabled ? selectedPin : undefined}
+        {turnOnState}
+        {turnOnTime}
+        {onPinSelect}
+        {onTurnOnTimeSelect} />
+    </div>
+  {/if}
 </main>

--- a/src/components/output/OutputGestureStack.svelte
+++ b/src/components/output/OutputGestureStack.svelte
@@ -38,7 +38,8 @@
 
   type TriggerAction = 'turnOn' | 'turnOff' | 'none';
 
-  const enableOutputGestures = false;
+  // Bool flag that determines the visibility of the output gesture panels
+  export let enableOutputGestures = false;
 
   // Variables for component
   export let gesture: GestureData;
@@ -248,23 +249,23 @@
     </div>
   </GestureTilePart>
 
-  <!-- ARROW -->
-  <div class="text-center w-15">
-    <img
-      class="m-auto"
-      class:hidden={wasTriggered}
-      src={'imgs/right_arrow.svg'}
-      alt="right arrow icon"
-      width="30px" />
-    <img
-      class="m-auto"
-      class:hidden={!wasTriggered || !$state.isInputReady}
-      src={'imgs/right_arrow_blue.svg'}
-      alt="right arrow icon"
-      width="30px" />
-  </div>
-
   {#if enableOutputGestures}
+    <!-- ARROW -->
+    <div class="text-center w-15">
+      <img
+        class="m-auto"
+        class:hidden={wasTriggered}
+        src={'imgs/right_arrow.svg'}
+        alt="right arrow icon"
+        width="30px" />
+      <img
+        class="m-auto"
+        class:hidden={!wasTriggered || !$state.isInputReady}
+        src={'imgs/right_arrow_blue.svg'}
+        alt="right arrow icon"
+        width="30px" />
+    </div>
+
     <!-- OUTPUT SETTINGS -->
     <div class="relative flex items-center">
       <div

--- a/src/components/output/OutputGestureStack.svelte
+++ b/src/components/output/OutputGestureStack.svelte
@@ -38,9 +38,6 @@
 
   type TriggerAction = 'turnOn' | 'turnOff' | 'none';
 
-  // Bool flag that determines the visibility of the output gesture panels
-  export let enableOutputGestures = false;
-
   // Variables for component
   export let gesture: GestureData;
   export let onUserInteraction: () => void = () => {
@@ -62,6 +59,9 @@
     : StaticConfiguration.defaultPinTurnOnState;
 
   const confidence = Gestures.getConfidence(gesture.ID);
+
+  // Bool flag that determines the visibility of the output gesture panels
+  const enableOutputGestures = false;
 
   let requiredConfidence = StaticConfiguration.defaultRequiredConfidence;
   $: currentConfidence = $state.isInputReady ? $confidence : 0;

--- a/src/pages/model/ModelPage.svelte
+++ b/src/pages/model/ModelPage.svelte
@@ -17,6 +17,6 @@
   {#if $state.modelView == ModelView.TILE}
     <ModelPageTileView />
   {:else}
-    <ModelPageStackView enableOutputGestures={false} />
+    <ModelPageStackView />
   {/if}
 </div>

--- a/src/pages/model/ModelPage.svelte
+++ b/src/pages/model/ModelPage.svelte
@@ -17,6 +17,6 @@
   {#if $state.modelView == ModelView.TILE}
     <ModelPageTileView />
   {:else}
-    <ModelPageStackView />
+    <ModelPageStackView enableOutputGestures={false}/>
   {/if}
 </div>

--- a/src/pages/model/ModelPage.svelte
+++ b/src/pages/model/ModelPage.svelte
@@ -17,6 +17,6 @@
   {#if $state.modelView == ModelView.TILE}
     <ModelPageTileView />
   {:else}
-    <ModelPageStackView enableOutputGestures={false}/>
+    <ModelPageStackView enableOutputGestures={false} />
   {/if}
 </div>

--- a/src/pages/model/ModelPageStackView.svelte
+++ b/src/pages/model/ModelPageStackView.svelte
@@ -134,7 +134,11 @@
       <div class="pl-1">
         <!-- Display all gestures and their output capabilities -->
         {#each $gestures as gesture}
-          <OutputGesture variant="stack" {gesture} {onUserInteraction} enableOutputGestures={enableOutputGestures}/>
+          <OutputGesture
+            variant="stack"
+            {gesture}
+            {onUserInteraction}
+            {enableOutputGestures} />
         {/each}
       </div>
       {#if !$state.isOutputConnected && !hasClosedPopup && hasInteracted}

--- a/src/pages/model/ModelPageStackView.svelte
+++ b/src/pages/model/ModelPageStackView.svelte
@@ -28,12 +28,12 @@
   let recordingTime = 0;
   // let lastRecording;
 
-  // Bool flag to know whether to show the titles for the output gestures
-  export let enableOutputGestures: boolean;
-
   // Bool flags to know whether output microbit popup should be show
   let hasClosedPopup = false;
   let hasInteracted = false;
+
+  // Bool flag to know whether to show the titles for the output gestures
+  const enableOutputGestures = false;
 
   function onUserInteraction(): void {
     hasInteracted = true;
@@ -134,11 +134,7 @@
       <div class="pl-1">
         <!-- Display all gestures and their output capabilities -->
         {#each $gestures as gesture}
-          <OutputGesture
-            variant="stack"
-            {gesture}
-            {onUserInteraction}
-            {enableOutputGestures} />
+          <OutputGesture variant="stack" {gesture} {onUserInteraction} />
         {/each}
       </div>
       {#if !$state.isOutputConnected && !hasClosedPopup && hasInteracted}

--- a/src/pages/model/ModelPageStackView.svelte
+++ b/src/pages/model/ModelPageStackView.svelte
@@ -28,6 +28,9 @@
   let recordingTime = 0;
   // let lastRecording;
 
+  // Bool flag to know whether to show the titles for the output gestures
+  export let enableOutputGestures: boolean;
+
   // Bool flags to know whether output microbit popup should be show
   let hasClosedPopup = false;
   let hasInteracted = false;
@@ -103,33 +106,35 @@
             titleText={$t('content.model.output.prediction.descriptionTitle')}
             bodyText={$t('content.model.output.prediction.descriptionBody')} />
         </div>
-        <div class="absolute left-78 flex">
-          <Information
-            isLightTheme={false}
-            iconText={$t('content.model.output.ledOutput.descriptionTitle')}
-            titleText={$t('content.model.output.ledOutput.descriptionTitle')}
-            bodyText={$t('content.model.output.ledOutput.descriptionBody')} />
-        </div>
-        <div class="absolute left-125 flex">
-          <Information
-            isLightTheme={false}
-            iconText={$t('content.model.output.sound.iconTitle')}
-            titleText={$t('content.model.output.sound.descriptionTitle')}
-            bodyText={$t('content.model.output.sound.descriptionBody')} />
-        </div>
-        <div class="absolute left-167 flex">
-          <Information
-            isLightTheme={false}
-            iconText={$t('content.model.output.pin.iconTitle')}
-            titleText={$t('content.model.output.pin.descriptionTitle')}
-            bodyText={$t('content.model.output.pin.descriptionBody')} />
-        </div>
+        {#if enableOutputGestures}
+          <div class="absolute left-78 flex">
+            <Information
+              isLightTheme={false}
+              iconText={$t('content.model.output.ledOutput.descriptionTitle')}
+              titleText={$t('content.model.output.ledOutput.descriptionTitle')}
+              bodyText={$t('content.model.output.ledOutput.descriptionBody')} />
+          </div>
+          <div class="absolute left-125 flex">
+            <Information
+              isLightTheme={false}
+              iconText={$t('content.model.output.sound.iconTitle')}
+              titleText={$t('content.model.output.sound.descriptionTitle')}
+              bodyText={$t('content.model.output.sound.descriptionBody')} />
+          </div>
+          <div class="absolute left-167 flex">
+            <Information
+              isLightTheme={false}
+              iconText={$t('content.model.output.pin.iconTitle')}
+              titleText={$t('content.model.output.pin.descriptionTitle')}
+              bodyText={$t('content.model.output.pin.descriptionBody')} />
+          </div>
+        {/if}
       </div>
 
       <div class="pl-1">
         <!-- Display all gestures and their output capabilities -->
         {#each $gestures as gesture}
-          <OutputGesture variant="stack" {gesture} {onUserInteraction} />
+          <OutputGesture variant="stack" {gesture} {onUserInteraction} enableOutputGestures={enableOutputGestures}/>
         {/each}
       </div>
       {#if !$state.isOutputConnected && !hasClosedPopup && hasInteracted}


### PR DESCRIPTION
Gives the option to hide the output panels on the model page.

This PR relates to https://github.com/microbit-foundation/ml-trainer/pull/44 but does not delete code.

Before change:
![image](https://github.com/microbit-foundation/ml-trainer/assets/138705536/cc36b3d0-0975-441e-a505-93730465a78d)


After change:
![image](https://github.com/microbit-foundation/ml-trainer/assets/138705536/c4ad9abf-7fef-475f-8310-2d7822b05dfb)

