### PR TITLE
Limits characters that can be inserted as an action title

### DIFF
--- a/src/components/Gesture.svelte
+++ b/src/components/Gesture.svelte
@@ -252,7 +252,7 @@
     <!-- Title of gesture-->
     <GestureTilePart mr small elevated>
       <div class="flex flex-col p-2 h-30 w-70">
-        <button class="w-5 outline-none ml-auto pb-5" on:click={removeClicked}>
+        <button class="w-5 outline-none ml-auto pb-3" on:click={removeClicked}>
           <i class="fa fa-times fa-lg text-gray-500" />
         </button>
         <div class="transition ease rounded">

--- a/src/components/Gesture.svelte
+++ b/src/components/Gesture.svelte
@@ -248,23 +248,25 @@
     </div>
   </BaseDialog>
 
-  <div class="items-center flex mb-1">
+  <div class="flex mb-1">
     <!-- Title of gesture-->
     <GestureTilePart mr small elevated>
-      <div class="grid grid-cols-5 place-items-center p-2 w-50 h-30">
-        <div class="w-40 col-start-2 col-end-5 transition ease rounded bg-gray-100">
-          <h3
-            class="px-2"
-            contenteditable
-            bind:innerText={$nameBind}
-            on:click={titleClicked}
-            on:keypress={onTitleKeypress} />
-        </div>
+      <div class="flex flex-col p-2 h-30 w-70">
         <button
-          class="pl-3 col-start-5 place-self-start justify-self-end outline-none"
+          class="w-5 outline-none ml-auto pb-5"
           on:click={removeClicked}>
-          <i class="far fa-times-circle fa-lg text-gray-500" />
+          <i class="fa fa-times fa-lg text-gray-500" />
         </button>
+        <div class="transition ease rounded">
+          <input
+            type="text"
+            class="px-2 w-full justify-self-start font-semibold bg-gray-100 py-1 rounded"
+            placeholder="Name of action"
+            maxlength="{StaticConfiguration.gestureNameMaxLength}"
+            bind:value={$nameBind}
+            on:click={titleClicked}
+            on:keypress={onTitleKeypress}/>
+        </div>
       </div>
     </GestureTilePart>
 

--- a/src/components/Gesture.svelte
+++ b/src/components/Gesture.svelte
@@ -252,9 +252,7 @@
     <!-- Title of gesture-->
     <GestureTilePart mr small elevated>
       <div class="flex flex-col p-2 h-30 w-70">
-        <button
-          class="w-5 outline-none ml-auto pb-5"
-          on:click={removeClicked}>
+        <button class="w-5 outline-none ml-auto pb-5" on:click={removeClicked}>
           <i class="fa fa-times fa-lg text-gray-500" />
         </button>
         <div class="transition ease rounded">
@@ -262,10 +260,10 @@
             type="text"
             class="px-2 w-full justify-self-start font-semibold bg-gray-100 py-1 rounded"
             placeholder="Name of action"
-            maxlength="{StaticConfiguration.gestureNameMaxLength}"
+            maxlength={StaticConfiguration.gestureNameMaxLength}
             bind:value={$nameBind}
             on:click={titleClicked}
-            on:keypress={onTitleKeypress}/>
+            on:keypress={onTitleKeypress} />
         </div>
       </div>
     </GestureTilePart>

--- a/src/components/Recording.svelte
+++ b/src/components/Recording.svelte
@@ -44,6 +44,6 @@
   <RecordingGraph data={recording.data} />
 
   <button class="absolute right-0px top-0px z-2" on:click={deleteClicked}>
-    <i class="far fa-times-circle fa-lg text-gray-500" />
+    <i class="fa fa-times fa-lg text-gray-500" />
   </button>
 </div>


### PR DESCRIPTION
Limits the number of characters that can be inputted including when pasted from the clipboard. The cross icon has also been changed to match the new design.

![image](https://github.com/microbit-foundation/ml-trainer/assets/138705536/e40a9319-9610-4f95-aede-7788f86e9e63)

Closes https://github.com/microbit-foundation/ml-trainer/issues/65