### PR TITLE
Add configuration commands to MicrobitSerial.

### DIFF
--- a/src/__tests__/serialProtocol.test.ts
+++ b/src/__tests__/serialProtocol.test.ts
@@ -11,6 +11,7 @@ import {
   MicrobitSensorState,
   splitMessages,
   processPeriodicMessage,
+  processResponseMessage,
 } from '../script/microbit-interfacing/serialProtocol';
 
 describe('splitMessages', () => {
@@ -51,10 +52,47 @@ describe('splitMessages', () => {
     expect(msgs.remainingInput).toEqual(message3);
   });
 
+  it('sets the remainingInput from incomplete message', () => {
+    const message1 = 'R[0]INCOMPLETE';
+
+    const msgs = splitMessages(message1);
+
+    expect(msgs.messages.length).toEqual(0);
+    expect(msgs.remainingInput).toEqual(message1);
+  });
+
   it('processes empty input correctly', () => {
     const msgs = splitMessages('');
 
     expect(msgs.messages.length).toEqual(0);
+    expect(msgs.remainingInput).toEqual('');
+  });
+
+  it('throws away empty lines correctly', () => {
+    const msgs = splitMessages('\n\n\n');
+
+    expect(msgs.messages.length).toEqual(0);
+    expect(msgs.remainingInput).toEqual('');
+  });
+
+  it('throws away remainingInput of invalid type', () => {
+    const message1 = 'R[0]START[]';
+    const message_invalid_start = 'NOT_A_VALID_MSG_START';
+
+    const msgs = splitMessages(message1 + '\n' + message_invalid_start);
+
+    expect(msgs.messages.length).toEqual(1);
+    expect(msgs.messages[0]).toEqual(message1);
+    expect(msgs.remainingInput).toEqual('');
+  });
+
+  it('throws messages of invalid type', () => {
+    const msgs = splitMessages('P00\nC11\nR22\nX33\n');
+
+    expect(msgs.messages.length).toEqual(3);
+    expect(msgs.messages[0]).toEqual('P00');
+    expect(msgs.messages[1]).toEqual('C11');
+    expect(msgs.messages[2]).toEqual('R22');
     expect(msgs.remainingInput).toEqual('');
   });
 });
@@ -139,5 +177,195 @@ describe('processPeriodicMessage', () => {
     const got1 = processPeriodicMessage(message1);
 
     expect(got1).toBeUndefined();
+  });
+});
+
+describe('processResponseMessage', () => {
+  it('processes valid Handshake responses', () => {
+    const message1 = 'R[0]HS[1]';
+    const message2 = 'R[1122aabb]HS[255]';
+    const message3 = 'R[FFFFFFFF]HS[-1000]';
+
+    const got1 = processResponseMessage(message1);
+    const got2 = processResponseMessage(message2);
+    const got3 = processResponseMessage(message3);
+
+    expect(got1).toEqual({
+      message: message1,
+      messageId: 0,
+      cmdType: 'HS',
+      value: 1,
+    });
+    expect(got2).toEqual({
+      message: message2,
+      messageId: 0x1122aabb,
+      cmdType: 'HS',
+      value: 255,
+    });
+    expect(got3).toEqual({
+      message: message3,
+      messageId: 0xffffffff,
+      cmdType: 'HS',
+      value: -1000,
+    });
+  });
+
+  it('processes valid Radio Frequency response', () => {
+    const message = 'R[1234]RF[42]';
+
+    const got = processResponseMessage(message);
+
+    expect(got).toEqual({
+      message: message,
+      messageId: 0x1234,
+      cmdType: 'RF',
+      value: 42,
+    });
+  });
+
+  it('processes valid Software Versions responses', () => {
+    const message1 = 'R[1234]SWVER[0.0.0]';
+    const message2 = 'R[1234]SWVER[99.99.99]';
+    const message3 = 'R[1234]SWVER[1.2.3]';
+
+    const got1 = processResponseMessage(message1);
+    const got2 = processResponseMessage(message2);
+    const got3 = processResponseMessage(message3);
+
+    expect(got1).toEqual({
+      message: message1,
+      messageId: 0x1234,
+      cmdType: 'SWVER',
+      value: '0.0.0',
+    });
+    expect(got2).toEqual({
+      message: message2,
+      messageId: 0x1234,
+      cmdType: 'SWVER',
+      value: '99.99.99',
+    });
+    expect(got3).toEqual({
+      message: message3,
+      messageId: 0x1234,
+      cmdType: 'SWVER',
+      value: '1.2.3',
+    });
+  });
+
+  it('processes valid Hardware Versions responses', () => {
+    const message1 = 'R[1234]HWVER[0]';
+    const message2 = 'R[1234]HWVER[9999]';
+
+    const got1 = processResponseMessage(message1);
+    const got2 = processResponseMessage(message2);
+
+    expect(got1).toEqual({
+      message: message1,
+      messageId: 0x1234,
+      cmdType: 'HWVER',
+      value: 0,
+    });
+    expect(got2).toEqual({
+      message: message2,
+      messageId: 0x1234,
+      cmdType: 'HWVER',
+      value: 9999,
+    });
+  });
+
+  it('processes valid Zstart response', () => {
+    const message = 'R[1234]ZSTART[]';
+
+    const got = processResponseMessage(message);
+
+    expect(got).toEqual({
+      message: message,
+      messageId: 0x1234,
+      cmdType: 'ZSTART',
+      value: '',
+    });
+  });
+
+  it('processes valid Stop response', () => {
+    const message = 'R[1234]STOP[]';
+
+    const got = processResponseMessage(message);
+
+    expect(got).toEqual({
+      message: message,
+      messageId: 0x1234,
+      cmdType: 'STOP',
+      value: '',
+    });
+  });
+
+  it('throws away messages that are not a response', () => {
+    // First a valid response to stablish a baseline
+    expect(processResponseMessage('R[0]STOP[]')).not.toBeUndefined();
+    // Now non-response messages types
+    expect(processResponseMessage('C[0]STOP[]')).toBeUndefined();
+    expect(processResponseMessage('P[0]STOP[]')).toBeUndefined();
+    expect(processResponseMessage('P0E80495C4341')).toBeUndefined();
+    // Invalid message types
+    expect(processResponseMessage('Z[0]STOP[]')).toBeUndefined();
+    expect(processResponseMessage('9[0]STOP[]')).toBeUndefined();
+  });
+
+  it('throws away response messages with invalid IDs', () => {
+    // First a valid response to stablish a baseline
+    expect(processResponseMessage('R[0]STOP[]')).not.toBeUndefined();
+    // Now invalid IDs
+    expect(processResponseMessage('R[]STOP[]')).toBeUndefined();
+    expect(processResponseMessage('R[123456789]STOP[]')).toBeUndefined();
+    expect(processResponseMessage('R[12G]STOP[]')).toBeUndefined();
+    expect(processResponseMessage('R[-1]STOP[]')).toBeUndefined();
+    expect(processResponseMessage('R[1.1]STOP[]')).toBeUndefined();
+    expect(processResponseMessage('R[word]STOP[]')).toBeUndefined();
+  });
+
+  it('throws away response messages with invalid number values', () => {
+    // First valid messages to stablish a baseline
+    expect(processResponseMessage('R[0]RF[10000]')).not.toBeUndefined();
+    expect(processResponseMessage('R[0]RF[-1]')).not.toBeUndefined();
+    // Now invalid values
+    expect(processResponseMessage('R[0]RF[1-2]')).toBeUndefined();
+    expect(processResponseMessage('R[0]RF[1,2]')).toBeUndefined();
+    expect(processResponseMessage('R[0]RF[1F]')).toBeUndefined();
+    expect(processResponseMessage('R[0]RF[word]')).toBeUndefined();
+  });
+
+  it('throws away response messages with invalid version values', () => {
+    // First valid messages to stablish a baseline
+    expect(processResponseMessage('R[0]SWVER[1.1.1]')).not.toBeUndefined();
+    // Now invalid values
+    expect(processResponseMessage('R[0]SWVER[1]')).toBeUndefined();
+    expect(processResponseMessage('R[0]SWVER[1.1]')).toBeUndefined();
+    expect(processResponseMessage('R[0]SWVER[123.1.1]')).toBeUndefined();
+    expect(processResponseMessage('R[0]SWVER[1.123.1]')).toBeUndefined();
+    expect(processResponseMessage('R[0]SWVER[1.1.123]')).toBeUndefined();
+    expect(processResponseMessage('R[0]SWVER[11.22.AA]')).toBeUndefined();
+    expect(processResponseMessage('R[0]SWVER[word]')).toBeUndefined();
+  });
+
+  it('throws away response messages with invalid empty value', () => {
+    // First a valid response to stablish a baseline
+    expect(processResponseMessage('R[0]STOP[]')).not.toBeUndefined();
+    // Now non-response messages types
+    expect(processResponseMessage('R[0]STOP[0]')).toBeUndefined();
+    expect(processResponseMessage('R[0]STOP[-1]')).toBeUndefined();
+    expect(processResponseMessage('R[0]STOP[a]')).toBeUndefined();
+  });
+
+  it('throws away other types of invalid responses', () => {
+    expect(processResponseMessage('R0STOP[]')).toBeUndefined();
+    expect(processResponseMessage('[0]STOP[]')).toBeUndefined();
+    expect(processResponseMessage('R[0]STOP')).toBeUndefined();
+    expect(processResponseMessage('R[0][]')).toBeUndefined();
+    expect(processResponseMessage('R[0]')).toBeUndefined();
+    expect(processResponseMessage('R[0]STOP[]STOP[]')).toBeUndefined();
+    expect(processResponseMessage('R[0]R[1]STOP[]')).toBeUndefined();
+    expect(processResponseMessage('R[0]STOP[]S')).toBeUndefined();
+    expect(processResponseMessage('R[0]RF[1')).toBeUndefined();
+    expect(processResponseMessage('R[0]RF1]')).toBeUndefined();
   });
 });

--- a/src/__tests__/serialProtocol.test.ts
+++ b/src/__tests__/serialProtocol.test.ts
@@ -300,7 +300,7 @@ describe('processResponseMessage', () => {
   });
 
   it('throws away messages that are not a response', () => {
-    // First a valid response to stablish a baseline
+    // First a valid response to establish a baseline
     expect(processResponseMessage('R[0]STOP[]')).not.toBeUndefined();
     // Now non-response messages types
     expect(processResponseMessage('C[0]STOP[]')).toBeUndefined();

--- a/src/script/microbit-interfacing/MicrobitSerial.ts
+++ b/src/script/microbit-interfacing/MicrobitSerial.ts
@@ -12,17 +12,30 @@ import * as protocol from './serialProtocol';
 
 const enum SerialProtocolState {
   AwaitingHandshakeResponse,
+  AwaitingConfiguration,
+  Ready,
   Running,
 }
 
 class MicrobitSerial implements MicrobitConnection {
   private serialProtocolState = SerialProtocolState.AwaitingHandshakeResponse;
-  private unprocessedInput = '';
+  // TODO: The radio frequency should be randomly generated once per session.
+  //       If we want a session to be restored (e.g. from local storage) and
+  //       the previously flashed micro:bits to continue working without
+  //       reflashing we need to store and retrieve this value somehow.
+  // FIXME: Setting this to the hex files default value for now, as we need
+  //        to configure the radio frequency for both micro:bits after they
+  //        are flashed, not just the radio bridge.
+  private static sessionRadioFrequency = 42;
 
   constructor(
     private usb: MicrobitUSB,
     private onDisconnect: (manual?: boolean) => void,
-  ) {}
+  ) {
+    if (MicrobitSerial.sessionRadioFrequency === -1) {
+      MicrobitSerial.sessionRadioFrequency = protocol.generateRandomRadioFrequency();
+    }
+  }
 
   isSameDevice(other: MicrobitConnection): boolean {
     return (
@@ -31,50 +44,71 @@ class MicrobitSerial implements MicrobitConnection {
     );
   }
 
-  public async listenToInputServices(
-    inputBehaviour: InputBehaviour,
-    _inputUartHandler: (data: string) => void,
-  ): Promise<void> {
-    this.serialProtocolState = SerialProtocolState.AwaitingHandshakeResponse;
-
-    let previousButtonState = { A: 0, B: 0 };
-    await this.usb.startSerial(data => {
-      this.unprocessedInput += data;
-      let messages = protocol.splitMessages(this.unprocessedInput);
-      this.unprocessedInput = messages.remainingInput;
-      messages.messages.forEach(async msg => {
-        if (this.serialProtocolState === SerialProtocolState.AwaitingHandshakeResponse) {
-          let handshakeResponse = protocol.processHandshake(msg);
-          if (handshakeResponse && handshakeResponse.value === protocol.version) {
-            this.serialProtocolState = SerialProtocolState.Running;
-
-            // Request the micro:bit to start sending the periodic messages
-            const startCmd = protocol.generateCmdStart({
-              accelerometer: true,
-              buttons: true,
-            });
-            await this.usb.serialWrite(startCmd);
-          }
-        } else {
-          const sensorData = protocol.processPeriodicMessage(msg);
-          if (sensorData) {
-            inputBehaviour.accelerometerChange(
-              sensorData.accelerometerX,
-              sensorData.accelerometerY,
-              sensorData.accelerometerZ,
-            );
-            if (sensorData.buttonA !== previousButtonState.A) {
-              previousButtonState.A = sensorData.buttonA;
-              inputBehaviour.buttonChange(sensorData.buttonA, 'A');
-            }
-            if (sensorData.buttonB !== previousButtonState.B) {
-              previousButtonState.B = sensorData.buttonB;
-              inputBehaviour.buttonChange(sensorData.buttonB, 'B');
-            }
-          }
+  private async sendCmdWaitResponse(
+    cmd: protocol.MessageCmd,
+  ): Promise<protocol.MessageResponse> {
+    let unprocessedData = '';
+    let responseQueue: protocol.MessageResponse[] = [];
+    const onSerialResponses = (data: string): void => {
+      let protocolMessages = protocol.splitMessages(unprocessedData + data);
+      unprocessedData = protocolMessages.remainingInput;
+      protocolMessages.messages.forEach(msg => {
+        let response = protocol.processResponseMessage(msg);
+        if (response) {
+          responseQueue.push(response);
         }
       });
-    });
+    };
+    this.usb.addSerialListener(onSerialResponses);
+
+    console.log(`Sending cmd: ${cmd.message}`);
+    await this.usb.serialWrite(cmd.message);
+
+    const timeout = Date.now() + 1000;
+    while (Date.now() < timeout) {
+      while (responseQueue.length !== 0) {
+        let response = responseQueue.pop();
+        if (
+          response &&
+          response.cmdType === cmd.cmdType &&
+          response.messageId === cmd.messageId
+        ) {
+          console.log(`Cmd response received: ${response.message}`);
+          this.usb.removeSerialListener(onSerialResponses);
+          return response;
+        }
+      }
+      await new Promise(resolve => setTimeout(resolve, 20));
+    }
+    this.usb.removeSerialListener(onSerialResponses);
+    throw new Error(`Timeout waiting for response to ${cmd.message}`);
+  }
+
+  private async initProtocol(): Promise<void> {
+    if (this.serialProtocolState !== SerialProtocolState.AwaitingHandshakeResponse) {
+      return;
+    }
+
+    let unprocessedData = '';
+    const processHandshakeMessage = (data: string) => {
+      let messages = protocol.splitMessages(unprocessedData + data);
+      unprocessedData = messages.remainingInput;
+      messages.messages.forEach(async msg => {
+        let messageResponse = protocol.processResponseMessage(msg);
+        if (
+          messageResponse &&
+          messageResponse.cmdType === protocol.CommandTypes.Handshake
+        ) {
+          if (messageResponse.value !== protocol.version) {
+            throw new Error(
+              `Handshake failed. Unexpected protocol version ${protocol.version}`,
+            );
+          }
+          this.serialProtocolState = SerialProtocolState.AwaitingConfiguration;
+        }
+      });
+    };
+    await this.usb.startSerial(processHandshakeMessage);
 
     // There is an issue where we cannot read data out from the micro:bit serial
     // buffer until the buffer has been filled.
@@ -86,14 +120,76 @@ class MicrobitSerial implements MicrobitConnection {
       this.serialProtocolState == SerialProtocolState.AwaitingHandshakeResponse &&
       attempts++ < 20
     ) {
-      const handshakeCmd = protocol.generateCmdHandshake();
+      const handshakeCmd = protocol.generateCmdHandshake().message;
       console.log(`Sending handshake ${handshakeCmd}`);
       await this.usb.serialWrite(handshakeCmd);
       await new Promise(resolve => setTimeout(resolve, 100));
     }
+
+    this.usb.removeSerialListener(processHandshakeMessage);
     if (this.serialProtocolState === SerialProtocolState.AwaitingHandshakeResponse) {
       throw new Error('Handshake not received');
     }
+  }
+
+  public async setup(): Promise<void> {
+    await this.initProtocol();
+
+    // Set the radio frequency to a value unique to this session
+    const radioFreqCommand = protocol.generateCmdRadioFrequency(
+      MicrobitSerial.sessionRadioFrequency,
+    );
+    const radioFreqResponse = await this.sendCmdWaitResponse(radioFreqCommand);
+    if (radioFreqResponse.value !== MicrobitSerial.sessionRadioFrequency) {
+      throw new Error(
+        `Failed to set radio frequency. Expected ${MicrobitSerial.sessionRadioFrequency}, got ${radioFreqResponse.value}`,
+      );
+    }
+
+    this.serialProtocolState = SerialProtocolState.Ready;
+  }
+
+  public async listenToInputServices(
+    inputBehaviour: InputBehaviour,
+    _inputUartHandler: (data: string) => void,
+  ): Promise<void> {
+    if (this.serialProtocolState !== SerialProtocolState.Ready) {
+      await this.setup();
+    }
+    let previousButtonState = { A: 0, B: 0 };
+
+    let unprocessedData = '';
+    const onSerialPeriodicMessages = (data: string) => {
+      let messages = protocol.splitMessages(unprocessedData + data);
+      unprocessedData = messages.remainingInput;
+      messages.messages.forEach(async msg => {
+        const sensorData = protocol.processPeriodicMessage(msg);
+        if (sensorData) {
+          inputBehaviour.accelerometerChange(
+            sensorData.accelerometerX,
+            sensorData.accelerometerY,
+            sensorData.accelerometerZ,
+          );
+          if (sensorData.buttonA !== previousButtonState.A) {
+            previousButtonState.A = sensorData.buttonA;
+            inputBehaviour.buttonChange(sensorData.buttonA, 'A');
+          }
+          if (sensorData.buttonB !== previousButtonState.B) {
+            previousButtonState.B = sensorData.buttonB;
+            inputBehaviour.buttonChange(sensorData.buttonB, 'B');
+          }
+        }
+      });
+    };
+
+    this.usb.addSerialListener(onSerialPeriodicMessages);
+    // Request the micro:bit to start sending the periodic messages
+    const startCmd = protocol.generateCmdStart({
+      accelerometer: true,
+      buttons: true,
+    });
+    await this.usb.serialWrite(startCmd.message);
+    this.serialProtocolState = SerialProtocolState.Running;
   }
 
   public isConnected(): boolean {
@@ -104,7 +200,7 @@ class MicrobitSerial implements MicrobitConnection {
     // Weirdly this disconnects the CortexM...
     this.usb.disconnect();
     this.onDisconnect(true);
-    this.unprocessedInput = '';
+    this.serialProtocolState = SerialProtocolState.AwaitingHandshakeResponse;
     this.usb.stopSerial().catch(e => {
       // It's hard to make disconnect() async so we've left this as a background error for now.
       console.error(e);

--- a/src/script/microbit-interfacing/MicrobitUSB.ts
+++ b/src/script/microbit-interfacing/MicrobitUSB.ts
@@ -139,6 +139,14 @@ class MicrobitUSB extends CortexM {
     this.serialPromise = this.serialDAPLink.startSerialRead(serialDelay, false);
   }
 
+  public addSerialListener(callback: (data: string) => void) {
+    this.serialDAPLink?.addListener(DAPLink.EVENT_SERIAL_DATA, callback);
+  }
+
+  public removeSerialListener(callback: (data: string) => void) {
+    this.serialDAPLink?.removeListener(DAPLink.EVENT_SERIAL_DATA, callback);
+  }
+
   public async serialWrite(data: string): Promise<void> {
     return this.serialDAPLink?.serialWrite(data);
   }

--- a/src/script/microbit-interfacing/Microbits.ts
+++ b/src/script/microbit-interfacing/Microbits.ts
@@ -333,6 +333,7 @@ class Microbits {
     const connectionBehaviour = ConnectionBehaviours.getInputBehaviour();
 
     const microbitSerial = new MicrobitSerial(Microbits.getLinked(), onInputDisconnect);
+    await microbitSerial.setup();
 
     this.assignedInputMicrobit = microbitSerial;
     this.inputName = name;


### PR DESCRIPTION
So before we sent the "start" command we have to configure the device with other commands like "select radio frequency".

At the moment the main goal of this PR is do the required updates to be able to send protocol commands between the handshake and the start of the periodic messages. For the radio frequency specifically, we also need to send this command to the "micro:bit 1" (the remote micro:bit) right after flashing and before asking the user to unplug it. But that part is not included in this PR.

CC @microbit-matt-hillsdon @microbit-robert 