### PR TITLE
Add support for translating text containing links and fix existing copy

### DIFF
--- a/src/__tests__/parseTag.test.ts
+++ b/src/__tests__/parseTag.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * (c) 2023, Center for Computational Thinking and Design at Aarhus University and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+import { parseTag } from '../parseTag';
+
+describe('parseTag', () => {
+  test('No tag returns text', () => {
+    const text = 'abcsde';
+    expect(parseTag(text, 'tag')).toEqual([{ text }]);
+  });
+  test('returns parsed parts with untagged start and ends', () => {
+    expect(parseTag('aaa<a>bbbb</a>ccc<a>ddd</a>eee', 'a')).toEqual([
+      {
+        text: 'aaa',
+      },
+      {
+        endIndex: 14,
+        startIndex: 3,
+        tag: 'a',
+        text: 'bbbb',
+      },
+      {
+        text: 'ccc',
+      },
+      {
+        endIndex: 27,
+        startIndex: 17,
+        tag: 'a',
+        text: 'ddd',
+      },
+      {
+        text: 'eee',
+      },
+    ]);
+  });
+  test('returns parsed parts with tagged end', () => {
+    expect(parseTag('aaa<a>bbbb</a>ccc<a>ddd</a>', 'a')).toEqual([
+      {
+        text: 'aaa',
+      },
+      {
+        endIndex: 14,
+        startIndex: 3,
+        tag: 'a',
+        text: 'bbbb',
+      },
+      {
+        text: 'ccc',
+      },
+      {
+        endIndex: 27,
+        startIndex: 17,
+        tag: 'a',
+        text: 'ddd',
+      },
+    ]);
+  });
+  test('returns parsed parts with tagged start', () => {
+    expect(parseTag('<a>bbbb</a>ccc<a>ddd</a>eee', 'a')).toEqual([
+      {
+        endIndex: 11,
+        startIndex: 0,
+        tag: 'a',
+        text: 'bbbb',
+      },
+      {
+        text: 'ccc',
+      },
+      {
+        endIndex: 24,
+        startIndex: 14,
+        tag: 'a',
+        text: 'ddd',
+      },
+      {
+        text: 'eee',
+      },
+    ]);
+  });
+});

--- a/src/components/TextWithLink.svelte
+++ b/src/components/TextWithLink.svelte
@@ -1,0 +1,24 @@
+<!--
+  (c) 2023, Center for Computational Thinking and Design at Aarhus University and contributors
+
+  SPDX-License-Identifier: MIT
+ -->
+
+<script lang="ts">
+  import { t } from '../i18n';
+  import { parseTag } from '../parseTag';
+  export let href: string;
+  export let textId: string;
+</script>
+
+{#each parseTag($t(textId), 'link') as { tag, text }}
+  {#if tag}
+    <a
+      class="text-link outline-none focus-visible:ring-4 focus-visible:ring-offset-1 focus-visible:ring-ring"
+      rel="noopener noreferrer"
+      {href}
+      target="_blank">{text}</a>
+  {:else}
+    {text}
+  {/if}
+{/each}

--- a/src/components/connection-prompt/MicrobitWearingInstructionDialog.svelte
+++ b/src/components/connection-prompt/MicrobitWearingInstructionDialog.svelte
@@ -10,7 +10,7 @@
   import microbitStrapImage from '../../imgs/microbit_strap.png';
   import microbitHolderImage from '../../imgs/microbit_holder.png';
   import DialogHeading from '../DialogHeading.svelte';
-  import { parseTag } from '../../parseTag.ts';
+  import TextWithLink from '../TextWithLink.svelte';
 
   export let onNextClick: () => void;
   export let onBackClick: () => void;
@@ -30,17 +30,9 @@
     </DialogHeading>
     <div class="space-y-10">
       <p class="leading-normal">
-        {#each parseTag($t('connectMB.wearingSetup.subtitle'), 'link') as { tag, text }}
-          {#if tag}
-            <a
-              class="text-link"
-              href={instructionsVideoLink}
-              target="_blank"
-              rel="noopener">{text}</a>
-          {:else}
-            {text}
-          {/if}
-        {/each}
+        <TextWithLink
+          textId="connectMB.wearingSetup.subtitle"
+          href={instructionsVideoLink} />
       </p>
       <div class="flex flex-col font-semibold items-center gap-8">
         <div class="flex flex-col items-center gap-y-2">

--- a/src/components/connection-prompt/MicrobitWearingInstructionDialog.svelte
+++ b/src/components/connection-prompt/MicrobitWearingInstructionDialog.svelte
@@ -10,6 +10,7 @@
   import microbitStrapImage from '../../imgs/microbit_strap.png';
   import microbitHolderImage from '../../imgs/microbit_holder.png';
   import DialogHeading from '../DialogHeading.svelte';
+  import { parseTag } from '../../parseTag.ts';
 
   export let onNextClick: () => void;
   export let onBackClick: () => void;
@@ -29,9 +30,17 @@
     </DialogHeading>
     <div class="space-y-10">
       <p class="leading-normal">
-        <a class="text-link" href={instructionsVideoLink} target="_blank" rel="noopener"
-          >{$t('connectMB.wearingSetup.subtitle1')}</a>
-        {$t('connectMB.wearingSetup.subtitle2')}
+        {#each parseTag($t('connectMB.wearingSetup.subtitle'), 'link') as { tag, text }}
+          {#if tag}
+            <a
+              class="text-link"
+              href={instructionsVideoLink}
+              target="_blank"
+              rel="noopener">{text}</a>
+          {:else}
+            {text}
+          {/if}
+        {/each}
       </p>
       <div class="flex flex-col font-semibold items-center gap-8">
         <div class="flex flex-col items-center gap-y-2">

--- a/src/components/connection-prompt/usb/manual/ManualInstallTutorial.svelte
+++ b/src/components/connection-prompt/usb/manual/ManualInstallTutorial.svelte
@@ -15,6 +15,7 @@
   import transferFirmwareChromeOSImage from '../../../../imgs/transfer_firmware_chromeos.gif';
   import transferFirmwareWindowsImage from '../../../../imgs/transfer_firmware_windows.gif';
   import DialogHeading from '../../../DialogHeading.svelte';
+  import { parseTag } from '../../../../parseTag';
 
   export let onConnectBluetoothClick: () => void;
 
@@ -47,13 +48,17 @@
     </DialogHeading>
     <div class="space-y-5">
       <p>
-        {$t('connectMB.usb.manual.manualDownload')}
-        <span>
-          <button
-            class="hover:cursor-pointer text-red-500 underline"
-            on:click={() => Microbits.downloadFirmware()}
-            >{$t('connectMB.usb.manual.manualDownloadLink')}</button>
-        </span>
+        {#each parseTag($t('connectMB.usb.manual.manualDownload'), 'link') as { tag, text }}
+          {#if tag}
+            <span>
+              <button
+                class="hover:cursor-pointer text-red-500 underline"
+                on:click={() => Microbits.downloadFirmware()}>{text}</button>
+            </span>
+          {:else}
+            {text}
+          {/if}
+        {/each}
       </p>
       <div class="flex gap-5">
         <ol class="col-span-2">

--- a/src/messages/ui.en.json
+++ b/src/messages/ui.en.json
@@ -19,8 +19,7 @@
   "alert.recordingsPerGesture": "You need at least three examples per action",
 
   "content.index.title": "machine learning tool",
-  "content.index.toolInfo1": "Use this tool with the",
-  "content.index.toolInfo2": "BBC micro:bit playground survey",
+  "content.index.toolInfo": "Use this tool with the <link>BBC micro:bit playground survey</link>",
   "content.index.toolProcessCards.main.title": "How this tool works",
   "content.index.toolProcessCards.data.title": "Add data",
   "content.index.toolProcessCards.data.description": "Add samples of the actions you would like your model to recognise (e.g. waving and clapping).",
@@ -193,8 +192,7 @@
   "connectMB.usb.done.body4": "If you do not have a battery for the micro:bit, you can simply keep powering it through the usb cable.",
 
   "connectMB.usb.manual.header": "Transfer file to your micro:bit",
-  "connectMB.usb.manual.manualDownload": "If the file did not automatically download press",
-  "connectMB.usb.manual.manualDownloadLink": "here",
+  "connectMB.usb.manual.manualDownload": "If the file did not automatically download press <link>here</link>",
   "connectMB.usb.manual.done": "Done: Connect using Bluetooth",
 
   "connectMB.usb.firmwareBroken.warning": "We detected issues with your micro:bit firmware",

--- a/src/messages/ui.en.json
+++ b/src/messages/ui.en.json
@@ -136,8 +136,7 @@
 
   "connectMB.wearingSetup.radioConnection.heading": "Is micro:bit 1 ready to wear?",
   "connectMB.wearingSetup.bluetooth.heading": "Is the micro:bit ready to wear?",
-  "connectMB.wearingSetup.subtitle1": "Watch this video for instructions ",
-  "connectMB.wearingSetup.subtitle2": " on how to attach your micro:bit and battery pack to your flexible micro:bit holder and wearable strap so that it is easy to wear on your wrist.",
+  "connectMB.wearingSetup.subtitle": "<link>Watch this video for instructions</link> on how to attach your micro:bit and battery pack to your flexible micro:bit holder and wearable strap so that it is easy to wear on your wrist.",
   "connectMB.wearingSetup.requirements1": "micro:bit holder",
   "connectMB.wearingSetup.requirements2": "Wearable strap",
 

--- a/src/pages/Homepage.svelte
+++ b/src/pages/Homepage.svelte
@@ -13,6 +13,7 @@
   import { t } from '../i18n';
   import { startConnectionProcess } from '../script/stores/connectDialogStore';
   import ConnectDialogContainer from '../components/connection-prompt/ConnectDialogContainer.svelte';
+  import { parseTag } from '../parseTag';
 
   // Avoid youtube cookie. rel=0 should limit related videos to youtube channel.
   // Once we have translated videos we can try e.g. cc_lang_pref=fr
@@ -45,9 +46,13 @@
         allowFullScreen>
       </iframe>
       <p>
-        {$t('content.index.toolInfo1')}
-        <a class="text-link" href={playgroundSurveyUrl} target="_blank"
-          >{$t('content.index.toolInfo2')}</a>
+        {#each parseTag($t('content.index.toolInfo'), 'link') as { tag, text }}
+          {#if tag}
+            <a class="text-link" href={playgroundSurveyUrl} target="_blank">{text}</a>
+          {:else}
+            {text}
+          {/if}
+        {/each}
       </p>
     </div>
 

--- a/src/pages/Homepage.svelte
+++ b/src/pages/Homepage.svelte
@@ -13,7 +13,7 @@
   import { t } from '../i18n';
   import { startConnectionProcess } from '../script/stores/connectDialogStore';
   import ConnectDialogContainer from '../components/connection-prompt/ConnectDialogContainer.svelte';
-  import { parseTag } from '../parseTag';
+  import TextWithLink from '../components/TextWithLink.svelte';
 
   // Avoid youtube cookie. rel=0 should limit related videos to youtube channel.
   // Once we have translated videos we can try e.g. cc_lang_pref=fr
@@ -46,17 +46,7 @@
         allowFullScreen>
       </iframe>
       <p>
-        {#each parseTag($t('content.index.toolInfo'), 'link') as { tag, text }}
-          {#if tag}
-            <a
-              class="text-link outline-none focus-visible:ring-4 focus-visible:ring-offset-1 focus-visible:ring-ring"
-              rel="noopener noreferrer"
-              href={playgroundSurveyUrl}
-              target="_blank">{text}</a>
-          {:else}
-            {text}
-          {/if}
-        {/each}
+        <TextWithLink textId="content.index.toolInfo" href={playgroundSurveyUrl} />
       </p>
     </div>
 

--- a/src/parseTag.ts
+++ b/src/parseTag.ts
@@ -1,0 +1,44 @@
+/**
+ * (c) 2023, Center for Computational Thinking and Design at Aarhus University and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+interface ParsedPart {
+  text: string;
+  tag?: string;
+  startIndex?: number;
+  endIndex?: number;
+}
+
+const getPartFromMatch = (m: RegExpMatchArray, tag: string) => {
+  if (m.index === undefined) {
+    throw new Error('Unexpect error in tagged parts');
+  }
+  return {
+    tag,
+    text: m[1],
+    startIndex: m.index,
+    endIndex: m.index + m[0].length,
+  };
+};
+
+export const parseTag = (s: string, tag: string): ParsedPart[] => {
+  const taggedRegexp = new RegExp(`<${tag}>(.*?)</${tag}>`, 'g');
+  const matches = [...s.matchAll(taggedRegexp)];
+  if (matches.length === 0) {
+    return [{ text: s }];
+  }
+  return matches.reduce((accParts, m, i) => {
+    const currPart = getPartFromMatch(m, tag);
+    const { startIndex, endIndex } = currPart;
+    const nextPartStartIndex =
+      i === matches.length - 1 ? undefined : matches[i + 1].index;
+    return [
+      ...(i === 0 && startIndex !== 0 ? [{ text: s.slice(0, startIndex) }] : []),
+      ...accParts,
+      currPart,
+      ...(endIndex !== s.length ? [{ text: s.slice(endIndex, nextPartStartIndex) }] : []),
+    ];
+  }, [] as ParsedPart[]);
+};


### PR DESCRIPTION
Task: https://microbit-global.monday.com/boards/1356069004/pulses/1356389125

[svelte-i18n](https://github.com/kaisermann/svelte-i18n/blob/main/docs/Getting%20Started.md) doesn't provide support for embedding links. So a `parseTag` function was introduced to parse translated strings into an array of tagged and not-tagged parts so that they can be rendered separately according to whether or not the part is tagged/not-tagged.