### PR TITLE
Add total msg count to the debug log.

### DIFF
--- a/src/script/connection-behaviours/InputBehaviour.ts
+++ b/src/script/connection-behaviours/InputBehaviour.ts
@@ -22,6 +22,7 @@ t.subscribe(t => (text = t));
 
 // Temporary debug for time between messages received.
 const zeroBins = () => ({
+  total: 0,
   '0-20': 0,
   '21-30': 0,
   '31-40': 0,
@@ -38,6 +39,7 @@ let timeBinsMs = zeroBins();
 let interval: any;
 
 const binTimeInterval = (time: number) => {
+  timeBinsMs['total']++;
   if (time <= 20) {
     timeBinsMs['0-20']++;
   } else if (time <= 30) {
@@ -200,7 +202,7 @@ class InputBehaviour extends LoggingDecorator {
       this.t = now;
       if (!interval) {
         interval = setInterval(() => {
-          console.log(timeBinsMs);
+          console.log('Data rate', timeBinsMs);
           timeBinsMs = zeroBins();
         }, 10_000);
       }


### PR DESCRIPTION
Small addition for easy comparison of how many messages went through in the given time.

Also added a string to the console.log, so that it is easier to filter. Not really needed when there isn't other stuff going to console, but as part local development I print a few other things, so this helps.
