### PR TITLE
[POC- DO NOT MERGE] Use heatmap to fingerprint recording data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@microsoft/applicationinsights-web": "^3.0.0",
         "@sentry/svelte": "^7.100.1",
         "@tensorflow/tfjs": "^4.4.0",
+        "@tensorflow/tfjs-vis": "^1.5.1",
         "@types/w3c-web-serial": "^1.0.6",
         "@types/w3c-web-usb": "^1.0.6",
         "bowser": "^2.11.0",
@@ -3247,6 +3248,33 @@
         "@tensorflow/tfjs-core": "4.15.0"
       }
     },
+    "node_modules/@tensorflow/tfjs-vis": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-vis/-/tfjs-vis-1.5.1.tgz",
+      "integrity": "sha512-oNithKiR7VZaE+xUvz6Leww4TYEPhKi8j5xnEYvT3j7brK2Njdvril7UgFtZ8EYZBdeX6XNim5Eu3/23gTQ1dA==",
+      "dependencies": {
+        "d3-format": "~1.3.0",
+        "d3-selection": "~1.3.0",
+        "glamor": "~2.20.40",
+        "preact": "~8.2.9",
+        "vega": "5.20.0",
+        "vega-embed": "6.17.0",
+        "vega-lite": "4.13.1"
+      },
+      "peerDependencies": {
+        "@tensorflow/tfjs-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@tensorflow/tfjs-vis/node_modules/d3-format": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.3.2.tgz",
+      "integrity": "sha512-Z18Dprj96ExragQ0DeGi+SYPQ7pPfRMtUXtsg/ChVIKNBCzjO8XYJvRTC1usblx52lqge56V5ect+frYTQc8WQ=="
+    },
+    "node_modules/@tensorflow/tfjs-vis/node_modules/d3-selection": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.3.2.tgz",
+      "integrity": "sha512-OoXdv1nZ7h2aKMVg3kaUFbLLK5jXUFAMLD/Tu5JA96mjf8f2a9ZUESGY+C36t8R1WFeWk/e55hy54Ml2I62CRQ=="
+    },
     "node_modules/@tensorflow/tfjs/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -3575,6 +3603,11 @@
       "integrity": "sha512-F6UrLn++11o967g8+G4c0mILIuSuyhpE9N989T4Rr+sgHqYpdrAbPgp3KOPPf4AA2A09dQDUB8/3K1GBG9Daeg==",
       "dev": true
     },
+    "node_modules/@types/clone": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@types/clone/-/clone-0.1.30.tgz",
+      "integrity": "sha512-vcxBr+ybljeSiasmdke1cQ9ICxoEwaBgM1OQ/P5h4MPj/kRyLcDl5L8PrftlbyV1kBbJIs3M3x1A1+rcWd4mEA=="
+    },
     "node_modules/@types/d3": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
@@ -3832,6 +3865,15 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+    },
+    "node_modules/@types/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-IyNhGHu71jH1jCXTHmafuoAAdsbBON3kDh7u/UUhLmjYgN5TYB54e1R8ckTCiIevl2UuZaCsi9XRxineY5yUjw==",
+      "deprecated": "This is a stub types definition. fast-json-stable-stringify provides its own type definitions, so you do not need this installed.",
+      "dependencies": {
+        "fast-json-stable-stringify": "*"
+      }
     },
     "node_modules/@types/geojson": {
       "version": "7946.0.13",
@@ -4600,6 +4642,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/array-flat-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-flat-polyfill/-/array-flat-polyfill-1.0.1.tgz",
+      "integrity": "sha512-hfJmKupmQN0lwi0xG6FQ5U8Rd97RnIERplymOv/qpq8AoNKPPAnxJadjFA23FNWm88wykh9HmpLJUUwUtNU/iw==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -4608,6 +4658,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
     "node_modules/assertion-error": {
       "version": "1.1.0",
@@ -4811,6 +4866,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001570",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001570.tgz",
@@ -4950,6 +5013,14 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/code-red": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.4.tgz",
@@ -5044,6 +5115,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-in-js-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
+      "integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
+      "dependencies": {
+        "hyphenate-style-name": "^1.0.2",
+        "isobject": "^3.0.1"
       }
     },
     "node_modules/css-tree": {
@@ -5307,6 +5387,50 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-geo-projection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-3.0.0.tgz",
+      "integrity": "sha512-1JE+filVbkEX2bT25dJdQ05iA4QHvUwev6o0nIQHOSrNlHCAKfVss/U10vEM3pA4j5v7uQoFdQ4KLbx9BlEbWA==",
+      "dependencies": {
+        "commander": "2",
+        "d3-array": "1 - 2",
+        "d3-geo": "1.12.0 - 2",
+        "resolve": "^1.1.10"
+      },
+      "bin": {
+        "geo2svg": "bin/geo2svg",
+        "geograticule": "bin/geograticule",
+        "geoproject": "bin/geoproject",
+        "geoquantize": "bin/geoquantize",
+        "geostitch": "bin/geostitch"
+      }
+    },
+    "node_modules/d3-geo-projection/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "node_modules/d3-geo-projection/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-geo-projection/node_modules/d3-geo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.2.tgz",
+      "integrity": "sha512-8pM1WGMLGFuhq9S+FpPURxic+gKzjluCD/CHTuUF3mXMeiCo0i6R0tO1s4+GArRFde96SLcW/kOFRjoAosPsFA==",
+      "dependencies": {
+        "d3-array": "^2.5.0"
+      }
+    },
+    "node_modules/d3-geo-projection/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
+    },
     "node_modules/d3-hierarchy": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
@@ -5374,9 +5498,9 @@
       }
     },
     "node_modules/d3-scale-chromatic": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz",
-      "integrity": "sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
       "dependencies": {
         "d3-color": "1 - 3",
         "d3-interpolate": "1 - 3"
@@ -5508,6 +5632,14 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/decimal.js": {
@@ -5693,6 +5825,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
     },
     "node_modules/entities": {
       "version": "4.5.0",
@@ -6244,8 +6384,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -6275,11 +6414,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fast-json-patch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ=="
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -6295,6 +6438,26 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fbjs": {
+      "version": "0.8.18",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.18.tgz",
+      "integrity": "sha512-EQaWFK+fEPSoibjNy8IxUtaFOMXcWsY0JaVrQoZR9zC8N2Ygf9iDITPWjUTVIax95b6I742JFLqASHfsag/vKA==",
+      "dependencies": {
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.30"
+      }
+    },
+    "node_modules/fbjs/node_modules/core-js": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "integrity": "sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA==",
+      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js."
     },
     "node_modules/fflate": {
       "version": "0.6.10",
@@ -6417,7 +6580,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6483,6 +6645,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glamor": {
+      "version": "2.20.40",
+      "resolved": "https://registry.npmjs.org/glamor/-/glamor-2.20.40.tgz",
+      "integrity": "sha512-DNXCd+c14N9QF8aAKrfl4xakPk5FdcFwmH7sD0qnC0Pr7xoZ5W9yovhUrY/dJc3psfGGXC58vqQyRtuskyUJxA==",
+      "dependencies": {
+        "fbjs": "^0.8.12",
+        "inline-style-prefixer": "^3.0.6",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.5.10",
+        "through": "^2.3.8"
       }
     },
     "node_modules/glob": {
@@ -6653,7 +6827,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
       "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -6707,6 +6880,11 @@
       "engines": {
         "node": ">=16.17.0"
       }
+    },
+    "node_modules/hyphenate-style-name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
+      "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw=="
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -6780,6 +6958,20 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "node_modules/inline-style-prefixer": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz",
+      "integrity": "sha512-ne8XIyyqkRaNJ1JfL1NYzNdCNxq+MCBQhC8NgOQlzNm2vv3XxlP0VSLQUbSRCF6KPEoveCVEpayHoHzcMyZsMQ==",
+      "dependencies": {
+        "bowser": "^1.7.3",
+        "css-in-js-utils": "^2.0.0"
+      }
+    },
+    "node_modules/inline-style-prefixer/node_modules/bowser": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",
+      "integrity": "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.6",
@@ -6900,7 +7092,6 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
       "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
-      "dev": true,
       "dependencies": {
         "hasown": "^2.0.0"
       },
@@ -7141,6 +7332,40 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==",
+      "dependencies": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
+    },
+    "node_modules/isomorphic-fetch/node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isomorphic-fetch/node_modules/node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dependencies": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
+    },
     "node_modules/jiti": {
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
@@ -7161,8 +7386,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -7252,6 +7476,11 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
+      "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA=="
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -7394,6 +7623,17 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/loupe": {
       "version": "2.3.7",
@@ -7702,6 +7942,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
@@ -7825,6 +8073,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7853,7 +8109,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -7879,8 +8134,7 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -8055,6 +8309,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/preact": {
+      "version": "8.2.9",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-8.2.9.tgz",
+      "integrity": "sha512-ThuGXBmJS3VsT+jIP+eQufD3L8pRw/PY3FoCys6O9Pu6aF12Pn9zAJDX99TfwRAFOCEKm/P0lwiPTbqKMJp0fA==",
+      "hasInstallScript": true
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -8114,6 +8374,29 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dependencies": {
+        "asap": "~2.0.3"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/psl": {
       "version": "1.9.0",
@@ -8309,6 +8592,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -8319,7 +8607,6 @@
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
       "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -8519,6 +8806,11 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+    },
     "node_modules/set-function-length": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
@@ -8547,6 +8839,11 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -8763,7 +9060,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -9067,6 +9363,11 @@
       "resolved": "https://registry.npmjs.org/three/-/three-0.152.2.tgz",
       "integrity": "sha512-Ff9zIpSfkkqcBcpdiFo2f35vA9ZucO+N8TNacJOqaEE6DrB0eufItVMib8bK8Pcju/ZNT6a7blE1GhTpkdsILw=="
     },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    },
     "node_modules/timers-ext": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
@@ -9129,6 +9430,24 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/topojson-client/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/tough-cookie": {
       "version": "4.1.3",
@@ -9232,6 +9551,28 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/ua-parser-js": {
+      "version": "0.7.38",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.38.tgz",
+      "integrity": "sha512-fYmIy7fKTSFAhG3fuPlubeGaMoAd6r0rSnfEsO5nEY55i26KSLt9EH7PLQiiqPUhNqYIJvSkTy1oArIcXAbPbA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ufo": {
@@ -9430,6 +9771,1143 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/uuid4/-/uuid4-2.0.3.tgz",
       "integrity": "sha512-CTpAkEVXMNJl2ojgtpLXHgz23dh8z81u6/HEPiQFOvBc/c2pde6TVHmH4uwY0d/GLF3tb7+VDAj4+2eJaQSdZQ=="
+    },
+    "node_modules/vega": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-5.20.0.tgz",
+      "integrity": "sha512-L2hDaTH2gz9DFbu7l1B8fR637HzctViuosFCo/Db5aBe93fCJ/w/oJu+vQNfQELzfm9sntkS/+A4u+39xrDCNA==",
+      "dependencies": {
+        "vega-crossfilter": "~4.0.5",
+        "vega-dataflow": "~5.7.3",
+        "vega-encode": "~4.8.3",
+        "vega-event-selector": "~2.0.6",
+        "vega-expression": "~4.0.1",
+        "vega-force": "~4.0.7",
+        "vega-format": "~1.0.4",
+        "vega-functions": "~5.12.0",
+        "vega-geo": "~4.3.8",
+        "vega-hierarchy": "~4.0.9",
+        "vega-label": "~1.0.0",
+        "vega-loader": "~4.4.0",
+        "vega-parser": "~6.1.3",
+        "vega-projection": "~1.4.5",
+        "vega-regression": "~1.0.9",
+        "vega-runtime": "~6.1.3",
+        "vega-scale": "~7.1.1",
+        "vega-scenegraph": "~4.9.4",
+        "vega-statistics": "~1.7.9",
+        "vega-time": "~2.0.4",
+        "vega-transforms": "~4.9.3",
+        "vega-typings": "~0.20.0",
+        "vega-util": "~1.16.1",
+        "vega-view": "~5.10.0",
+        "vega-view-transforms": "~4.5.8",
+        "vega-voronoi": "~4.1.5",
+        "vega-wordcloud": "~4.1.3"
+      }
+    },
+    "node_modules/vega-canvas": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.7.tgz",
+      "integrity": "sha512-OkJ9CACVcN9R5Pi9uF6MZBF06pO6qFpDYHWSKBJsdHP5o724KrsgR6UvbnXFH82FdsiTOff/HqjuaG8C7FL+9Q=="
+    },
+    "node_modules/vega-crossfilter": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.0.5.tgz",
+      "integrity": "sha512-yF+iyGP+ZxU7Tcj5yBsMfoUHTCebTALTXIkBNA99RKdaIHp1E690UaGVLZe6xde2n5WaYpho6I/I6wdAW3NXcg==",
+      "dependencies": {
+        "d3-array": "^2.7.1",
+        "vega-dataflow": "^5.7.3",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-crossfilter/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/vega-crossfilter/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
+    },
+    "node_modules/vega-dataflow": {
+      "version": "5.7.6",
+      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.7.6.tgz",
+      "integrity": "sha512-9Md8+5iUC1MVKPKDyZ7pCEHk6I9am+DgaMzZqo/27O/KI4f23/WQXPyuI8jbNmc/mkm340P0TKREmzL5M7+2Dg==",
+      "dependencies": {
+        "vega-format": "^1.1.2",
+        "vega-loader": "^4.5.2",
+        "vega-util": "^1.17.2"
+      }
+    },
+    "node_modules/vega-dataflow/node_modules/vega-format": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.1.2.tgz",
+      "integrity": "sha512-0kUfAj0dg0U6GcEY0Kp6LiSTCZ8l8jl1qVdQyToMyKmtZg/q56qsiJQZy3WWRr1MtWkTIZL71xSJXgjwjeUaAw==",
+      "dependencies": {
+        "d3-array": "^3.2.2",
+        "d3-format": "^3.1.0",
+        "d3-time-format": "^4.1.0",
+        "vega-time": "^2.1.2",
+        "vega-util": "^1.17.2"
+      }
+    },
+    "node_modules/vega-dataflow/node_modules/vega-loader": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.5.2.tgz",
+      "integrity": "sha512-ktIdGz3DRIS3XfTP9lJ6oMT5cKwC86nQkjUbXZbOtwXQFVNE2xVWBuH13GP6FKUZxg5hJCMtb5v/e/fwTvhKsQ==",
+      "dependencies": {
+        "d3-dsv": "^3.0.1",
+        "node-fetch": "^2.6.7",
+        "topojson-client": "^3.1.0",
+        "vega-format": "^1.1.2",
+        "vega-util": "^1.17.2"
+      }
+    },
+    "node_modules/vega-dataflow/node_modules/vega-time": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.1.2.tgz",
+      "integrity": "sha512-6rXc6JdDt8MnCRy6UzUCsa6EeFycPDmvioMddLfKw38OYCV8pRQC5nw44gyddOwXgUTJLiCtn/sp53P0iA542A==",
+      "dependencies": {
+        "d3-array": "^3.2.2",
+        "d3-time": "^3.1.0",
+        "vega-util": "^1.17.2"
+      }
+    },
+    "node_modules/vega-dataflow/node_modules/vega-util": {
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.2.tgz",
+      "integrity": "sha512-omNmGiZBdjm/jnHjZlywyYqafscDdHaELHx1q96n5UOz/FlO9JO99P4B3jZg391EFG8dqhWjQilSf2JH6F1mIw=="
+    },
+    "node_modules/vega-embed": {
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/vega-embed/-/vega-embed-6.17.0.tgz",
+      "integrity": "sha512-9eiVZCrLDb/EiVCMbMYouWB/q9dOeVkL5Bh0vU6wsUpIV/bbEvS47uljuo3YSxFqkfNpJ+Qt8xvLRiYSnN4lqw==",
+      "dependencies": {
+        "fast-json-patch": "^3.0.0-1",
+        "json-stringify-pretty-compact": "^3.0.0",
+        "semver": "^7.3.5",
+        "vega-schema-url-parser": "^2.1.0",
+        "vega-themes": "^2.10.0",
+        "vega-tooltip": "^0.25.1"
+      },
+      "peerDependencies": {
+        "vega": "^5.13.0",
+        "vega-lite": "*"
+      }
+    },
+    "node_modules/vega-embed/node_modules/semver": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/vega-encode": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.8.3.tgz",
+      "integrity": "sha512-JoRYtaV2Hs8spWLzTu/IjR7J9jqRmuIOEicAaWj6T9NSZrNWQzu2zF3IVsX85WnrIDIRUDaehXaFZvy9uv9RQg==",
+      "dependencies": {
+        "d3-array": "^2.7.1",
+        "d3-interpolate": "^2.0.1",
+        "vega-dataflow": "^5.7.3",
+        "vega-scale": "^7.0.3",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-encode/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/vega-encode/node_modules/d3-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
+    },
+    "node_modules/vega-encode/node_modules/d3-interpolate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "dependencies": {
+        "d3-color": "1 - 2"
+      }
+    },
+    "node_modules/vega-encode/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
+    },
+    "node_modules/vega-event-selector": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-2.0.6.tgz",
+      "integrity": "sha512-UwCu50Sqd8kNZ1X/XgiAY+QAyQUmGFAwyDu7y0T5fs6/TPQnDo/Bo346NgSgINBEhEKOAMY1Nd/rPOk4UEm/ew=="
+    },
+    "node_modules/vega-expression": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-4.0.1.tgz",
+      "integrity": "sha512-ZrDj0hP8NmrCpdLFf7Rd/xMUHGoSYsAOTaYp7uXZ2dkEH5x0uPy5laECMc8TiQvL8W+8IrN2HAWCMRthTSRe2Q==",
+      "dependencies": {
+        "vega-util": "^1.16.0"
+      }
+    },
+    "node_modules/vega-force": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.0.7.tgz",
+      "integrity": "sha512-pyLKdwXSZ9C1dVIqdJOobvBY29rLvZjvRRTla9BU/nMwAiAGlGi6WKUFdRGdneyGe3zo2nSZDTZlZM/Z5VaQNA==",
+      "dependencies": {
+        "d3-force": "^2.1.1",
+        "vega-dataflow": "^5.7.3",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-force/node_modules/d3-dispatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
+      "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA=="
+    },
+    "node_modules/vega-force/node_modules/d3-force": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-2.1.1.tgz",
+      "integrity": "sha512-nAuHEzBqMvpFVMf9OX75d00OxvOXdxY+xECIXjW6Gv8BRrXu6gAWbv/9XKrvfJ5i5DCokDW7RYE50LRoK092ew==",
+      "dependencies": {
+        "d3-dispatch": "1 - 2",
+        "d3-quadtree": "1 - 2",
+        "d3-timer": "1 - 2"
+      }
+    },
+    "node_modules/vega-force/node_modules/d3-quadtree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-2.0.0.tgz",
+      "integrity": "sha512-b0Ed2t1UUalJpc3qXzKi+cPGxeXRr4KU9YSlocN74aTzp6R/Ud43t79yLLqxHRWZfsvWXmbDWPpoENK1K539xw=="
+    },
+    "node_modules/vega-force/node_modules/d3-timer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
+      "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA=="
+    },
+    "node_modules/vega-format": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.0.4.tgz",
+      "integrity": "sha512-oTAeub3KWm6nKhXoYCx1q9G3K43R6/pDMXvqDlTSUtjoY7b/Gixm8iLcir5S9bPjvH40n4AcbZsPmNfL/Up77A==",
+      "dependencies": {
+        "d3-array": "^2.7.1",
+        "d3-format": "^2.0.0",
+        "d3-time-format": "^3.0.0",
+        "vega-time": "^2.0.3",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-format/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/vega-format/node_modules/d3-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
+      "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
+    },
+    "node_modules/vega-format/node_modules/d3-time": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+      "dependencies": {
+        "d3-array": "2"
+      }
+    },
+    "node_modules/vega-format/node_modules/d3-time-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "dependencies": {
+        "d3-time": "1 - 2"
+      }
+    },
+    "node_modules/vega-format/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
+    },
+    "node_modules/vega-functions": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.12.1.tgz",
+      "integrity": "sha512-7cHfcjXOj27qEbh2FTzWDl7FJK4xGcMFF7+oiyqa0fp7BU/wNT5YdNV0t5kCX9WjV7mfJWACKV74usLJbyM6GA==",
+      "dependencies": {
+        "d3-array": "^2.7.1",
+        "d3-color": "^2.0.0",
+        "d3-geo": "^2.0.1",
+        "vega-dataflow": "^5.7.3",
+        "vega-expression": "^5.0.0",
+        "vega-scale": "^7.1.1",
+        "vega-scenegraph": "^4.9.3",
+        "vega-selections": "^5.3.1",
+        "vega-statistics": "^1.7.9",
+        "vega-time": "^2.0.4",
+        "vega-util": "^1.16.0"
+      }
+    },
+    "node_modules/vega-functions/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/vega-functions/node_modules/d3-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
+    },
+    "node_modules/vega-functions/node_modules/d3-geo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.2.tgz",
+      "integrity": "sha512-8pM1WGMLGFuhq9S+FpPURxic+gKzjluCD/CHTuUF3mXMeiCo0i6R0tO1s4+GArRFde96SLcW/kOFRjoAosPsFA==",
+      "dependencies": {
+        "d3-array": "^2.5.0"
+      }
+    },
+    "node_modules/vega-functions/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
+    },
+    "node_modules/vega-functions/node_modules/vega-expression": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.1.1.tgz",
+      "integrity": "sha512-zv9L1Hm0KHE9M7mldHyz8sXbGu3KmC0Cdk7qfHkcTNS75Jpsem6jkbu6ZAwx5cNUeW91AxUQOu77r4mygq2wUQ==",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "vega-util": "^1.17.2"
+      }
+    },
+    "node_modules/vega-functions/node_modules/vega-util": {
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.2.tgz",
+      "integrity": "sha512-omNmGiZBdjm/jnHjZlywyYqafscDdHaELHx1q96n5UOz/FlO9JO99P4B3jZg391EFG8dqhWjQilSf2JH6F1mIw=="
+    },
+    "node_modules/vega-geo": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.3.8.tgz",
+      "integrity": "sha512-fsGxV96Q/QRgPqOPtMBZdI+DneIiROKTG3YDZvGn0EdV16OG5LzFhbNgLT5GPzI+kTwgLpAsucBHklexlB4kfg==",
+      "dependencies": {
+        "d3-array": "^2.7.1",
+        "d3-color": "^2.0.0",
+        "d3-geo": "^2.0.1",
+        "vega-canvas": "^1.2.5",
+        "vega-dataflow": "^5.7.3",
+        "vega-projection": "^1.4.5",
+        "vega-statistics": "^1.7.9",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-geo/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/vega-geo/node_modules/d3-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
+    },
+    "node_modules/vega-geo/node_modules/d3-geo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.2.tgz",
+      "integrity": "sha512-8pM1WGMLGFuhq9S+FpPURxic+gKzjluCD/CHTuUF3mXMeiCo0i6R0tO1s4+GArRFde96SLcW/kOFRjoAosPsFA==",
+      "dependencies": {
+        "d3-array": "^2.5.0"
+      }
+    },
+    "node_modules/vega-geo/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
+    },
+    "node_modules/vega-hierarchy": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.0.9.tgz",
+      "integrity": "sha512-4XaWK6V38/QOZ+vllKKTafiwL25m8Kd+ebHmDV+Q236ONHmqc/gv82wwn9nBeXPEfPv4FyJw2SRoqa2Jol6fug==",
+      "dependencies": {
+        "d3-hierarchy": "^2.0.0",
+        "vega-dataflow": "^5.7.3",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-hierarchy/node_modules/d3-hierarchy": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz",
+      "integrity": "sha512-SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw=="
+    },
+    "node_modules/vega-label": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.0.0.tgz",
+      "integrity": "sha512-hCdm2pcHgkKgxnzW9GvX5JmYNiUMlOXOibtMmBzvFBQHX3NiV9giQ5nsPiQiFbV08VxEPtM+VYXr2HyrIcq5zQ==",
+      "dependencies": {
+        "vega-canvas": "^1.2.5",
+        "vega-dataflow": "^5.7.3",
+        "vega-scenegraph": "^4.9.2",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-lite": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-4.13.1.tgz",
+      "integrity": "sha512-OHZSSqVLuikoZ3idz3jIRk0UCKtVU2Lq5gaD6cLNTnJjNetoHKKdfZ023LVj4+Y9yWPz5meb+EJUsfBAGfF4Vw==",
+      "dependencies": {
+        "@types/clone": "~0.1.30",
+        "@types/fast-json-stable-stringify": "^2.0.0",
+        "array-flat-polyfill": "^1.0.1",
+        "clone": "~2.1.2",
+        "fast-deep-equal": "~3.1.1",
+        "fast-json-stable-stringify": "~2.1.0",
+        "json-stringify-pretty-compact": "~2.0.0",
+        "tslib": "~2.0.0",
+        "vega-event-selector": "~2.0.3",
+        "vega-expression": "~2.6.5",
+        "vega-util": "~1.14.0",
+        "yargs": "~15.3.1"
+      },
+      "bin": {
+        "vl2pdf": "bin/vl2pdf",
+        "vl2png": "bin/vl2png",
+        "vl2svg": "bin/vl2svg",
+        "vl2vg": "bin/vl2vg"
+      },
+      "peerDependencies": {
+        "vega": "^5.12.1"
+      }
+    },
+    "node_modules/vega-lite/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/vega-lite/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/vega-lite/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/vega-lite/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/vega-lite/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/vega-lite/node_modules/json-stringify-pretty-compact": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz",
+      "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ=="
+    },
+    "node_modules/vega-lite/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/vega-lite/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vega-lite/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/vega-lite/node_modules/tslib": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+    },
+    "node_modules/vega-lite/node_modules/vega-expression": {
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-2.6.6.tgz",
+      "integrity": "sha512-zxPzXO33FawU3WQHRmHJaRreyJlyMaNMn1uuCFSouJttPkBBWB5gCrha2f5+pF3t4NMFWTnSrgCkR6mcaubnng==",
+      "dependencies": {
+        "vega-util": "^1.15.0"
+      }
+    },
+    "node_modules/vega-lite/node_modules/vega-expression/node_modules/vega-util": {
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.2.tgz",
+      "integrity": "sha512-omNmGiZBdjm/jnHjZlywyYqafscDdHaELHx1q96n5UOz/FlO9JO99P4B3jZg391EFG8dqhWjQilSf2JH6F1mIw=="
+    },
+    "node_modules/vega-lite/node_modules/vega-util": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.14.1.tgz",
+      "integrity": "sha512-pSKJ8OCkgfgHZDTljyj+gmGltgulceWbk1BV6LWrXqp6P3J8qPA/oZA8+a93YNApYxXZ3yzIVUDOo5O27xk0jw=="
+    },
+    "node_modules/vega-lite/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/vega-lite/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+    },
+    "node_modules/vega-lite/node_modules/yargs": {
+      "version": "15.3.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
+      "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/vega-lite/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/vega-loader": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.4.1.tgz",
+      "integrity": "sha512-dj65i4qlNhK0mOmjuchHgUrF5YUaWrYpx0A8kXA68lBk5Hkx8FNRztkcl07CZJ1+8V81ymEyJii9jzGbhEX0ag==",
+      "dependencies": {
+        "d3-dsv": "^2.0.0",
+        "node-fetch": "^2.6.1",
+        "topojson-client": "^3.1.0",
+        "vega-format": "^1.0.4",
+        "vega-util": "^1.16.0"
+      }
+    },
+    "node_modules/vega-loader/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "node_modules/vega-loader/node_modules/d3-dsv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-2.0.0.tgz",
+      "integrity": "sha512-E+Pn8UJYx9mViuIUkoc93gJGGYut6mSDKy2+XaPwccwkRGlR+LO97L2VCCRjQivTwLHkSnAJG7yo00BWY6QM+w==",
+      "dependencies": {
+        "commander": "2",
+        "iconv-lite": "0.4",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json",
+        "csv2tsv": "bin/dsv2dsv",
+        "dsv2dsv": "bin/dsv2dsv",
+        "dsv2json": "bin/dsv2json",
+        "json2csv": "bin/json2dsv",
+        "json2dsv": "bin/json2dsv",
+        "json2tsv": "bin/json2dsv",
+        "tsv2csv": "bin/dsv2dsv",
+        "tsv2json": "bin/dsv2json"
+      }
+    },
+    "node_modules/vega-loader/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/vega-parser": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.1.4.tgz",
+      "integrity": "sha512-tORdpWXiH/kkXcpNdbSVEvtaxBuuDtgYp9rBunVW9oLsjFvFXbSWlM1wvJ9ZFSaTfx6CqyTyGMiJemmr1QnTjQ==",
+      "dependencies": {
+        "vega-dataflow": "^5.7.3",
+        "vega-event-selector": "^3.0.0",
+        "vega-functions": "^5.12.1",
+        "vega-scale": "^7.1.1",
+        "vega-util": "^1.16.0"
+      }
+    },
+    "node_modules/vega-parser/node_modules/vega-event-selector": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-3.0.1.tgz",
+      "integrity": "sha512-K5zd7s5tjr1LiOOkjGpcVls8GsH/f2CWCrWcpKy74gTCp+llCdwz0Enqo013ZlGaRNjfgD/o1caJRt3GSaec4A=="
+    },
+    "node_modules/vega-projection": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.4.5.tgz",
+      "integrity": "sha512-85kWcPv0zrrNfxescqHtSYpRknilrS0K3CVRZc7IYQxnLtL1oma9WEbrSr1LCmDoCP5hl2Z1kKbomPXkrQX5Ag==",
+      "dependencies": {
+        "d3-geo": "^2.0.1",
+        "d3-geo-projection": "^3.0.0"
+      }
+    },
+    "node_modules/vega-projection/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/vega-projection/node_modules/d3-geo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.2.tgz",
+      "integrity": "sha512-8pM1WGMLGFuhq9S+FpPURxic+gKzjluCD/CHTuUF3mXMeiCo0i6R0tO1s4+GArRFde96SLcW/kOFRjoAosPsFA==",
+      "dependencies": {
+        "d3-array": "^2.5.0"
+      }
+    },
+    "node_modules/vega-projection/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
+    },
+    "node_modules/vega-regression": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.0.9.tgz",
+      "integrity": "sha512-KSr3QbCF0vJEAWFVY2MA9X786oiJncTTr3gqRMPoaLr/Yo3f7OPKXRoUcw36RiWa0WCOEMgTYtM28iK6ZuSgaA==",
+      "dependencies": {
+        "d3-array": "^2.7.1",
+        "vega-dataflow": "^5.7.3",
+        "vega-statistics": "^1.7.9",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-regression/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/vega-regression/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
+    },
+    "node_modules/vega-runtime": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.1.4.tgz",
+      "integrity": "sha512-0dDYXyFLQcxPQ2OQU0WuBVYLRZnm+/CwVu6i6N4idS7R9VXIX5581EkCh3pZ20pQ/+oaA7oJ0pR9rJgJ6rukRQ==",
+      "dependencies": {
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-runtime/node_modules/vega-util": {
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.2.tgz",
+      "integrity": "sha512-omNmGiZBdjm/jnHjZlywyYqafscDdHaELHx1q96n5UOz/FlO9JO99P4B3jZg391EFG8dqhWjQilSf2JH6F1mIw=="
+    },
+    "node_modules/vega-scale": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.1.1.tgz",
+      "integrity": "sha512-yE0to0prA9E5PBJ/XP77TO0BMkzyUVyt7TH5PAwj+CZT7PMsMO6ozihelRhoIiVcP0Ae/ByCEQBUQkzN5zJ0ZA==",
+      "dependencies": {
+        "d3-array": "^2.7.1",
+        "d3-interpolate": "^2.0.1",
+        "d3-scale": "^3.2.2",
+        "vega-time": "^2.0.4",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-scale/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/vega-scale/node_modules/d3-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
+    },
+    "node_modules/vega-scale/node_modules/d3-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
+      "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
+    },
+    "node_modules/vega-scale/node_modules/d3-interpolate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "dependencies": {
+        "d3-color": "1 - 2"
+      }
+    },
+    "node_modules/vega-scale/node_modules/d3-scale": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
+      "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
+      "dependencies": {
+        "d3-array": "^2.3.0",
+        "d3-format": "1 - 2",
+        "d3-interpolate": "1.2.0 - 2",
+        "d3-time": "^2.1.1",
+        "d3-time-format": "2 - 3"
+      }
+    },
+    "node_modules/vega-scale/node_modules/d3-time": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+      "dependencies": {
+        "d3-array": "2"
+      }
+    },
+    "node_modules/vega-scale/node_modules/d3-time-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "dependencies": {
+        "d3-time": "1 - 2"
+      }
+    },
+    "node_modules/vega-scale/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
+    },
+    "node_modules/vega-scenegraph": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.9.4.tgz",
+      "integrity": "sha512-QaegQzbFE2yhYLNWAmHwAuguW3yTtQrmwvfxYT8tk0g+KKodrQ5WSmNrphWXhqwtsgVSvtdZkfp2IPeumcOQJg==",
+      "dependencies": {
+        "d3-path": "^2.0.0",
+        "d3-shape": "^2.0.0",
+        "vega-canvas": "^1.2.5",
+        "vega-loader": "^4.3.3",
+        "vega-scale": "^7.1.1",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-scenegraph/node_modules/d3-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
+      "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA=="
+    },
+    "node_modules/vega-scenegraph/node_modules/d3-shape": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.1.0.tgz",
+      "integrity": "sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==",
+      "dependencies": {
+        "d3-path": "1 - 2"
+      }
+    },
+    "node_modules/vega-schema-url-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vega-schema-url-parser/-/vega-schema-url-parser-2.2.0.tgz",
+      "integrity": "sha512-yAtdBnfYOhECv9YC70H2gEiqfIbVkq09aaE4y/9V/ovEFmH9gPKaEgzIZqgT7PSPQjKhsNkb6jk6XvSoboxOBw=="
+    },
+    "node_modules/vega-selections": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.4.2.tgz",
+      "integrity": "sha512-99FUhYmg0jOJr2/K4TcEURmJRkuibrCDc8KBUX7qcQEITzrZ5R6a4QE+sarCvbb3hi8aA9GV2oyST6MQeA9mgQ==",
+      "dependencies": {
+        "d3-array": "3.2.4",
+        "vega-expression": "^5.0.1",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-selections/node_modules/vega-expression": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.1.1.tgz",
+      "integrity": "sha512-zv9L1Hm0KHE9M7mldHyz8sXbGu3KmC0Cdk7qfHkcTNS75Jpsem6jkbu6ZAwx5cNUeW91AxUQOu77r4mygq2wUQ==",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "vega-util": "^1.17.2"
+      }
+    },
+    "node_modules/vega-selections/node_modules/vega-util": {
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.2.tgz",
+      "integrity": "sha512-omNmGiZBdjm/jnHjZlywyYqafscDdHaELHx1q96n5UOz/FlO9JO99P4B3jZg391EFG8dqhWjQilSf2JH6F1mIw=="
+    },
+    "node_modules/vega-statistics": {
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.7.10.tgz",
+      "integrity": "sha512-QLb12gcfpDZ9K5h3TLGrlz4UXDH9wSPyg9LLfOJZacxvvJEPohacUQNrGEAVtFO9ccUCerRfH9cs25ZtHsOZrw==",
+      "dependencies": {
+        "d3-array": "^2.7.1"
+      }
+    },
+    "node_modules/vega-statistics/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/vega-statistics/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
+    },
+    "node_modules/vega-themes": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/vega-themes/-/vega-themes-2.15.0.tgz",
+      "integrity": "sha512-DicRAKG9z+23A+rH/3w3QjJvKnlGhSbbUXGjBvYGseZ1lvj9KQ0BXZ2NS/+MKns59LNpFNHGi9us/wMlci4TOA==",
+      "peerDependencies": {
+        "vega": "*",
+        "vega-lite": "*"
+      }
+    },
+    "node_modules/vega-time": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.0.4.tgz",
+      "integrity": "sha512-U314UDR9+ZlWrD3KBaeH+j/c2WSMdvcZq5yJfFT0yTg1jsBKAQBYFGvl+orackD8Zx3FveHOxx3XAObaQeDX+Q==",
+      "dependencies": {
+        "d3-array": "^2.7.1",
+        "d3-time": "^2.0.0",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-time/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/vega-time/node_modules/d3-time": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+      "dependencies": {
+        "d3-array": "2"
+      }
+    },
+    "node_modules/vega-time/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
+    },
+    "node_modules/vega-tooltip": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/vega-tooltip/-/vega-tooltip-0.25.1.tgz",
+      "integrity": "sha512-ugGwGi2/p3OpB8N15xieuzP8DyV5DreqMWcmJ9zpWT8GlkyKtef4dGRXnvHeHQ+iJFmWrq4oZJ+kLTrdiECjAg==",
+      "dependencies": {
+        "vega-util": "^1.16.0"
+      }
+    },
+    "node_modules/vega-transforms": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.9.4.tgz",
+      "integrity": "sha512-JGBhm5Bf6fiGTUSB5Qr5ckw/KU9FJcSV5xIe/y4IobM/i/KNwI1i1fP45LzP4F4yZc0DMTwJod2UvFHGk9plKA==",
+      "dependencies": {
+        "d3-array": "^2.7.1",
+        "vega-dataflow": "^5.7.4",
+        "vega-statistics": "^1.7.9",
+        "vega-time": "^2.0.4",
+        "vega-util": "^1.16.1"
+      }
+    },
+    "node_modules/vega-transforms/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/vega-transforms/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
+    },
+    "node_modules/vega-typings": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-0.20.0.tgz",
+      "integrity": "sha512-S+HIRN/3WYiS5zrQjJ4FDEOlvFVHLxPXMJerrnN3YZ6bxCDYo7tEvQUUuByGZ3d19GuKjgejczWS7XHvF3WjDw==",
+      "dependencies": {
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-util": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.16.1.tgz",
+      "integrity": "sha512-FdgD72fmZMPJE99FxvFXth0IL4BbLA93WmBg/lvcJmfkK4Uf90WIlvGwaIUdSePIsdpkZjBPyQcHMQ8OcS8Smg=="
+    },
+    "node_modules/vega-view": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.10.1.tgz",
+      "integrity": "sha512-4xvQ5KZcgKdZx1Z7jjenCUumvlyr/j4XcHLRf9gyeFrFvvS596dVpL92V8twhV6O++DmS2+fj+rHagO8Di4nMg==",
+      "dependencies": {
+        "d3-array": "^2.7.1",
+        "d3-timer": "^2.0.0",
+        "vega-dataflow": "^5.7.3",
+        "vega-format": "^1.0.4",
+        "vega-functions": "^5.10.0",
+        "vega-runtime": "^6.1.3",
+        "vega-scenegraph": "^4.9.4",
+        "vega-util": "^1.16.1"
+      }
+    },
+    "node_modules/vega-view-transforms": {
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.5.9.tgz",
+      "integrity": "sha512-NxEq4ZD4QwWGRrl2yDLnBRXM9FgCI+vvYb3ZC2+nVDtkUxOlEIKZsMMw31op5GZpfClWLbjCT3mVvzO2xaTF+g==",
+      "dependencies": {
+        "vega-dataflow": "^5.7.5",
+        "vega-scenegraph": "^4.10.2",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-view-transforms/node_modules/vega-format": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.1.2.tgz",
+      "integrity": "sha512-0kUfAj0dg0U6GcEY0Kp6LiSTCZ8l8jl1qVdQyToMyKmtZg/q56qsiJQZy3WWRr1MtWkTIZL71xSJXgjwjeUaAw==",
+      "dependencies": {
+        "d3-array": "^3.2.2",
+        "d3-format": "^3.1.0",
+        "d3-time-format": "^4.1.0",
+        "vega-time": "^2.1.2",
+        "vega-util": "^1.17.2"
+      }
+    },
+    "node_modules/vega-view-transforms/node_modules/vega-loader": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.5.2.tgz",
+      "integrity": "sha512-ktIdGz3DRIS3XfTP9lJ6oMT5cKwC86nQkjUbXZbOtwXQFVNE2xVWBuH13GP6FKUZxg5hJCMtb5v/e/fwTvhKsQ==",
+      "dependencies": {
+        "d3-dsv": "^3.0.1",
+        "node-fetch": "^2.6.7",
+        "topojson-client": "^3.1.0",
+        "vega-format": "^1.1.2",
+        "vega-util": "^1.17.2"
+      }
+    },
+    "node_modules/vega-view-transforms/node_modules/vega-scale": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.4.1.tgz",
+      "integrity": "sha512-dArA28DbV/M92O2QvswnzCmQ4bq9WwLKUoyhqFYWCltmDwkmvX7yhqiFLFMWPItIm7mi4Qyoygby6r4DKd1X2A==",
+      "dependencies": {
+        "d3-array": "^3.2.2",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.1.0",
+        "vega-time": "^2.1.2",
+        "vega-util": "^1.17.2"
+      }
+    },
+    "node_modules/vega-view-transforms/node_modules/vega-scenegraph": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.13.0.tgz",
+      "integrity": "sha512-nfl45XtuqB5CxyIZJ+bbJ+dofzosPCRlmF+eUQo+0J23NkNXsTzur+1krJDSdhcw0SOYs4sbYRoMz1cpuOM4+Q==",
+      "dependencies": {
+        "d3-path": "^3.1.0",
+        "d3-shape": "^3.2.0",
+        "vega-canvas": "^1.2.7",
+        "vega-loader": "^4.5.2",
+        "vega-scale": "^7.4.1",
+        "vega-util": "^1.17.2"
+      }
+    },
+    "node_modules/vega-view-transforms/node_modules/vega-time": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.1.2.tgz",
+      "integrity": "sha512-6rXc6JdDt8MnCRy6UzUCsa6EeFycPDmvioMddLfKw38OYCV8pRQC5nw44gyddOwXgUTJLiCtn/sp53P0iA542A==",
+      "dependencies": {
+        "d3-array": "^3.2.2",
+        "d3-time": "^3.1.0",
+        "vega-util": "^1.17.2"
+      }
+    },
+    "node_modules/vega-view-transforms/node_modules/vega-util": {
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.2.tgz",
+      "integrity": "sha512-omNmGiZBdjm/jnHjZlywyYqafscDdHaELHx1q96n5UOz/FlO9JO99P4B3jZg391EFG8dqhWjQilSf2JH6F1mIw=="
+    },
+    "node_modules/vega-view/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/vega-view/node_modules/d3-timer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
+      "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA=="
+    },
+    "node_modules/vega-view/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
+    },
+    "node_modules/vega-voronoi": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.1.5.tgz",
+      "integrity": "sha512-950IkgCFLj0zG33EWLAm1hZcp+FMqWcNQliMYt+MJzOD5S4MSpZpZ7K4wp2M1Jktjw/CLKFL9n38JCI0i3UonA==",
+      "dependencies": {
+        "d3-delaunay": "^5.3.0",
+        "vega-dataflow": "^5.7.3",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-voronoi/node_modules/d3-delaunay": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-5.3.0.tgz",
+      "integrity": "sha512-amALSrOllWVLaHTnDLHwMIiz0d1bBu9gZXd1FiLfXf8sHcX9jrcj81TVZOqD4UX7MgBZZ07c8GxzEgBpJqc74w==",
+      "dependencies": {
+        "delaunator": "4"
+      }
+    },
+    "node_modules/vega-voronoi/node_modules/delaunator": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
+      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag=="
+    },
+    "node_modules/vega-wordcloud": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.1.5.tgz",
+      "integrity": "sha512-p+qXU3cb9VeWzJ/HEdax0TX2mqDJcSbrCIfo2d/EalOXGkvfSLKobsmMQ8DxPbtVp0uhnpvfCGDyMJw+AzcI2A==",
+      "dependencies": {
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.6",
+        "vega-scale": "^7.4.1",
+        "vega-statistics": "^1.9.0",
+        "vega-util": "^1.17.2"
+      }
+    },
+    "node_modules/vega-wordcloud/node_modules/vega-scale": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.4.1.tgz",
+      "integrity": "sha512-dArA28DbV/M92O2QvswnzCmQ4bq9WwLKUoyhqFYWCltmDwkmvX7yhqiFLFMWPItIm7mi4Qyoygby6r4DKd1X2A==",
+      "dependencies": {
+        "d3-array": "^3.2.2",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.1.0",
+        "vega-time": "^2.1.2",
+        "vega-util": "^1.17.2"
+      }
+    },
+    "node_modules/vega-wordcloud/node_modules/vega-statistics": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.9.0.tgz",
+      "integrity": "sha512-GAqS7mkatpXcMCQKWtFu1eMUKLUymjInU0O8kXshWaQrVWjPIO2lllZ1VNhdgE0qGj4oOIRRS11kzuijLshGXQ==",
+      "dependencies": {
+        "d3-array": "^3.2.2"
+      }
+    },
+    "node_modules/vega-wordcloud/node_modules/vega-time": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.1.2.tgz",
+      "integrity": "sha512-6rXc6JdDt8MnCRy6UzUCsa6EeFycPDmvioMddLfKw38OYCV8pRQC5nw44gyddOwXgUTJLiCtn/sp53P0iA542A==",
+      "dependencies": {
+        "d3-array": "^3.2.2",
+        "d3-time": "^3.1.0",
+        "vega-util": "^1.17.2"
+      }
+    },
+    "node_modules/vega-wordcloud/node_modules/vega-util": {
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.2.tgz",
+      "integrity": "sha512-omNmGiZBdjm/jnHjZlywyYqafscDdHaELHx1q96n5UOz/FlO9JO99P4B3jZg391EFG8dqhWjQilSf2JH6F1mIw=="
     },
     "node_modules/vite": {
       "version": "5.0.10",
@@ -9710,6 +11188,11 @@
         "node": ">=18"
       }
     },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="
+    },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
@@ -9777,6 +11260,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="
     },
     "node_modules/which-typed-array": {
       "version": "1.1.13",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@microsoft/applicationinsights-web": "^3.0.0",
     "@sentry/svelte": "^7.100.1",
     "@tensorflow/tfjs": "^4.4.0",
+    "@tensorflow/tfjs-vis": "^1.5.1",
     "@types/w3c-web-serial": "^1.0.6",
     "@types/w3c-web-usb": "^1.0.6",
     "bowser": "^2.11.0",

--- a/src/__tests__/ml.test.ts
+++ b/src/__tests__/ml.test.ts
@@ -8,14 +8,22 @@
  */
 
 import * as tf from '@tensorflow/tfjs';
-import { makeInputs, trainModel } from '../script/ml';
+import { ModelSettings, makeInputs, trainModel } from '../script/ml';
 import { gestures } from '../script/stores/Stores';
 import gestureData from './fixtures/gesture-data.json';
 import gestureDataBadLabels from './fixtures/gesture-data-bad-labels.json';
 import testdataShakeStill from './fixtures/test-data-shake-still.json';
 import { PersistantGestureData } from '../script/domain/Gestures';
+import { get } from 'svelte/store';
+import { settings } from '../script/stores/mlStore';
 
 let tensorFlowModel: tf.LayersModel | void;
+const mlSettings = get(settings);
+const modelSettings = {
+  axes: mlSettings.includedAxes,
+  filters: mlSettings.includedFilters,
+};
+
 beforeAll(async () => {
   // No webgl in tests running in node.
   tf.setBackend('cpu');
@@ -34,7 +42,7 @@ const getModelResults = (data: PersistantGestureData[]) => {
   const numActions = data.length;
   data.forEach((action, index) => {
     action.recordings.forEach(recording => {
-      x.push(makeInputs(recording.data));
+      x.push(makeInputs(modelSettings, recording.data));
       const label = new Array(numActions);
       label.fill(0, 0, numActions);
       label[index] = 1;

--- a/src/components/AverageFingerprint.svelte
+++ b/src/components/AverageFingerprint.svelte
@@ -1,0 +1,53 @@
+<!--
+  (c) 2024, Center for Computational Thinking and Design at Aarhus University and contributors
+
+  SPDX-License-Identifier: MIT
+ -->
+
+<script lang="ts">
+  import * as tfvis from '@tensorflow/tfjs-vis';
+  import { onMount } from 'svelte';
+  import { get } from 'svelte/store';
+  import { makeInputs, ModelSettings } from '../script/ml';
+  import { GestureData, settings } from '../script/stores/mlStore';
+  import { gestures } from '../script/stores/Stores';
+  import Fingerprint from './Fingerprint.svelte';
+
+  export let gesture: GestureData;
+  let surface: undefined | tfvis.Drawable;
+
+  const filters = Array.from(get(settings).includedFilters);
+
+  const mlSettings = get(settings);
+  const modelSettings: ModelSettings = {
+    axes: mlSettings.includedAxes,
+    filters: mlSettings.includedFilters,
+  };
+
+  const filtersLabels: string[] = [];
+  filters.forEach(filter => {
+    filtersLabels.push(`${filter}-x`, `${filter}-y`, `${filter}-z`);
+  });
+
+  const getFingerprintData = () => {
+    const inputData: number[][] = [];
+    gesture.recordings.forEach(r => {
+      inputData.push(makeInputs(modelSettings, r.data, 'computeNormalizedOutput'));
+    });
+    const averagedData: number[] = [];
+    for (let i = 0; i < filters.length * 3; i++) {
+      let filterValues: number[] = [];
+      inputData.forEach(d => {
+        filterValues.push(d[i]);
+      });
+      averagedData.push(filterValues.reduce((a, b) => a + b, 0) / filterValues.length);
+    }
+    return averagedData;
+  };
+</script>
+
+<Fingerprint
+  gestureName={`${gesture.name} average`}
+  recordingData={undefined}
+  averagedData={getFingerprintData()}
+  height="full" />

--- a/src/components/AverageFingerprint.svelte
+++ b/src/components/AverageFingerprint.svelte
@@ -5,16 +5,12 @@
  -->
 
 <script lang="ts">
-  import * as tfvis from '@tensorflow/tfjs-vis';
-  import { onMount } from 'svelte';
   import { get } from 'svelte/store';
   import { makeInputs, ModelSettings } from '../script/ml';
   import { GestureData, settings } from '../script/stores/mlStore';
-  import { gestures } from '../script/stores/Stores';
   import Fingerprint from './Fingerprint.svelte';
 
   export let gesture: GestureData;
-  let surface: undefined | tfvis.Drawable;
 
   const filters = Array.from(get(settings).includedFilters);
 
@@ -46,8 +42,9 @@
   };
 </script>
 
-<Fingerprint
-  gestureName={`${gesture.name} average`}
-  recordingData={undefined}
-  averagedData={getFingerprintData()}
-  height="full" />
+<div class="h-full overflow-hidden">
+  <Fingerprint
+    gestureName={`${gesture.name} average`}
+    recordingData={undefined}
+    averagedData={getFingerprintData()} />
+</div>

--- a/src/components/Fingerprint.svelte
+++ b/src/components/Fingerprint.svelte
@@ -1,0 +1,60 @@
+<!--
+  (c) 2024, Center for Computational Thinking and Design at Aarhus University and contributors
+
+  SPDX-License-Identifier: MIT
+ -->
+
+<script lang="ts">
+  import * as tfvis from '@tensorflow/tfjs-vis';
+  import { onMount } from 'svelte';
+  import { get } from 'svelte/store';
+  import { makeInputs, ModelSettings } from '../script/ml';
+  import { RecordingData, settings } from '../script/stores/mlStore';
+
+  export let recordingData: RecordingData;
+  export let gestureName: string;
+
+  let surface: undefined | tfvis.Drawable;
+
+  const mlSettings = get(settings);
+  const modelSettings: ModelSettings = {
+    axes: mlSettings.includedAxes,
+    filters: mlSettings.includedFilters,
+  };
+
+  const filtersLabels: string[] = [];
+  modelSettings.filters.forEach(filter => {
+    filtersLabels.push(`${filter}-x`, `${filter}-y`, `${filter}-z`);
+  });
+
+  const processedData = makeInputs(
+    modelSettings,
+    recordingData.data,
+    'computeNormalizedOutput',
+  );
+
+  const chartData = {
+    values: [processedData],
+    xTickLabels: filtersLabels,
+    yTickLabels: [gestureName],
+  };
+
+  onMount(() => {
+    if (surface) {
+      tfvis.render.heatmap(surface, chartData, {
+        colorMap: 'viridis',
+        height: 20,
+        width: 204,
+        rowMajor: true,
+        domain: [0, 1],
+        fontSize: 0,
+      });
+    }
+  });
+</script>
+
+<div class="relative h-20px w-full">
+  <div class="absolute h-20px w-full -bottom-8px -left-8px">
+    <div bind:this={surface}></div>
+  </div>
+</div>

--- a/src/components/Fingerprint.svelte
+++ b/src/components/Fingerprint.svelte
@@ -11,8 +11,10 @@
   import { makeInputs, ModelSettings } from '../script/ml';
   import { RecordingData, settings } from '../script/stores/mlStore';
 
-  export let recordingData: RecordingData;
+  export let recordingData: RecordingData | undefined;
   export let gestureName: string;
+  export let averagedData: number[] = [];
+  export let height: 'small' | 'half' | 'full' = 'small';
 
   let surface: undefined | tfvis.Drawable;
 
@@ -27,14 +29,13 @@
     filtersLabels.push(`${filter}-x`, `${filter}-y`, `${filter}-z`);
   });
 
-  const processedData = makeInputs(
-    modelSettings,
-    recordingData.data,
-    'computeNormalizedOutput',
-  );
+  const getProcessedData = () =>
+    recordingData
+      ? makeInputs(modelSettings, recordingData.data, 'computeNormalizedOutput')
+      : [];
 
   const chartData = {
-    values: [processedData],
+    values: recordingData ? [getProcessedData()] : [averagedData],
     xTickLabels: filtersLabels,
     yTickLabels: [gestureName],
   };
@@ -43,7 +44,7 @@
     if (surface) {
       tfvis.render.heatmap(surface, chartData, {
         colorMap: 'viridis',
-        height: 20,
+        height: height === 'small' ? 29 : height === 'half' ? 60 : 111,
         width: 204,
         rowMajor: true,
         domain: [0, 1],
@@ -53,8 +54,16 @@
   });
 </script>
 
-<div class="relative h-20px w-full">
-  <div class="absolute h-20px w-full -bottom-8px -left-8px">
+<div
+  class="relative w-full"
+  class:h-11px={height === 'small'}
+  class:h-42px={height === 'half'}
+  class:h-102px={height === 'full'}>
+  <div
+    class="absolute w-full -bottom-9px top-0 -left-8px"
+    class:h-11px={height === 'small'}
+    class:h-42px={height === 'half'}
+    class:h-102px={height === 'full'}>
     <div bind:this={surface}></div>
   </div>
 </div>

--- a/src/components/Fingerprint.svelte
+++ b/src/components/Fingerprint.svelte
@@ -14,7 +14,6 @@
   export let recordingData: RecordingData | undefined;
   export let gestureName: string;
   export let averagedData: number[] = [];
-  export let height: 'small' | 'half' | 'full' = 'small';
 
   let surface: undefined | tfvis.Drawable;
 
@@ -36,17 +35,16 @@
 
   const chartData = {
     values: recordingData ? [getProcessedData()] : [averagedData],
-    xTickLabels: filtersLabels,
-    yTickLabels: [gestureName],
+    xTickLabels: [gestureName],
+    yTickLabels: filtersLabels,
   };
 
   onMount(() => {
     if (surface) {
       tfvis.render.heatmap(surface, chartData, {
         colorMap: 'viridis',
-        height: height === 'small' ? 29 : height === 'half' ? 60 : 111,
-        width: 204,
-        rowMajor: true,
+        height: 109,
+        width: 80,
         domain: [0, 1],
         fontSize: 0,
       });
@@ -54,16 +52,15 @@
   });
 </script>
 
-<div
-  class="relative w-full"
-  class:h-11px={height === 'small'}
-  class:h-42px={height === 'half'}
-  class:h-102px={height === 'full'}>
+<div class="relative w-40px" class:h-full={!recordingData}>
   <div
-    class="absolute w-full -bottom-9px top-0 -left-8px"
-    class:h-11px={height === 'small'}
-    class:h-42px={height === 'half'}
-    class:h-102px={height === 'full'}>
+    class="absolute h-full w-full -left-10px right-0 -bottom-1px"
+    class:top-1px={!recordingData}
+    class:top-0={recordingData}>
     <div bind:this={surface}></div>
   </div>
+  {#if !recordingData}
+    <div class="absolute bg-white h-full w-20px left-34px top-0 bottom-0" />
+    <div class="absolute bg-white h-8px w-40px left-0 -bottom-7px" />
+  {/if}
 </div>

--- a/src/components/Gesture.svelte
+++ b/src/components/Gesture.svelte
@@ -164,12 +164,12 @@
   }
 
   // Delete recording from recordings array
-  function deleteRecording(recording: RecordingData) {
+  function deleteRecording(gestureId: number, recording: RecordingData) {
     if (!areActionsAllowed(false)) {
       return;
     }
     $state.isPredicting = false;
-    removeRecording(gesture.getId(), recording.ID);
+    removeRecording(gestureId, recording.ID);
   }
 
   function selectGesture(): void {
@@ -367,6 +367,7 @@
         {#if hasRecordings}
           {#each $gesture.recordings as recording (String($gesture.ID) + String(recording.ID))}
             <Recording
+              gestureId={$gesture.ID}
               gestureName={$nameBind}
               {recording}
               onDelete={deleteRecording}

--- a/src/components/Gesture.svelte
+++ b/src/components/Gesture.svelte
@@ -366,7 +366,11 @@
         </div>
         {#if hasRecordings}
           {#each $gesture.recordings as recording (String($gesture.ID) + String(recording.ID))}
-            <Recording {recording} onDelete={deleteRecording} on:focus={selectGesture} />
+            <Recording
+              gestureName={$nameBind}
+              {recording}
+              onDelete={deleteRecording}
+              on:focus={selectGesture} />
           {/each}
         {/if}
       </div>

--- a/src/components/GestureTilePart.svelte
+++ b/src/components/GestureTilePart.svelte
@@ -13,7 +13,8 @@
 </script>
 
 <div
-  class="{$$restProps.class || ''} rounded-lg bg-backgroundlight border-1 {selected
+  class="{$$restProps.class ||
+    ''} overflow-hidden rounded-lg bg-backgroundlight border-1 {selected
     ? 'border-brand-500'
     : 'border-transparent'}"
   class:h-30={small}

--- a/src/components/Recording.svelte
+++ b/src/components/Recording.svelte
@@ -15,19 +15,26 @@
   // get recording from mother prop
   export let recording: RecordingData;
   export let gestureName: string;
-  export let onDelete: (recording: RecordingData) => void;
+  export let showFingerprint: boolean = false;
+  export let onDelete: ((recording: RecordingData) => void) | undefined = undefined;
 </script>
 
-<div class="h-full flex flex-col w-40 relative overflow-hidden">
+<div class="h-full flex flex-col w-40 relative overflow-hidden gap-2">
   <RecordingGraph data={recording.data} />
-  <Fingerprint {gestureName} recordingData={recording} />
+  {#if showFingerprint}
+    <div class="flex-grow">
+      <Fingerprint {gestureName} recordingData={recording} height="half" />
+    </div>
+  {/if}
 
-  <div class="absolute right-0 top-0 z-2">
-    <IconButton
-      ariaLabel={$t('content.data.deleteRecording')}
-      onClick={() => onDelete(recording)}
-      on:focus>
-      <CloseIcon class="text-xl m-1" />
-    </IconButton>
-  </div>
+  {#if onDelete}
+    <div class="absolute right-0 top-0 z-2">
+      <IconButton
+        ariaLabel={$t('content.data.deleteRecording')}
+        onClick={() => onDelete && onDelete(recording)}
+        on:focus>
+        <CloseIcon class="text-xl m-1" />
+      </IconButton>
+    </div>
+  {/if}
 </div>

--- a/src/components/Recording.svelte
+++ b/src/components/Recording.svelte
@@ -5,20 +5,22 @@
  -->
 
 <script lang="ts">
-  import { fade } from 'svelte/transition';
+  import CloseIcon from 'virtual:icons/ri/close-line';
+  import { t } from '../i18n';
   import type { RecordingData } from '../script/stores/mlStore';
+  import Fingerprint from './Fingerprint.svelte';
   import RecordingGraph from './graphs/RecordingGraph.svelte';
   import IconButton from './IconButton.svelte';
-  import { t } from '../i18n';
-  import CloseIcon from 'virtual:icons/ri/close-line';
 
   // get recording from mother prop
   export let recording: RecordingData;
+  export let gestureName: string;
   export let onDelete: (recording: RecordingData) => void;
 </script>
 
-<div class="h-full w-40 relative">
+<div class="h-full flex flex-col w-40 relative overflow-hidden">
   <RecordingGraph data={recording.data} />
+  <Fingerprint {gestureName} recordingData={recording} />
 
   <div class="absolute right-0 top-0 z-2">
     <IconButton

--- a/src/components/Recording.svelte
+++ b/src/components/Recording.svelte
@@ -19,6 +19,7 @@
   export let showFingerprint: boolean = false;
   export let onDelete: (gestureId: number, recording: RecordingData) => void;
   export let fullWidth: boolean = false;
+  export let showProcessedData: boolean = false;
 </script>
 
 <div
@@ -30,13 +31,12 @@
   class:border-neutral-300={showFingerprint}>
   <RecordingGraph data={recording.data} showBorder={!showFingerprint} />
   {#if showFingerprint}
-    <Fingerprint {gestureName} recordingData={recording} />
+    <div class="transition-all duration-1000 w-0" class:w-30px={showProcessedData}>
+      <Fingerprint {gestureName} recordingData={recording} />
+    </div>
   {/if}
 
-  <div
-    class="absolute top-0 z-2"
-    class:right-0={!showFingerprint}
-    class:right-34px={showFingerprint}>
+  <div class="absolute top-0 z-2 left-0">
     <IconButton
       ariaLabel={$t('content.data.deleteRecording')}
       onClick={() => onDelete(gestureId, recording)}

--- a/src/components/Recording.svelte
+++ b/src/components/Recording.svelte
@@ -15,26 +15,33 @@
   // get recording from mother prop
   export let recording: RecordingData;
   export let gestureName: string;
+  export let gestureId: number;
   export let showFingerprint: boolean = false;
-  export let onDelete: ((recording: RecordingData) => void) | undefined = undefined;
+  export let onDelete: (gestureId: number, recording: RecordingData) => void;
+  export let fullWidth: boolean = false;
 </script>
 
-<div class="h-full flex flex-col w-40 relative overflow-hidden gap-2">
-  <RecordingGraph data={recording.data} />
+<div
+  class="h-full flex w-40 relative overflow-hidden"
+  class:w-40={!fullWidth}
+  class:w-full={fullWidth}
+  class:rounded-md={showFingerprint}
+  class:border-1={showFingerprint}
+  class:border-neutral-300={showFingerprint}>
+  <RecordingGraph data={recording.data} showBorder={!showFingerprint} />
   {#if showFingerprint}
-    <div class="flex-grow">
-      <Fingerprint {gestureName} recordingData={recording} height="half" />
-    </div>
+    <Fingerprint {gestureName} recordingData={recording} />
   {/if}
 
-  {#if onDelete}
-    <div class="absolute right-0 top-0 z-2">
-      <IconButton
-        ariaLabel={$t('content.data.deleteRecording')}
-        onClick={() => onDelete && onDelete(recording)}
-        on:focus>
-        <CloseIcon class="text-xl m-1" />
-      </IconButton>
-    </div>
-  {/if}
+  <div
+    class="absolute top-0 z-2"
+    class:right-0={!showFingerprint}
+    class:right-34px={showFingerprint}>
+    <IconButton
+      ariaLabel={$t('content.data.deleteRecording')}
+      onClick={() => onDelete(gestureId, recording)}
+      on:focus>
+      <CloseIcon class="text-xl m-1" />
+    </IconButton>
+  </div>
 </div>

--- a/src/components/bottom/BottomPanel.svelte
+++ b/src/components/bottom/BottomPanel.svelte
@@ -5,16 +5,16 @@
  -->
 
 <script lang="ts">
-  import LiveGraph from '../graphs/LiveGraph.svelte';
+  import { onMount } from 'svelte';
   import { t } from '../../i18n';
-  import ConnectedLiveGraphButtons from './ConnectedLiveGraphButtons.svelte';
-  import LiveGraphInformationSection from './LiveGraphInformationSection.svelte';
-  import BaseDialog from '../dialogs/BaseDialog.svelte';
-  import View3DLive from '../3d-inspector/View3DLive.svelte';
-  import Information from '../information/Information.svelte';
   import { state } from '../../script/stores/uiStore';
-  import Fingerprint from '../Fingerprint.svelte';
+  import View3DLive from '../3d-inspector/View3DLive.svelte';
+  import BaseDialog from '../dialogs/BaseDialog.svelte';
+  import LiveGraph from '../graphs/LiveGraph.svelte';
+  import Information from '../information/Information.svelte';
+  import ConnectedLiveGraphButtons from './ConnectedLiveGraphButtons.svelte';
   import LiveFingerprint from './LiveFingerprint.svelte';
+  import LiveGraphInformationSection from './LiveGraphInformationSection.svelte';
 
   export let showFingerprint: boolean = false;
   const live3dViewVisible = false;
@@ -26,7 +26,9 @@
 <div bind:clientWidth={componentWidth} class="relative w-full h-full bg-white">
   <div class="relative z-1">
     <div
-      class="flex items-center justify-between gap-2 pt-4 px-7 m-0 absolute top-0 left-0 right-0">
+      class="flex items-center justify-between gap-2 pt-4 px-7 m-0 absolute top-0 left-0"
+      class:right-0={!showFingerprint}
+      class:right-80px={showFingerprint}>
       <div class="flex items-center gap-4">
         <!-- The live text and info box -->
         <LiveGraphInformationSection />
@@ -66,13 +68,11 @@
       </BaseDialog>
     {/if}
   </div>
-  <div
-    class="absolute w-full h-full overflow-hidden"
-    class:flex={showFingerprint}
-    class:flex-col={showFingerprint}>
-    <LiveGraph width={componentWidth - live3dViewSize} halfHeight={showFingerprint} />
+  <div class="absolute w-full h-full overflow-hidden" class:flex={showFingerprint}>
+    <!-- <div class="bg-red-200" style={`width: ${componentWidth}px`}></div> -->
+    <LiveGraph width={componentWidth - live3dViewSize - (showFingerprint ? 80 : 0)} />
     {#if showFingerprint}
-      <LiveFingerprint width={componentWidth} />
+      <LiveFingerprint />
     {/if}
   </div>
 </div>

--- a/src/components/bottom/BottomPanel.svelte
+++ b/src/components/bottom/BottomPanel.svelte
@@ -13,7 +13,10 @@
   import View3DLive from '../3d-inspector/View3DLive.svelte';
   import Information from '../information/Information.svelte';
   import { state } from '../../script/stores/uiStore';
+  import Fingerprint from '../Fingerprint.svelte';
+  import LiveFingerprint from './LiveFingerprint.svelte';
 
+  export let showFingerprint: boolean = false;
   const live3dViewVisible = false;
   const live3dViewSize = live3dViewVisible ? 160 : 0;
   let componentWidth: number;
@@ -63,7 +66,13 @@
       </BaseDialog>
     {/if}
   </div>
-  <div class="absolute w-full h-full">
-    <LiveGraph width={componentWidth - live3dViewSize} />
+  <div
+    class="absolute w-full h-full overflow-hidden"
+    class:flex={showFingerprint}
+    class:flex-col={showFingerprint}>
+    <LiveGraph width={componentWidth - live3dViewSize} halfHeight={showFingerprint} />
+    {#if showFingerprint}
+      <LiveFingerprint width={componentWidth} />
+    {/if}
   </div>
 </div>

--- a/src/components/bottom/LiveFingerprint.svelte
+++ b/src/components/bottom/LiveFingerprint.svelte
@@ -1,0 +1,65 @@
+<!--
+  (c) 2024, Center for Computational Thinking and Design at Aarhus University and contributors
+
+  SPDX-License-Identifier: MIT
+ -->
+
+<script lang="ts">
+  import * as tfvis from '@tensorflow/tfjs-vis';
+  import { onMount } from 'svelte';
+  import { get } from 'svelte/store';
+  import { makeInputs, ModelSettings } from '../../script/ml';
+  import { getPrevData, settings } from '../../script/stores/mlStore';
+
+  export let width: number;
+  let surface: undefined | tfvis.Drawable;
+  $: prevData = getPrevData();
+  const filters = Array.from(get(settings).includedFilters);
+
+  const mlSettings = get(settings);
+  const modelSettings: ModelSettings = {
+    axes: mlSettings.includedAxes,
+    filters: mlSettings.includedFilters,
+  };
+
+  const filtersLabels: string[] = [];
+  filters.forEach(filter => {
+    filtersLabels.push(`${filter}-x`, `${filter}-y`, `${filter}-z`);
+  });
+
+  const disconnectedData = new Array(filtersLabels.length).fill(0);
+
+  onMount(() => {
+    const interval = setInterval(() => {
+      prevData = getPrevData();
+
+      if (surface) {
+        const currentGestureData = prevData
+          ? makeInputs(modelSettings, prevData, 'computeNormalizedOutput')
+          : disconnectedData;
+        const currentData = {
+          values: [currentGestureData],
+          xTickLabels: filtersLabels,
+          yTickLabels: ['Live'],
+        };
+        tfvis.render.heatmap(surface, currentData, {
+          colorMap: 'viridis',
+          height: 89,
+          width: width + 44,
+          rowMajor: true,
+          domain: [0, 1],
+          fontSize: 0,
+        });
+      }
+    });
+    return () => {
+      clearInterval(interval);
+    };
+  });
+</script>
+
+<div class="relative w-full h-full flex-grow">
+  <div class="absolute h-full w-full top-0 -left-8px">
+    <div bind:this={surface}></div>
+  </div>
+</div>

--- a/src/components/bottom/LiveFingerprint.svelte
+++ b/src/components/bottom/LiveFingerprint.svelte
@@ -10,8 +10,8 @@
   import { get } from 'svelte/store';
   import { makeInputs, ModelSettings } from '../../script/ml';
   import { getPrevData, settings } from '../../script/stores/mlStore';
+  import { state } from '../../script/stores/uiStore';
 
-  export let width: number;
   let surface: undefined | tfvis.Drawable;
   $: prevData = getPrevData();
   const filters = Array.from(get(settings).includedFilters);
@@ -39,14 +39,13 @@
           : disconnectedData;
         const currentData = {
           values: [currentGestureData],
-          xTickLabels: filtersLabels,
-          yTickLabels: ['Live'],
+          xTickLabels: ['Live'],
+          yTickLabels: filtersLabels,
         };
         tfvis.render.heatmap(surface, currentData, {
           colorMap: 'viridis',
-          height: 89,
-          width: width + 44,
-          rowMajor: true,
+          height: 166,
+          width: 160,
           domain: [0, 1],
           fontSize: 0,
         });
@@ -58,8 +57,8 @@
   });
 </script>
 
-<div class="relative w-full h-full flex-grow">
-  <div class="absolute h-full w-full top-0 -left-8px">
+<div class="relative w-20 h-full z-0">
+  <div class="absolute h-full w-full top-0 -left-10px right-0 bottom-0">
     <div bind:this={surface}></div>
   </div>
 </div>

--- a/src/components/graphs/DimensionLabels.svelte
+++ b/src/components/graphs/DimensionLabels.svelte
@@ -15,6 +15,8 @@
   import { currentData } from '../../script/stores/mlStore';
   import { state } from '../../script/stores/uiStore';
 
+  export let halfHeight: boolean = false;
+  const heightValue = halfHeight ? 5 : 10;
   $: {
     const data = $currentData;
     const dataInArray = [data.x, data.y, data.z];
@@ -27,9 +29,20 @@
     { label: 'z', arrowHeight: 0, labelHeight: 0, color: '#808ef9', id: 2 },
   ];
 
-  function updateDimensionLabels(axes: number[]) {
+  function scale(value: number) {
+    const newMin = (heightValue / (2.3 + Math.abs(-2.3))) * 0.3;
+    const newMax = heightValue - newMin;
+    const existingMin = 2;
+    const existingMax = -2;
+    return (
+      ((newMax - newMin) * (value - existingMin)) / (existingMax - existingMin) + newMin
+    );
+  }
+
+  function updateDimensionLabels(data: number[]) {
     for (let i = 0; i < 3; i++) {
-      labels[i].arrowHeight = (2.1 - axes[labels[i].id]) * 2.32;
+      const value = data[labels[i].id];
+      labels[i].arrowHeight = scale(value);
     }
     fixOverlappingLabels();
   }
@@ -76,16 +89,18 @@
 </script>
 
 {#if $state.isInputConnected}
-  <div class="h-40 w-6 relative">
+  <div class="w-6 relative" class:h-40={!halfHeight} class:h-20={halfHeight}>
     {#each labels as dimension}
       <div
         class="absolute arrowLeft -m-3.5"
         style="transform: translateY({dimension.arrowHeight +
-          0.75}rem) scale(1, 0.75); border-right-color: {dimension.color};" />
+          heightValue /
+            16 /
+            2}rem) scale(1, 0.75); border-right-color: {dimension.color};" />
       <p
         class="absolute ml-3 text-xl"
         style="transform: translateY({dimension.labelHeight -
-          0.5}rem); color: {dimension.color};">
+          1.75 / 2}rem); color: {dimension.color};">
         {dimension.label}
       </p>
     {/each}

--- a/src/components/graphs/DimensionLabels.svelte
+++ b/src/components/graphs/DimensionLabels.svelte
@@ -15,8 +15,6 @@
   import { currentData } from '../../script/stores/mlStore';
   import { state } from '../../script/stores/uiStore';
 
-  export let halfHeight: boolean = false;
-  const heightValue = halfHeight ? 5 : 10;
   $: {
     const data = $currentData;
     const dataInArray = [data.x, data.y, data.z];
@@ -29,20 +27,9 @@
     { label: 'z', arrowHeight: 0, labelHeight: 0, color: '#808ef9', id: 2 },
   ];
 
-  function scale(value: number) {
-    const newMin = (heightValue / (2.3 + Math.abs(-2.3))) * 0.3;
-    const newMax = heightValue - newMin;
-    const existingMin = 2;
-    const existingMax = -2;
-    return (
-      ((newMax - newMin) * (value - existingMin)) / (existingMax - existingMin) + newMin
-    );
-  }
-
-  function updateDimensionLabels(data: number[]) {
+  function updateDimensionLabels(axes: number[]) {
     for (let i = 0; i < 3; i++) {
-      const value = data[labels[i].id];
-      labels[i].arrowHeight = scale(value);
+      labels[i].arrowHeight = (2.1 - axes[labels[i].id]) * 2.32;
     }
     fixOverlappingLabels();
   }
@@ -88,21 +75,19 @@
   }
 </script>
 
-{#if $state.isInputConnected}
-  <div class="w-6 relative" class:h-40={!halfHeight} class:h-20={halfHeight}>
+<div class="h-40 w-6 relative z-10 bg-white">
+  {#if $state.isInputConnected}
     {#each labels as dimension}
       <div
         class="absolute arrowLeft -m-3.5"
         style="transform: translateY({dimension.arrowHeight +
-          heightValue /
-            16 /
-            2}rem) scale(1, 0.75); border-right-color: {dimension.color};" />
+          0.75}rem) scale(1, 0.75); border-right-color: {dimension.color};" />
       <p
         class="absolute ml-3 text-xl"
         style="transform: translateY({dimension.labelHeight -
-          1.75 / 2}rem); color: {dimension.color};">
+          0.5}rem); color: {dimension.color};">
         {dimension.label}
       </p>
     {/each}
-  </div>
-{/if}
+  {/if}
+</div>

--- a/src/components/graphs/LiveGraph.svelte
+++ b/src/components/graphs/LiveGraph.svelte
@@ -14,6 +14,7 @@
 
   // Updates width to ensure that the canvas fills the whole screen
   export let width: number;
+  export let halfHeight: boolean = false;
 
   var canvas: HTMLCanvasElement | undefined = undefined;
   var chart: SmoothieChart | undefined;
@@ -27,7 +28,7 @@
   onMount(() => {
     chart = new SmoothieChart({
       maxValue: 2.3,
-      minValue: -2,
+      minValue: -2.3,
       millisPerPixel: 7,
       grid: {
         fillStyle: '#ffffff00',
@@ -72,14 +73,14 @@
     }
 
     // Set start line
-    recordLines.append(new Date().getTime() - 1, -2, false);
+    recordLines.append(new Date().getTime() - 1, -2.3, false);
     recordLines.append(new Date().getTime(), 2.3, false);
 
     // Wait a second and set end line
     blockRecordingStart = true;
     setTimeout(() => {
       recordLines.append(new Date().getTime() - 1, 2.3, false);
-      recordLines.append(new Date().getTime(), -2, false);
+      recordLines.append(new Date().getTime(), -2.3, false);
       blockRecordingStart = false;
     }, get(settings).duration);
   }
@@ -92,7 +93,11 @@
   }
 </script>
 
-<div class="flex overflow-hidden">
-  <canvas bind:this={canvas} height={160} id="smoothie-chart" width={width - 30} />
-  <DimensionLabels />
+<div class="flex flex-grow h-full w-full overflow-hidden">
+  <canvas
+    bind:this={canvas}
+    height={halfHeight ? 80 : 160}
+    id="smoothie-chart"
+    width={width - 30} />
+  <DimensionLabels {halfHeight} />
 </div>

--- a/src/components/graphs/LiveGraph.svelte
+++ b/src/components/graphs/LiveGraph.svelte
@@ -14,7 +14,6 @@
 
   // Updates width to ensure that the canvas fills the whole screen
   export let width: number;
-  export let halfHeight: boolean = false;
 
   var canvas: HTMLCanvasElement | undefined = undefined;
   var chart: SmoothieChart | undefined;
@@ -28,7 +27,7 @@
   onMount(() => {
     chart = new SmoothieChart({
       maxValue: 2.3,
-      minValue: -2.3,
+      minValue: -2,
       millisPerPixel: 7,
       grid: {
         fillStyle: '#ffffff00',
@@ -49,7 +48,20 @@
     });
     chart.streamTo(<HTMLCanvasElement>canvas, 0);
     chart.render();
-    return () => chart?.stop();
+
+    const resizeChart = () => {
+      window.requestAnimationFrame(() => {
+        if (chart && canvas && !$state.isInputConnected) {
+          canvas.width = width - 30;
+          chart.render();
+        }
+      });
+    };
+    window.addEventListener('resize', resizeChart);
+    return () => {
+      chart?.stop();
+      window.removeEventListener('resize', resizeChart);
+    };
   });
 
   $: {
@@ -73,14 +85,14 @@
     }
 
     // Set start line
-    recordLines.append(new Date().getTime() - 1, -2.3, false);
+    recordLines.append(new Date().getTime() - 1, -2, false);
     recordLines.append(new Date().getTime(), 2.3, false);
 
     // Wait a second and set end line
     blockRecordingStart = true;
     setTimeout(() => {
       recordLines.append(new Date().getTime() - 1, 2.3, false);
-      recordLines.append(new Date().getTime(), -2.3, false);
+      recordLines.append(new Date().getTime(), -2, false);
       blockRecordingStart = false;
     }, get(settings).duration);
   }
@@ -93,11 +105,7 @@
   }
 </script>
 
-<div class="flex flex-grow h-full w-full overflow-hidden">
-  <canvas
-    bind:this={canvas}
-    height={halfHeight ? 80 : 160}
-    id="smoothie-chart"
-    width={width - 30} />
-  <DimensionLabels {halfHeight} />
+<div class="flex overflow-hidden">
+  <canvas bind:this={canvas} height={160} id="smoothie-chart" width={width - 30} />
+  <DimensionLabels />
 </div>

--- a/src/components/graphs/RecordingGraph.svelte
+++ b/src/components/graphs/RecordingGraph.svelte
@@ -20,6 +20,7 @@
   import { smoothenXYZData } from '../../script/smoothenXYZData';
 
   export let data: { x: number[]; y: number[]; z: number[] };
+  export let showBorder: boolean;
 
   const smoothData = smoothenXYZData(data);
   let verticalLineX = NaN;
@@ -229,7 +230,10 @@
 
 <div
   bind:this={htmlElement}
-  class="h-full w-full relative rounded-md border-1 border-neutral-300">
+  class="h-full w-full relative bg-white z-1"
+  class:rounded-md={showBorder}
+  class:border-1={showBorder}
+  class:border-neutral-300={showBorder}>
   <div class="z-1 h-full w-full absolute">
     {#if enableInspector && !isNaN(hoverIndex)}
       <p

--- a/src/pages/ProcessDataPage.svelte
+++ b/src/pages/ProcessDataPage.svelte
@@ -16,9 +16,14 @@
   import Recording from '../components/Recording.svelte';
   import { t } from '../i18n';
   import { makeInputs, ModelSettings } from '../script/ml';
-  import { getPrevData, settings } from '../script/stores/mlStore';
+  import {
+    getPrevData,
+    RecordingData,
+    removeRecording,
+    settings,
+  } from '../script/stores/mlStore';
   import { gestures } from '../script/stores/Stores';
-  import { state } from '../script/stores/uiStore';
+  import { areActionsAllowed, state } from '../script/stores/uiStore';
   import TabView from '../views/TabView.svelte';
   import Fingerprint from '../components/Fingerprint.svelte';
   import AverageFingerprint from '../components/AverageFingerprint.svelte';
@@ -104,6 +109,15 @@
     };
   });
 
+  // Delete recording from recordings array
+  function deleteRecording(gestureId: number, recording: RecordingData) {
+    if (!areActionsAllowed(false)) {
+      return;
+    }
+    $state.isPredicting = false;
+    removeRecording(gestureId, recording.ID);
+  }
+
   $: hasSomeData = (): boolean => {
     if ($gestures.length === 0) {
       return false;
@@ -144,10 +158,12 @@
           {#each $gestures as gesture (gesture.ID)}
             <section class="contents">
               <GestureTilePart small elevated>
-                <div class="flex items-center px-6 w-50 h-30 relative">
+                <div
+                  class="flex items-center justify-between py-2 px-6 w-50 h-30 relative">
                   <h3>
                     {gesture.name}
                   </h3>
+                  <AverageFingerprint {gesture} />
                 </div>
               </GestureTilePart>
               <div
@@ -156,18 +172,16 @@
                   : 'invisible'}">
                 <GestureTilePart small elevated>
                   <div class="h-full flex items-center gap-x-3 p-2">
-                    <div
-                      class="w-40 flex justify-center items-center gap-x-3 overflow-hidden">
-                      <AverageFingerprint {gesture} />
-                    </div>
                     {#if gesture.recordings.length}
                       {#each gesture.recordings as recording (String(gesture.ID) + String(recording.ID))}
-                        <div class="h-full flex flex-col w-40 relative overflow-hidden">
+                        <div class="h-full flex flex-col w-48 relative overflow-hidden">
                           <Recording
+                            gestureId={gesture.ID}
                             gestureName={gesture.name}
-                            showFingerprint
                             {recording}
-                            onDelete={undefined} />
+                            fullWidth={true}
+                            showFingerprint
+                            onDelete={deleteRecording} />
                         </div>
                       {/each}
                     {/if}

--- a/src/pages/ProcessDataPage.svelte
+++ b/src/pages/ProcessDataPage.svelte
@@ -1,0 +1,137 @@
+<!--
+  (c) 2024, Center for Computational Thinking and Design at Aarhus University and contributors
+
+  SPDX-License-Identifier: MIT
+ -->
+
+<script lang="ts">
+  import * as tfvis from '@tensorflow/tfjs-vis';
+  import { onMount } from 'svelte';
+  import { gestures } from '../script/stores/Stores';
+  import { get } from 'svelte/store';
+  import { getPrevData, settings } from '../script/stores/mlStore';
+  import { makeInputs, ModelSettings } from '../script/ml';
+  import TabView from '../views/TabView.svelte';
+  import { state } from '../script/stores/uiStore';
+  import BottomPanel from '../components/bottom/BottomPanel.svelte';
+  import LoadingAnimation from '../components/LoadingBlobs.svelte';
+
+  let surfaceAll: undefined | tfvis.Drawable;
+  let surfaceCurrent: undefined | tfvis.Drawable;
+  $: prevData = getPrevData();
+  const filters = Array.from(get(settings).includedFilters);
+
+  const mlSettings = get(settings);
+  const modelSettings: ModelSettings = {
+    axes: mlSettings.includedAxes,
+    filters: mlSettings.includedFilters,
+  };
+
+  const filtersLabels: string[] = [];
+  filters.forEach(filter => {
+    filtersLabels.push(`${filter}-x`, `${filter}-y`, `${filter}-z`);
+  });
+  const allData = $gestures.map(g => {
+    const inputData: number[][] = [];
+    g.recordings.forEach(r => {
+      inputData.push(makeInputs(modelSettings, r.data, 'computeNormalizedOutput'));
+    });
+    const averagedData: number[] = [];
+    for (let i = 0; i < filters.length * 3; i++) {
+      let filterValues: number[] = [];
+      inputData.forEach(d => {
+        filterValues.push(d[i]);
+      });
+      averagedData.push(filterValues.reduce((a, b) => a + b, 0) / filterValues.length);
+    }
+    return averagedData;
+  });
+
+  const data = {
+    values: allData,
+    xTickLabels: filtersLabels,
+    yTickLabels: $gestures.map(g => g.name),
+  };
+
+  onMount(() => {
+    const renderAllDataHeatmap = () => {
+      if (surfaceAll) {
+        tfvis.render.heatmap(surfaceAll, data, {
+          colorMap: 'viridis',
+          height: 250,
+          rowMajor: true,
+          domain: [0, 1],
+        });
+      }
+    };
+
+    renderAllDataHeatmap();
+
+    window.addEventListener('resize', renderAllDataHeatmap);
+
+    const interval = setInterval(() => {
+      prevData = getPrevData();
+
+      if (surfaceCurrent && prevData) {
+        const currentGestureData = makeInputs(
+          modelSettings,
+          prevData,
+          'computeNormalizedOutput',
+        );
+        const currentData = {
+          values: [currentGestureData],
+          xTickLabels: filtersLabels,
+          yTickLabels: ['Live'],
+        };
+        tfvis.render.heatmap(surfaceCurrent, currentData, {
+          colorMap: 'viridis',
+          height: 120,
+          rowMajor: true,
+          domain: [0, 1],
+        });
+      }
+    });
+    return () => {
+      clearInterval(interval);
+      window.removeEventListener('resize', renderAllDataHeatmap);
+    };
+  });
+</script>
+
+<div class="flex flex-col h-full inline-block w-full bg-backgrounddark">
+  <TabView />
+  <main class="contents">
+    <h1 class="sr-only">Process data</h1>
+    <div class="flex flex-col flex-grow items-center h-0 overflow-y-auto">
+      <div class="p-5 flex-grow flex flex-col gap-5 w-3/4">
+        <div class="flex flex-col gap-2">
+          <h2 class="font-semibold">All recordings</h2>
+          <p>The mean of the filters applied to all recordings for each action</p>
+          <div class="bg-white p-5 rounded-lg w-full">
+            <div bind:this={surfaceAll}></div>
+          </div>
+        </div>
+        <div class="flex flex-col gap-2">
+          <h2 class="font-semibold">Current action</h2>
+          <p>Filters applied to the live data</p>
+          <div class="bg-white p-5 min-h-160px rounded-lg w-full">
+            {#if $state.isInputConnected && prevData}
+              <div bind:this={surfaceCurrent}></div>
+            {:else if $state.isInputConnected && !prevData}
+              <div class="flex justify-center items-center h-full">
+                <LoadingAnimation />
+              </div>
+            {:else}
+              <div class="flex justify-center items-center h-full">
+                <p>Connect your micro:bit view live data</p>
+              </div>
+            {/if}
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="h-160px w-full">
+      <BottomPanel />
+    </div>
+  </main>
+</div>

--- a/src/pages/ProcessDataPage.svelte
+++ b/src/pages/ProcessDataPage.svelte
@@ -7,14 +7,21 @@
 <script lang="ts">
   import * as tfvis from '@tensorflow/tfjs-vis';
   import { onMount } from 'svelte';
-  import { gestures } from '../script/stores/Stores';
   import { get } from 'svelte/store';
-  import { getPrevData, settings } from '../script/stores/mlStore';
-  import { makeInputs, ModelSettings } from '../script/ml';
-  import TabView from '../views/TabView.svelte';
-  import { state } from '../script/stores/uiStore';
   import BottomPanel from '../components/bottom/BottomPanel.svelte';
+  import GestureTilePart from '../components/GestureTilePart.svelte';
+  import Information from '../components/information/Information.svelte';
   import LoadingAnimation from '../components/LoadingBlobs.svelte';
+  import PleaseConnectFirst from '../components/PleaseConnectFirst.svelte';
+  import Recording from '../components/Recording.svelte';
+  import { t } from '../i18n';
+  import { makeInputs, ModelSettings } from '../script/ml';
+  import { getPrevData, settings } from '../script/stores/mlStore';
+  import { gestures } from '../script/stores/Stores';
+  import { state } from '../script/stores/uiStore';
+  import TabView from '../views/TabView.svelte';
+  import Fingerprint from '../components/Fingerprint.svelte';
+  import AverageFingerprint from '../components/AverageFingerprint.svelte';
 
   let surfaceAll: undefined | tfvis.Drawable;
   let surfaceCurrent: undefined | tfvis.Drawable;
@@ -96,42 +103,84 @@
       window.removeEventListener('resize', renderAllDataHeatmap);
     };
   });
+
+  $: hasSomeData = (): boolean => {
+    if ($gestures.length === 0) {
+      return false;
+    }
+    return $gestures.some(gesture => gesture.recordings.length > 0);
+  };
 </script>
 
 <div class="flex flex-col h-full inline-block w-full bg-backgrounddark">
   <TabView />
   <main class="contents">
     <h1 class="sr-only">Process data</h1>
-    <div class="flex flex-col flex-grow items-center h-0 overflow-y-auto">
-      <div class="p-5 flex-grow flex flex-col gap-5 w-3/4">
-        <div class="flex flex-col gap-2">
-          <h2 class="font-semibold">All recordings</h2>
-          <p>The mean of the filters applied to all recordings for each action</p>
-          <div class="bg-white p-5 rounded-lg w-full">
-            <div bind:this={surfaceAll}></div>
-          </div>
+
+    {#if !hasSomeData() && !$state.isInputConnected}
+      <div class="flex justify-center items-center flex-grow">
+        <PleaseConnectFirst />
+      </div>
+    {:else}
+      <div class="flex flex-col flex-grow">
+        <div
+          class="grid grid-cols-[200px,1fr] gap-x-7 items-center flex-shrink-0 h-13 px-10 z-3 border-b-3 border-gray-200 sticky top-0 bg-backgrounddark">
+          <Information
+            isLightTheme={false}
+            underlineIconText={false}
+            iconText={$t('content.data.classification')}
+            titleText={$t('content.data.classHelpHeader')}
+            bodyText={$t('content.data.classHelpBody')} />
+          <Information
+            isVisible={$gestures.some(g => g.name.trim() || g.recordings.length > 0)}
+            isLightTheme={false}
+            underlineIconText={false}
+            iconText={$t('content.data.data')}
+            titleText={$t('content.data.data')}
+            bodyText={$t('content.data.dataDescription')} />
         </div>
-        <div class="flex flex-col gap-2">
-          <h2 class="font-semibold">Current action</h2>
-          <p>Filters applied to the live data</p>
-          <div class="bg-white p-5 min-h-160px rounded-lg w-full">
-            {#if $state.isInputConnected && prevData}
-              <div bind:this={surfaceCurrent}></div>
-            {:else if $state.isInputConnected && !prevData}
-              <div class="flex justify-center items-center h-full">
-                <LoadingAnimation />
+        <div
+          class="grid grid-cols-[200px,1fr] auto-rows-max gap-x-7 gap-y-3 py-2 px-10 flex-grow flex-shrink h-0 overflow-y-auto">
+          {#each $gestures as gesture (gesture.ID)}
+            <section class="contents">
+              <GestureTilePart small elevated>
+                <div class="flex items-center px-6 w-50 h-30 relative">
+                  <h3>
+                    {gesture.name}
+                  </h3>
+                </div>
+              </GestureTilePart>
+              <div
+                class="max-w-max {gesture.name && gesture.recordings.length
+                  ? 'visible'
+                  : 'invisible'}">
+                <GestureTilePart small elevated>
+                  <div class="h-full flex items-center gap-x-3 p-2">
+                    <div
+                      class="w-40 flex justify-center items-center gap-x-3 overflow-hidden">
+                      <AverageFingerprint {gesture} />
+                    </div>
+                    {#if gesture.recordings.length}
+                      {#each gesture.recordings as recording (String(gesture.ID) + String(recording.ID))}
+                        <div class="h-full flex flex-col w-40 relative overflow-hidden">
+                          <Recording
+                            gestureName={gesture.name}
+                            showFingerprint
+                            {recording}
+                            onDelete={undefined} />
+                        </div>
+                      {/each}
+                    {/if}
+                  </div>
+                </GestureTilePart>
               </div>
-            {:else}
-              <div class="flex justify-center items-center h-full">
-                <p>Connect your micro:bit view live data</p>
-              </div>
-            {/if}
-          </div>
+            </section>
+          {/each}
         </div>
       </div>
-    </div>
+    {/if}
     <div class="h-160px w-full">
-      <BottomPanel />
+      <BottomPanel showFingerprint />
     </div>
   </main>
 </div>

--- a/src/pages/ProcessDataPage.svelte
+++ b/src/pages/ProcessDataPage.svelte
@@ -27,6 +27,7 @@
   import TabView from '../views/TabView.svelte';
   import Fingerprint from '../components/Fingerprint.svelte';
   import AverageFingerprint from '../components/AverageFingerprint.svelte';
+  import StandardButton from '../components/StandardButton.svelte';
 
   let surfaceAll: undefined | tfvis.Drawable;
   let surfaceCurrent: undefined | tfvis.Drawable;
@@ -124,6 +125,14 @@
     }
     return $gestures.some(gesture => gesture.recordings.length > 0);
   };
+
+  let showProcessedData = false;
+  const processData = () => {
+    showProcessedData = true;
+  };
+  const hideProcessedData = () => {
+    showProcessedData = false;
+  };
 </script>
 
 <div class="flex flex-col h-full inline-block w-full bg-backgrounddark">
@@ -163,7 +172,11 @@
                   <h3>
                     {gesture.name}
                   </h3>
-                  <AverageFingerprint {gesture} />
+                  <div
+                    class="transition-all duration-1000 h-full w-0"
+                    class:w-30px={showProcessedData}>
+                    <AverageFingerprint {gesture} />
+                  </div>
                 </div>
               </GestureTilePart>
               <div
@@ -174,13 +187,16 @@
                   <div class="h-full flex items-center gap-x-3 p-2">
                     {#if gesture.recordings.length}
                       {#each gesture.recordings as recording (String(gesture.ID) + String(recording.ID))}
-                        <div class="h-full flex flex-col w-48 relative overflow-hidden">
+                        <div
+                          class="h-full flex flex-col w-40 relative overflow-hidden transition-all duration-1000"
+                          class:w-48={showProcessedData}>
                           <Recording
                             gestureId={gesture.ID}
                             gestureName={gesture.name}
                             {recording}
                             fullWidth={true}
                             showFingerprint
+                            {showProcessedData}
                             onDelete={deleteRecording} />
                         </div>
                       {/each}
@@ -193,6 +209,10 @@
         </div>
       </div>
     {/if}
+    <div
+      class="flex items-center justify-end px-10 py-2 border-b-3 border-t-3 border-gray-200">
+      <StandardButton type="primary" onClick={processData}>Process data</StandardButton>
+    </div>
     <div class="h-160px w-full">
       <BottomPanel showFingerprint />
     </div>

--- a/src/router/Router.svelte
+++ b/src/router/Router.svelte
@@ -16,6 +16,7 @@
   import TrainingPage from '../pages/training/TrainingPage.svelte';
   import { currentPageComponent } from '../views/currentComponentStore';
   import { currentPath, isValidPath, navigate, Paths, PathType } from './paths';
+  import FingerprintPage from '../pages/ProcessDataPage.svelte';
 
   const stripLeadingSlash = (s: string): string => (s.startsWith('/') ? s.slice(1) : s);
 
@@ -33,6 +34,8 @@
         return DataPage;
       case Paths.TRAINING:
         return TrainingPage;
+      case Paths.PROCESS:
+        return FingerprintPage;
       case Paths.MODEL:
         return ModelPage;
       case Paths.FILTERS:

--- a/src/router/paths.ts
+++ b/src/router/paths.ts
@@ -14,6 +14,7 @@ export const Paths = {
   GET_STARTED: 'resources/get-started',
   DATA: 'add-data',
   TRAINING: 'train-model',
+  PROCESS: 'process-data',
   MODEL: 'test-model',
   FILTERS: 'training/filters',
 } as const;
@@ -44,6 +45,9 @@ export const getTitle = (path: PathType, t: MessageFormatter) => {
     }
     case Paths.TRAINING: {
       return `${t('content.index.toolProcessCards.train.title')} | ${appName}`;
+    }
+    case Paths.PROCESS: {
+      return `Process data | ${appName}`;
     }
     case Paths.MODEL: {
       return `${t('content.index.toolProcessCards.model.title')} | ${appName}`;

--- a/src/script/navigation/Menus.ts
+++ b/src/script/navigation/Menus.ts
@@ -19,6 +19,10 @@ class Menus {
       navigationPath: Paths.DATA,
     },
     {
+      title: '1.5. Process data',
+      navigationPath: Paths.PROCESS,
+    },
+    {
       title: 'menu.trainer.helpHeading',
       navigationPath: Paths.TRAINING,
     },


### PR DESCRIPTION
The output data of the ML filters for each recording are used to plot heatmaps which are effectively fingerprints of the data we pass into the ML model for training and inference. The fingerprints use filter outputs normalized to 0..1, the ML model still uses the non-normalized values and is not impacted by these changes.

These fingerprints are displayed for each recording in the "Process data" page (shown via animation after clicking the "Process data button). The fingerprint of the mean of the filters applied to all recordings for each action is displayed in the same box as the action name. If a micro:bit is connected, the live data is also displayed as a fingerprint at the right hand side of the bottom panel next to the x/y/z traces.

These fingerprints are effectively an alternative visualization to the filters view in the upstream ML Machine app.

More discussion is required regarding the UI/UX and education content impact. We could merge the process data and train model pages and possible re-enable the ability to toggle individual filters.