### PR TITLE
Close about dialog with close button

### DIFF
--- a/src/components/dialogs/StandardDialog.svelte
+++ b/src/components/dialogs/StandardDialog.svelte
@@ -21,6 +21,8 @@
   // of using svelte-headlessui dialogs
   $: if (isOpen) {
     dialog.open();
+  } else {
+    dialog.close();
   }
   dialog.subscribe(({ expanded }) => {
     if (!expanded) {


### PR DESCRIPTION
Global fix for any dialog with that relies on a close button or external `isOpen` state changing without user interaction.

See https://microbit-global.monday.com/boards/1356069004/pulses/1356432286.