### PR TITLE
Update autogenerated code and extension version

### DIFF
--- a/src/script/makecode/generateCustomTsAndJson.ts
+++ b/src/script/makecode/generateCustomTsAndJson.ts
@@ -17,6 +17,18 @@ const createMlEvents = (actions: string[]) => {
   return code;
 };
 
+const createEventListeners = (numActions: number) => {
+  // Includes `None`.
+  const totalActions = numActions + 1;
+  let code = '';
+  for (let i = 1; i <= totalActions; i++) {
+    code += `    control.onEvent(MlRunnerIds.MlRunnerInference, ${i}, () => {\n`;
+    code += `      prevAction = ${i};\n`;
+    code += `    });${i === totalActions ? '' : '\n'}`;
+  }
+  return code;
+};
+
 const arrayBufferToHexString = (input: Uint8Array): string =>
   Array.from(input, i => i.toString(16).padStart(2, '0'))
     .join('')
@@ -38,22 +50,25 @@ export const generateCustomTs = (gs: Gesture[], m: LayersModel) => {
   const actionLabels = gs.map(g => g.getName());
 
   return `// Auto-generated. Do not edit.
-  namespace mlrunner {
-    export namespace Action {
-  ${createMlEvents(actionLabels)}
-      actions = [None,${actionLabels.toString()}];
-    }
+namespace mlrunner {
+  export namespace Action {
+${createMlEvents(actionLabels)}
+    actions = [None,${actionLabels.toString()}];
+
+${createEventListeners(actionLabels.length)}
   }
-  
-  getModelBlob = (): Buffer =>  {
-    const result = hex\`${headerHexString + modelHexString}\`;
-    return result;
-  }
-  
-  mlrunner.simulatorSendData();
-  
-  // Auto-generated. Do not edit. Really.
-  `;
+}
+
+
+getModelBlob = (): Buffer => {
+  const result = hex\`${headerHexString + modelHexString}\`;
+  return result;
+};
+
+mlrunner.simulatorSendData();
+
+// Auto-generated. Do not edit. Really.
+`;
 };
 
 export const generateCustomJson = (gs: Gesture[]) => {

--- a/src/script/makecode/utils.ts
+++ b/src/script/makecode/utils.ts
@@ -22,7 +22,7 @@ export const pxt = {
     core: '*',
     microphone: '*',
     radio: '*', // needed for compiling
-    'Machine Learning POC': 'github:microbit-foundation/pxt-ml-extension-poc#v0.3.8',
+    'Machine Learning POC': 'github:microbit-foundation/pxt-ml-extension-poc#v0.3.9',
   },
   files: [...Object.values(filenames), 'README.md'],
 };


### PR DESCRIPTION
See https://github.com/microbit-foundation/makecode-ml-editor-extension-poc/commit/2f8e0cefee83c309821b63a47198f3741d945ac3 and https://github.com/microbit-foundation/pxt-ml-extension-poc/commit/14c19f7b79e5b9ae89b290adfd7416450932fa21 for changes.

This PR also corrects the formatting of the autogenerated code.

Approved for POC branch here -> https://github.com/microbit-foundation/ml-trainer/pull/274