### PR TITLE
Don't show offer to reconnect on final attempt

### DIFF
--- a/src/script/microbit-interfacing/MicrobitConnection.ts
+++ b/src/script/microbit-interfacing/MicrobitConnection.ts
@@ -16,7 +16,7 @@ export enum DeviceRequestStates {
 interface MicrobitConnection {
   connect(...states: DeviceRequestStates[]): Promise<void>;
 
-  reconnect(): Promise<void>;
+  reconnect(finalAttempt: boolean): Promise<void>;
 
   disconnect(): Promise<void>;
 }

--- a/src/script/microbit-interfacing/Microbits.ts
+++ b/src/script/microbit-interfacing/Microbits.ts
@@ -91,8 +91,9 @@ class Microbits {
 
   public static async reconnect(
     requestState: DeviceRequestStates.INPUT | DeviceRequestStates.OUTPUT,
+    finalAttempt: boolean = false,
   ) {
-    return this.getMicrobit(requestState)?.reconnect();
+    return this.getMicrobit(requestState)?.reconnect(finalAttempt);
   }
 
   public static async disconnect(

--- a/src/script/utils/reconnect.ts
+++ b/src/script/utils/reconnect.ts
@@ -34,7 +34,7 @@ export const reconnect = async (finalAttempt: boolean = false) => {
   }
   try {
     for (const inUseAs of reconnectState.inUseAs.values()) {
-      await Microbits.reconnect(inUseAs);
+      await Microbits.reconnect(inUseAs, finalAttempt);
     }
     connectionDialogState.update(s => {
       s.connectionState = ConnectDialogStates.NONE;


### PR DESCRIPTION
We have seen the offer to reconnect dialog show up briefly over the top of the 'restart the connection flow from the beginning'. This PR aims to prevent that from happening.