### PR TITLE
Remove "Train new model" button

### DIFF
--- a/src/components/TrainModelFirstTitle.svelte
+++ b/src/components/TrainModelFirstTitle.svelte
@@ -27,6 +27,6 @@
     <StandardButton onClick={() => navigate(Paths.DATA)}>
       {$t('content.model.addData')}
     </StandardButton>
-    <TrainingButton type="secondary" action="navigate" />
+    <TrainingButton type="secondary" onClick={() => navigate(Paths.MODEL)} />
   </div>
 </div>

--- a/src/components/TrainModelFirstTitle.svelte
+++ b/src/components/TrainModelFirstTitle.svelte
@@ -27,6 +27,6 @@
     <StandardButton onClick={() => navigate(Paths.DATA)}>
       {$t('content.model.addData')}
     </StandardButton>
-    <TrainingButton type="secondary" onClick={() => navigate(Paths.MODEL)} />
+    <TrainingButton type="secondary" onClick={() => navigate(Paths.TRAINING)} />
   </div>
 </div>

--- a/src/messages/ui.en.json
+++ b/src/messages/ui.en.json
@@ -82,7 +82,6 @@
   "menu.trainer.notConnected2": " Select the ‘Connect’ button to connect a micro:bit.",
   "menu.trainer.notEnoughDataHeader1": "Status: You don't have enough data.",
   "menu.trainer.notEnoughDataInfoBody": "You need at least 3 data samples for 2 actions to train the model.",
-  "menu.trainer.trainNewModelButton": "Train a new model",
   "menu.trainer.TrainingFinished": "Status: Your model is trained.",
 
   "menu.trainer.trainModelButton": "Train model",

--- a/src/pages/DataPage.svelte
+++ b/src/pages/DataPage.svelte
@@ -22,6 +22,7 @@
   import TrainingButton from './training/TrainingButton.svelte';
   import DataPageMenu from '../components/datacollection/DataPageMenu.svelte';
   import BottomPanel from '../components/bottom/BottomPanel.svelte';
+  import { Paths, navigate } from '../router/paths';
 
   let isConnectionDialogOpen = false;
 
@@ -118,7 +119,7 @@
 
       <NewGestureButton />
       <div class="flex justify-end">
-        <TrainingButton action="navigate" />
+        <TrainingButton onClick={() => navigate(Paths.MODEL)} />
       </div>
     </div>
   {/if}

--- a/src/pages/DataPage.svelte
+++ b/src/pages/DataPage.svelte
@@ -119,7 +119,7 @@
 
       <NewGestureButton />
       <div class="flex justify-end">
-        <TrainingButton onClick={() => navigate(Paths.MODEL)} />
+        <TrainingButton onClick={() => navigate(Paths.TRAINING)} />
       </div>
     </div>
   {/if}

--- a/src/pages/training/TrainingButton.svelte
+++ b/src/pages/training/TrainingButton.svelte
@@ -5,44 +5,19 @@
 -->
 
 <script lang="ts">
-  import { hasSufficientData, state } from '../../script/stores/uiStore';
   import StandardButton, { ButtonVariant } from '../../components/StandardButton.svelte';
-  import { trainModel } from '../../script/ml';
   import { t } from '../../i18n';
-  import { Paths, navigate } from '../../router/paths';
   import { gestures } from '../../script/stores/Stores';
+  import { hasSufficientData, state } from '../../script/stores/uiStore';
 
   export let type: ButtonVariant = 'primary';
-  export let action: 'navigate' | 'train' = 'train';
-
-  $: trainButtonLabel = !$state.isPredicting
-    ? 'menu.trainer.trainModelButton'
-    : 'menu.trainer.trainNewModelButton';
+  export let onClick: () => void;
 
   // Workaround: hasSufficientData uses gestures but isn't reactive
   $: sufficientData = $gestures && hasSufficientData();
-
   $: trainingButtonDisabled = !sufficientData || $state.isTraining;
-
-  let trainingDialogOpen = false;
-
-  const closeTrainingDialog = () => {
-    trainingDialogOpen = false;
-  };
-
-  const startTraining = () => {
-    closeTrainingDialog();
-    trainModel();
-  };
-
-  const navitgateToTrainingPage = () => {
-    navigate(Paths.TRAINING);
-  };
 </script>
 
-<StandardButton
-  onClick={action === 'navigate' ? navitgateToTrainingPage : startTraining}
-  disabled={trainingButtonDisabled}
-  {type}
-  >{$t(trainButtonLabel)}
+<StandardButton {onClick} {type} disabled={trainingButtonDisabled}
+  >{$t('menu.trainer.trainModelButton')}
 </StandardButton>

--- a/src/pages/training/TrainingPage.svelte
+++ b/src/pages/training/TrainingPage.svelte
@@ -16,6 +16,7 @@
   import loadingSpinnerImage from '../../imgs/loadingspinner.gif';
   import StandardButton from '../../components/StandardButton.svelte';
   import { Paths, navigate } from '../../router/paths';
+  import { trainModel } from '../../script/ml';
 
   let descriptionTextColour = '#8892A3';
 
@@ -79,6 +80,9 @@
       </div>
     {:else if sufficientData && !$state.isTraining && !$state.isPredicting}
       <p class="font-semibold text-2xl py-10">{$t('content.trainer.enoughdata.title')}</p>
+      <div class="pt-10">
+        <TrainingButton onClick={trainModel} />
+      </div>
     {:else if $state.isTraining}
       <div class="text-primarytext">
         <div class="ml-auto mr-auto flex flex-col center-items justify-center">
@@ -103,9 +107,5 @@
           >{$t('menu.trainer.testModelButton')}</StandardButton>
       </div>
     {/if}
-  </div>
-
-  <div class="pt-10">
-    <TrainingButton />
   </div>
 </div>


### PR DESCRIPTION
Only show "Train model" as per the design.

Still a missing state for changed data but the app doesn't deal with that at all now (e.g. on test model page) so needs discussion.