### PR TITLE
Dialog behaviour fixes

### DIFF
--- a/src/components/dialogs/StandardDialog.svelte
+++ b/src/components/dialogs/StandardDialog.svelte
@@ -37,7 +37,7 @@
     // Use curr so we don't call onCloseDialog() on page load.
     if (curr && !next) {
       onCloseDialog();
-    } else {
+    } else if (!curr && next) {
       onOpenDialog();
     }
     return next;
@@ -55,7 +55,7 @@
   });
 
   const keyListener = (event: KeyboardEvent) => {
-    if (event.key === 'Escape') {
+    if (event.key === 'Escape' && isOpen) {
       onCloseDialog();
     }
   };
@@ -75,7 +75,7 @@
   $: sync.open(isOpen, v => (isOpen = v));
 
   let prevOpen: boolean;
-  $: if (isOpen) {
+  $: if (!prevOpen && isOpen) {
     onOpenDialog();
     prevOpen = isOpen;
   } else if (prevOpen && !isOpen) {


### PR DESCRIPTION
Only fire escape listener to close dialog while dialog is open. Stop calling open functions on app load.

See https://microbit-global.monday.com/boards/1356069004/views/10076885/pulses/1404321523