### PR TITLE
Fix existing session bug

### DIFF
--- a/src/pages/Homepage.svelte
+++ b/src/pages/Homepage.svelte
@@ -41,9 +41,7 @@
   const playgroundSurveyUrl =
     'https://stage.microbit.org/teach/playground-survey/exploring-machine-learning';
 
-  const hasExistingSession = gestures
-    .getGestures()
-    .some(g => g.getName() || g.getRecordings().length);
+  $: hasExistingSession = $gestures.some(g => g.name || g.recordings.length);
   let showDataLossWarning = false;
 
   const checkForExistingSession = () => {


### PR DESCRIPTION
On starting a new session and clearing data, hasExistingSession didn't update. It then appears as though you have a session to resume when you might not.