### PR TITLE
Add overflow hidden to live data view

### DIFF
--- a/src/components/graphs/LiveGraph.svelte
+++ b/src/components/graphs/LiveGraph.svelte
@@ -119,7 +119,7 @@
   }
 </script>
 
-<main class="flex">
+<main class="flex overflow-hidden">
   <canvas bind:this={canvas} height={160} id="smoothie-chart" width={width - 30} />
   <DimensionLabels />
 </main>


### PR DESCRIPTION
This prevents a transient vertical scroll bar appearing when the dimension labels approach the bottom of the screen.

See https://microbit-global.monday.com/boards/1356069004/views/10076885/pulses/1356390986