### PR TITLE
Swap to data actions menu on data page

### DIFF
--- a/src/components/control-bar/control-bar-items/MenuItem.svelte
+++ b/src/components/control-bar/control-bar-items/MenuItem.svelte
@@ -9,12 +9,15 @@
 
   export let menu: ReturnType<typeof createMenu>;
   export let value: any;
+  export let disabled: boolean | undefined = undefined;
 </script>
 
 <button
   use:menu.item={{ value }}
   {...$$restProps}
+  {disabled}
   class="group flex gap-2 items-center w-full px-4 py-2 text-sm text-black"
-  class:bg-gray-100={$menu.active === value}>
+  class:bg-gray-100={$menu.active === value}
+  class:opacity-50={disabled}>
   <slot />
 </button>

--- a/src/components/datacollection/DataPageMenu.svelte
+++ b/src/components/datacollection/DataPageMenu.svelte
@@ -1,0 +1,79 @@
+<!--
+  (c) 2023, Center for Computational Thinking and Design at Aarhus University and contributors
+
+  SPDX-License-Identifier: MIT
+ -->
+
+<style>
+  button:disabled {
+    cursor: default;
+    color: grey;
+  }
+</style>
+
+<script lang="ts">
+  import { t } from '../../i18n';
+  import { createMenu } from 'svelte-headlessui';
+  import ClearIcon from 'virtual:icons/ri/delete-bin-2-line';
+  import UploadIcon from 'virtual:icons/ri/upload-2-line';
+  import DownloadIcon from 'virtual:icons/ri/download-2-line';
+  import ArrowDownIcon from 'virtual:icons/ri/arrow-down-s-line';
+  import CookiesIcon from 'virtual:icons/mdi/cookie-outline';
+  import MenuItems from '../control-bar/control-bar-items/MenuItems.svelte';
+  import MenuItem from '../control-bar/control-bar-items/MenuItem.svelte';
+  import MenuTransition from '../MenuTransition.svelte';
+
+  export let downloadDisabled = false;
+  export let clearDisabled = false;
+  export let onClearGestures: () => void;
+  export let onDownloadGestures: () => void;
+  export let onUploadGestures: () => void;
+
+  const menu = createMenu({ label: $t('dataMenu.label') });
+
+  const onSelect = (event: Event) => {
+    const { selected } = (event as CustomEvent).detail;
+    switch (selected) {
+      case 'upload-gestures': {
+        onUploadGestures();
+        break;
+      }
+      case 'download-data': {
+        onDownloadGestures();
+        break;
+      }
+      case 'clear-data': {
+        onClearGestures();
+        break;
+      }
+    }
+    menu.set({ selected: null });
+  };
+</script>
+
+<div class="relative inline-block">
+  <button
+    use:menu.button
+    on:select={onSelect}
+    class="inline-flex items-center gap-x-1 p-2">
+    Data actions
+    <ArrowDownIcon />
+  </button>
+  <MenuTransition show={$menu.expanded}>
+    <MenuItems {menu}>
+      <div class="py-2">
+        <MenuItem {menu} value="upload-gestures">
+          <UploadIcon />
+          {$t('content.data.controlbar.button.uploadData')}
+        </MenuItem>
+        <MenuItem {menu} disabled={downloadDisabled} value="download-data">
+          <DownloadIcon />
+          {$t('content.data.controlbar.button.downloadData')}
+        </MenuItem>
+        <MenuItem {menu} disabled={clearDisabled} value="clear-data">
+          <ClearIcon />
+          {$t('content.data.controlbar.button.clearData')}
+        </MenuItem>
+      </div>
+    </MenuItems></MenuTransition>
+</div>

--- a/src/components/datacollection/DataPageMenu.svelte
+++ b/src/components/datacollection/DataPageMenu.svelte
@@ -33,15 +33,15 @@
   const onSelect = (event: Event) => {
     const { selected } = (event as CustomEvent).detail;
     switch (selected) {
-      case 'upload-gestures': {
+      case 'upload': {
         onUploadGestures();
         break;
       }
-      case 'download-data': {
+      case 'download': {
         onDownloadGestures();
         break;
       }
-      case 'clear-data': {
+      case 'clear': {
         onClearGestures();
         break;
       }
@@ -55,21 +55,21 @@
     use:menu.button
     on:select={onSelect}
     class="inline-flex items-center gap-x-1 p-2">
-    Data actions
+    {$t('content.data.controlbar.button.menu')}
     <ArrowDownIcon />
   </button>
   <MenuTransition show={$menu.expanded}>
     <MenuItems {menu}>
       <div class="py-2">
-        <MenuItem {menu} value="upload-gestures">
+        <MenuItem {menu} value="upload">
           <UploadIcon />
           {$t('content.data.controlbar.button.uploadData')}
         </MenuItem>
-        <MenuItem {menu} disabled={downloadDisabled} value="download-data">
+        <MenuItem {menu} disabled={downloadDisabled} value="download">
           <DownloadIcon />
           {$t('content.data.controlbar.button.downloadData')}
         </MenuItem>
-        <MenuItem {menu} disabled={clearDisabled} value="clear-data">
+        <MenuItem {menu} disabled={clearDisabled} value="clear">
           <ClearIcon />
           {$t('content.data.controlbar.button.clearData')}
         </MenuItem>

--- a/src/components/datacollection/DataPageMenu.svelte
+++ b/src/components/datacollection/DataPageMenu.svelte
@@ -18,7 +18,6 @@
   import UploadIcon from 'virtual:icons/ri/upload-2-line';
   import DownloadIcon from 'virtual:icons/ri/download-2-line';
   import ArrowDownIcon from 'virtual:icons/ri/arrow-down-s-line';
-  import CookiesIcon from 'virtual:icons/mdi/cookie-outline';
   import MenuItems from '../control-bar/control-bar-items/MenuItems.svelte';
   import MenuItem from '../control-bar/control-bar-items/MenuItem.svelte';
   import MenuTransition from '../MenuTransition.svelte';

--- a/src/messages/ui.en.json
+++ b/src/messages/ui.en.json
@@ -42,6 +42,7 @@
   "content.data.dataDescription": "Here you can see the gathered data. ",
   "content.data.noData": "You do not have any gestures to train on. Add the gestures you wish the micro:bit should learn to recognise.",
 
+  "content.data.controlbar.button.menu": "Data actions",
   "content.data.controlbar.button.clearData": "Clear examples",
   "content.data.controlbar.button.clearData.confirm": "Are you sure you wish to delete all gesture examples?\nThis cannot be undone.",
   "content.data.controlbar.button.downloadData": "Download dataset",

--- a/src/pages/DataPage.svelte
+++ b/src/pages/DataPage.svelte
@@ -15,12 +15,12 @@
   import { t } from '../i18n';
   import NewGestureButton from '../components/NewGestureButton.svelte';
   import PleaseConnectFirst from '../components/PleaseConnectFirst.svelte';
-  import DataPageControlBar from '../components/datacollection/DataPageControlBar.svelte';
   import Information from '../components/information/Information.svelte';
   import { onMount } from 'svelte';
   import TabView from '../views/TabView.svelte';
   import { gestures } from '../script/stores/Stores';
   import TrainingButton from './training/TrainingButton.svelte';
+  import DataPageMenu from '../components/datacollection/DataPageMenu.svelte';
 
   let isConnectionDialogOpen = false;
 
@@ -67,8 +67,8 @@
 <main class="h-full inline-block w-full bg-backgrounddark">
   <TabView />
 
-  <div>
-    <DataPageControlBar
+  <div class="flex justify-end px-10 my-3">
+    <DataPageMenu
       clearDisabled={$gestures.length === 0}
       downloadDisabled={$gestures.length === 0}
       {onClearGestures}

--- a/src/views/TabView.svelte
+++ b/src/views/TabView.svelte
@@ -22,7 +22,7 @@
   };
 </script>
 
-<div class="flex w-full justify-center">
+<div class="flex w-full justify-center bg-white border-b-3 border-gray-200">
   <div class="flex">
     {#each get(Menus.getMenuStore()) as menu, id}
       <MenuButton


### PR DESCRIPTION
Swap to data actions menu on data page and tweak tab view nav/toolbar styling.

Menu name is a bit awkward and needs discussion in the New Year. Still, an improvement on the buttons.

We discussed using a burger menu for this but I'd like to do better. I think ideally we'd have a heading for the table of samples and this would be a triple dot menu alongside the heading but that needs more discussion.