### PR TITLE
Commit .env so the app just works

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_FULL_URL=/

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,6 @@
 
 !.vscode/settings.json
 
-.env
+.env.*
 
 /src/.DS_Store


### PR DESCRIPTION
My reading of https://vitejs.dev/guide/env-and-mode#env-files is that:
- we can commit the .env file
- environment variables set in CI would win over .env
- we can put API backend config in .env.local as we needed to for local dev, which is not committed

I've changed the ignore so .env isn't ignored anymore but any additional .env add will be intentional.