### PR TITLE
Simplify the main nav

### DIFF
--- a/src/components/information/Information.svelte
+++ b/src/components/information/Information.svelte
@@ -6,6 +6,7 @@
 
 <script lang="ts">
   import { getInfoBoxColors } from './InformationComponentUtility';
+  import InfoIcon from 'virtual:icons/ri/information-line';
 
   export let underlineIconText = true;
   export let boxOffset: { x: number; y: number } = { x: 0, y: 0 };
@@ -46,12 +47,14 @@
       style="color: {colors.iconTextColor}">
       {iconText}
     </p>
-    <i
-      class="fas fa-info-circle cursor-pointer"
-      style="color: {colors.iconTextColor}; vertical-align: middle;"
-      on:mouseenter={() => onMouseEnter()}
-      on:mouseleave={() => (isOpen = false)} />
   {/if}
+  <div
+    on:mouseenter={() => onMouseEnter()}
+    on:mouseleave={() => (isOpen = false)}
+    class="flex items-center cursor-pointer"
+    style="color: {colors.iconTextColor}">
+    <InfoIcon />
+  </div>
 
   {#if isOpen}
     <div

--- a/src/menus/MenuButton.svelte
+++ b/src/menus/MenuButton.svelte
@@ -1,19 +1,12 @@
 <!--
   (c) 2023, Center for Computational Thinking and Design at Aarhus University and contributors
-
+ 
   SPDX-License-Identifier: MIT
  -->
 
 <style>
-  .menu-button {
-    cursor: pointer;
-    margin: 0 1rem;
-    min-width: 8rem;
-    padding: 0.5rem 3rem;
-  }
-
-  .selected {
-    border-bottom: 4px solid #00a000;
+  div {
+    transition: max-height 0.3s ease;
   }
 </style>
 
@@ -25,21 +18,36 @@
   export let helpTitle: string;
   export let helpDescription: string;
   export let onClickFunction: () => void;
-  export let isSelected: boolean;
+  export let isExpanded: boolean;
 </script>
 
-<div class="menu-button" class:selected={isSelected} on:click={onClickFunction}>
-  <div class="h-full relative">
-    <p class="text-lg font-bold text-center">
-      {$t(title)}
-    </p>
-    <div class="absolute top-3px right-12">
-      <Information
-        bodyText={$t(helpDescription)}
-        boxOffset={{ x: -200, y: 30 }}
-        titleText={$t(helpTitle)}
-        width={280} />
+<div>
+  <div
+    class="border bg-opacity-75 border-solid border-3
+           border-opacity-80 min-h-20
+		   text-secondarytext border-secondary
+		   select-none transition duration-300
+		   rounded-full bg-primary"
+    class:bg-secondary={isExpanded}
+    class:bg-opacity-90={isExpanded}
+    class:cursor-pointer={!isExpanded}
+    class:hover:bg-border-opacity-30={!isExpanded}
+    class:hover:bg-opacity-95={!isExpanded}
+    class:rounded-3xl={isExpanded}
+    on:click={onClickFunction}>
+    <!-- Title -->
+    <div class="h-full mt-6.2 relative">
+      <p class="text-lg font-medium text-center" class:underline={isExpanded}>
+        {$t(title)}
+      </p>
+      <div class="absolute top-3px right-12">
+        <Information
+          bodyText={$t(helpDescription)}
+          boxOffset={{ x: -200, y: 30 }}
+          titleText={$t(helpTitle)}
+          width={280} />
+      </div>
     </div>
+    <slot />
   </div>
-  <slot />
 </div>

--- a/src/script/navigation/Menus.ts
+++ b/src/script/navigation/Menus.ts
@@ -13,39 +13,25 @@ import { Paths, PathType } from '../../router/paths';
 
 export type MenuProperties = {
   title: string;
-  infoBubbleTitle: string;
-  infoBubbleContent: string;
   navigationPath: PathType;
-  collapsedButtonContent: typeof SvelteComponent<any> | undefined;
-  expandedButtonContent: typeof SvelteComponent<any>;
-  additionalExpandPaths?: PathType[];
+  content: typeof SvelteComponent<any>;
 };
 
 class Menus {
   private static menuStore = writable<MenuProperties[]>([
     {
       title: 'menu.data.helpHeading',
-      infoBubbleTitle: 'menu.data.helpHeading',
-      infoBubbleContent: 'menu.data.helpBody',
-      collapsedButtonContent: undefined,
-      expandedButtonContent: GestureMenu,
+      content: GestureMenu,
       navigationPath: Paths.DATA,
     },
     {
       title: 'menu.trainer.helpHeading',
-      infoBubbleTitle: 'menu.trainer.helpHeading',
-      infoBubbleContent: 'menu.trainer.helpBody',
-      collapsedButtonContent: undefined,
-      expandedButtonContent: NewTrainerMenu,
+      content: NewTrainerMenu,
       navigationPath: Paths.TRAINING,
-      additionalExpandPaths: [Paths.FILTERS],
     },
     {
       title: 'menu.model.helpHeading',
-      infoBubbleTitle: 'menu.model.helpHeading',
-      infoBubbleContent: 'menu.model.helpBody',
-      collapsedButtonContent: undefined,
-      expandedButtonContent: NewModelMenu,
+      content: NewModelMenu,
       navigationPath: Paths.MODEL,
     },
   ]);

--- a/src/views/TabView.svelte
+++ b/src/views/TabView.svelte
@@ -6,33 +6,34 @@
 
 <script lang="ts">
   import Menus, { MenuProperties } from '../script/navigation/Menus';
-  import MenuButton from '../menus/MenuButton.svelte';
   import { get } from 'svelte/store';
   import { currentPath, navigate } from '../router/paths';
+  import { t } from 'svelte-i18n';
 
   $: isSelected = (menuProps: MenuProperties) => {
     let path = $currentPath;
     if (menuProps.navigationPath === path) {
       return true;
     }
-    if (menuProps.additionalExpandPaths === undefined) {
-      return false;
-    }
-    return menuProps.additionalExpandPaths.includes(path);
+    return false;
   };
 </script>
 
 <div class="flex w-full justify-center bg-white border-b-3 border-gray-200">
   <div class="flex">
     {#each get(Menus.getMenuStore()) as menu, id}
-      <MenuButton
-        onClickFunction={() => {
-          navigate(menu.navigationPath);
-        }}
-        title={menu.title}
-        helpTitle={menu.infoBubbleTitle}
-        helpDescription={menu.infoBubbleContent}
-        isSelected={isSelected(menu)} />
+      <a
+        class="block cursor-pointer mx-4 min-w-8rem py-2 px-12 border-b-4px border-b-white outline-none focus-visible:ring-4 focus-visible:ring-offset-1 focus-visible:ring-ring"
+        class:border-b-secondary={isSelected(menu)}
+        href={menu.navigationPath}
+        on:click|preventDefault={() => navigate(menu.navigationPath)}>
+        <div class="h-full relative">
+          <p class="text-lg font-bold text-center">
+            {$t(menu.title)}
+          </p>
+        </div>
+        <slot />
+      </a>
     {/each}
   </div>
 </div>


### PR DESCRIPTION
It takes translations that it never displays in our updated version so I've simplified it so we can see what text is used.

Also:
- Use `a` tag for navigation not a div (!)
- Add focus rings (there's a z-index issue we'll come back to)
- Limit our changes to TabView and reinstate MenuItem. Ideally we'd have our own TabView component to limit conflicts.
- Fix weird issue that we introduced in the Information component where it only displayed the icon when text was provided too
- Switch to the same info icon as other Foundation apps
