### PR TITLE
Remove outdated micro:bit warning dialog

### DIFF
--- a/src/views/OverlayView.svelte
+++ b/src/views/OverlayView.svelte
@@ -73,7 +73,4 @@
   {#if $state.offerReconnect && isInputPatternValid()}
     <ReconnectPrompt />
   {/if}
-  {#if $state.isInputOutdated || $state.isOutputOutdated}
-    <OutdatedMicrobitWarning targetRole={$state.isInputOutdated ? 'INPUT' : 'OUTPUT'} />
-  {/if}
 </div>


### PR DESCRIPTION
The code that determines the hex version has a bug. It only provides this information `onConnect` which isn't called if the device is connected in another browser window or tab. I've also seen this fail on a single connection which is yet to be understood.

The dialog itself also needs updating to start the connection flow again without the skip flashing options available.

This is not likely to be a real issue for our users until we update a hex after going live.

See https://microbit-global.monday.com/boards/1356069004/views/10076885/pulses/1356472449