### PR TITLE
Handle radio connect/ reconnect error scenarios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@chakra-ui/react": "^2.8.2",
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
-        "@microbit/microbit-connection": "^0.0.0-alpha.17",
+        "@microbit/microbit-connection": "^0.0.0-alpha.18",
         "@tensorflow/tfjs": "^4.4.0",
         "@types/w3c-web-serial": "^1.0.6",
         "@types/w3c-web-usb": "^1.0.6",
@@ -4356,9 +4356,9 @@
       "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
     },
     "node_modules/@microbit/microbit-connection": {
-      "version": "0.0.0-alpha.17",
-      "resolved": "https://registry.npmjs.org/@microbit/microbit-connection/-/microbit-connection-0.0.0-alpha.17.tgz",
-      "integrity": "sha512-lgs2u0SDZZZpdbCVKEQ7FhN/PiZ8CJF6NTFIpY5r38/q8L3OO2SdHga1dizdbRPJ9lslbn9NubG2/M0yHr6o5g==",
+      "version": "0.0.0-alpha.18",
+      "resolved": "https://registry.npmjs.org/@microbit/microbit-connection/-/microbit-connection-0.0.0-alpha.18.tgz",
+      "integrity": "sha512-/3eFGsdHXwXtQqfyhHfngpsqpX5vM5t9CgR+9qppGW/9eP5J2N+v4zRlGb1dLxmWSsxyRJXE4av4TQ0W9P0zww==",
       "dependencies": {
         "@microbit/microbit-universal-hex": "^0.2.2",
         "@types/web-bluetooth": "^0.0.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@chakra-ui/react": "^2.8.2",
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
-        "@microbit/microbit-connection": "^0.0.0-alpha.14",
+        "@microbit/microbit-connection": "^0.0.0-alpha.15",
         "@tensorflow/tfjs": "^4.4.0",
         "@types/w3c-web-serial": "^1.0.6",
         "@types/w3c-web-usb": "^1.0.6",
@@ -4356,9 +4356,9 @@
       "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
     },
     "node_modules/@microbit/microbit-connection": {
-      "version": "0.0.0-alpha.14",
-      "resolved": "https://registry.npmjs.org/@microbit/microbit-connection/-/microbit-connection-0.0.0-alpha.14.tgz",
-      "integrity": "sha512-Z6PsxYTO359KD5hah0JOlxxehhlzmd7Q45NcrDYT6njTjbAT9FbSF4KnnQbgnbRgePmBzW4q/HAUl89Nvqevdw==",
+      "version": "0.0.0-alpha.15",
+      "resolved": "https://registry.npmjs.org/@microbit/microbit-connection/-/microbit-connection-0.0.0-alpha.15.tgz",
+      "integrity": "sha512-0yWLI63+sdIKqHbVyKfEaZMxYCXOv3uoJEOcSOYl7iK/MW9UWRcXFcQUjwWk1Q/6gUIzOdS/wboD7YixhcXBFQ==",
       "dependencies": {
         "@microbit/microbit-universal-hex": "^0.2.2",
         "@types/web-bluetooth": "^0.0.20",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@chakra-ui/react": "^2.8.2",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
-    "@microbit/microbit-connection": "^0.0.0-alpha.17",
+    "@microbit/microbit-connection": "^0.0.0-alpha.18",
     "@tensorflow/tfjs": "^4.4.0",
     "@types/w3c-web-serial": "^1.0.6",
     "@types/w3c-web-usb": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@chakra-ui/react": "^2.8.2",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
-    "@microbit/microbit-connection": "^0.0.0-alpha.14",
+    "@microbit/microbit-connection": "^0.0.0-alpha.15",
     "@tensorflow/tfjs": "^4.4.0",
     "@types/w3c-web-serial": "^1.0.6",
     "@types/w3c-web-usb": "^1.0.6",

--- a/src/buffered-data-hooks.tsx
+++ b/src/buffered-data-hooks.tsx
@@ -29,7 +29,7 @@ export const useBufferedData = (): BufferedData => {
 };
 
 const useBufferedDataInternal = (): BufferedData => {
-  const connectStatus = useConnectStatus();
+  const [connectStatus] = useConnectStatus();
   const connection = useConnectActions();
   const bufferRef = useRef<BufferedData>();
   const getBuffer = () => {

--- a/src/components/ConnectCableDialog.tsx
+++ b/src/components/ConnectCableDialog.tsx
@@ -5,6 +5,7 @@ import ConnectContainerDialog, {
   ConnectContainerDialogProps,
 } from "./ConnectContainerDialog";
 import { ConnectionFlowType } from "../connection-stage-hooks";
+import { stage } from "../environment";
 
 enum LinkType {
   Switch,
@@ -28,7 +29,14 @@ const configs: Record<ConnectionFlowType, Config> = {
   [ConnectionFlowType.RadioRemote]: {
     headingId: "connectMB.connectCableMB1.heading",
     subtitleId: "connectMB.connectCableMB1.subtitle",
-    onLink: LinkType.None,
+    ...(stage === "local"
+      ? {
+          linkTextId: "connectMB.connectCable.skip",
+          onLink: LinkType.Skip,
+        }
+      : {
+          onLink: LinkType.None,
+        }),
   },
   [ConnectionFlowType.RadioBridge]: {
     headingId: "connectMB.connectCableMB2.heading",

--- a/src/components/ConnectErrorDialog.tsx
+++ b/src/components/ConnectErrorDialog.tsx
@@ -20,12 +20,13 @@ import {
 } from "../connection-stage-hooks";
 import ExternalLink from "./ExternalLink";
 
-interface ReconnectErrorDialogProps {
+interface ConnectErrorDialogProps {
   isOpen: boolean;
   onClose: () => void;
-  onReconnect: () => void;
+  onConnect: () => void;
   flowType: ConnectionFlowType;
   errorStep:
+    | ConnectionFlowStep.ConnectFailed
     | ConnectionFlowStep.ReconnectFailed
     | ConnectionFlowStep.ConnectionLost;
 }
@@ -57,15 +58,16 @@ const contentConfig = {
 const errorTextIdPrefixConfig = {
   [ConnectionFlowStep.ConnectionLost]: "disconnectedWarning",
   [ConnectionFlowStep.ReconnectFailed]: "reconnectFailed",
+  [ConnectionFlowStep.ConnectFailed]: "connectFailed",
 };
 
 const ReconnectErrorDialog = ({
   isOpen,
   onClose,
-  onReconnect,
+  onConnect,
   flowType,
   errorStep,
-}: ReconnectErrorDialogProps) => {
+}: ConnectErrorDialogProps) => {
   const errorTextIdPrefix = errorTextIdPrefixConfig[errorStep];
   return (
     <Modal
@@ -113,8 +115,14 @@ const ReconnectErrorDialog = ({
               <Button onClick={onClose} variant="secondary" size="lg">
                 <FormattedMessage id="cancel-action" />
               </Button>
-              <Button onClick={onReconnect} variant="primary" size="lg">
-                <FormattedMessage id="actions.reconnect" />
+              <Button onClick={onConnect} variant="primary" size="lg">
+                <FormattedMessage
+                  id={
+                    errorStep === ConnectionFlowStep.ConnectFailed
+                      ? "footer.connectButton"
+                      : "actions.reconnect"
+                  }
+                />
               </Button>
             </HStack>
           </ModalFooter>

--- a/src/components/ConnectionFlowDialogs.tsx
+++ b/src/components/ConnectionFlowDialogs.tsx
@@ -13,7 +13,7 @@ import DownloadingDialog from "./DownloadingDialog";
 import EnterBluetoothPatternDialog from "./EnterBluetoothPatternDialog";
 import LoadingDialog from "./LoadingDialog";
 import ManualFlashingDialog from "./ManualFlashingDialog";
-import ReconnectErrorDialog from "./ReconnectErrorDialog";
+import ConnectErrorDialog from "./ConnectErrorDialog";
 import SelectMicrobitBluetoothDialog from "./SelectMicrobitBluetoothDialog";
 import SelectMicrobitUsbDialog from "./SelectMicrobitUsbDialog";
 import TryAgainDialog from "./TryAgainDialog";
@@ -196,9 +196,9 @@ const ConnectionDialogs = () => {
         <LoadingDialog isOpen={isOpen} headingId="connectMB.radio.heading" />
       );
     }
-    case ConnectionFlowStep.TryAgainBluetoothConnect:
+    case ConnectionFlowStep.TryAgainBluetoothSelectMicrobit:
     case ConnectionFlowStep.TryAgainReplugMicrobit:
-    case ConnectionFlowStep.TryAgainSelectMicrobit:
+    case ConnectionFlowStep.TryAgainWebUsbSelectMicrobit:
     case ConnectionFlowStep.TryAgainCloseTabs: {
       return (
         <TryAgainDialog
@@ -229,12 +229,13 @@ const ConnectionDialogs = () => {
     case ConnectionFlowStep.WebUsbBluetoothUnsupported: {
       return <WebUsbBluetoothUnsupportedDialog {...dialogCommonProps} />;
     }
+    case ConnectionFlowStep.ConnectFailed:
     case ConnectionFlowStep.ReconnectFailed:
     case ConnectionFlowStep.ConnectionLost: {
       return (
-        <ReconnectErrorDialog
+        <ConnectErrorDialog
           {...dialogCommonProps}
-          onReconnect={actions.reconnect}
+          onConnect={actions.reconnect}
           flowType={stage.flowType}
           errorStep={stage.flowStep}
         />

--- a/src/components/ConnectionFlowDialogs.tsx
+++ b/src/components/ConnectionFlowDialogs.tsx
@@ -60,19 +60,13 @@ const ConnectionDialogs = () => {
     [actions]
   );
 
-  const onFlashSuccess = useCallback(
-    async (newStage: ConnectionStage) => {
-      // Inferring microbit name saves the user from entering the pattern
-      // for bluetooth connection flow
-      if (newStage.bluetoothMicrobitName) {
-        setMicrobitName(newStage.bluetoothMicrobitName);
-      }
-      if (newStage.flowType === ConnectionFlowType.RadioBridge) {
-        await actions.connectMicrobits();
-      }
-    },
-    [actions]
-  );
+  const onFlashSuccess = useCallback((newStage: ConnectionStage) => {
+    // Inferring microbit name saves the user from entering the pattern
+    // for bluetooth connection flow
+    if (newStage.bluetoothMicrobitName) {
+      setMicrobitName(newStage.bluetoothMicrobitName);
+    }
+  }, []);
 
   async function connectAndFlash(): Promise<void> {
     await actions.connectAndflashMicrobit(progressCallback, onFlashSuccess);

--- a/src/components/LiveGraph.tsx
+++ b/src/components/LiveGraph.tsx
@@ -7,6 +7,7 @@ import { useConnectionStage } from "../connection-stage-hooks";
 import { AccelerometerDataEvent } from "@microbit/microbit-connection";
 import { MlStage, useMlStatus } from "../ml-status-hooks";
 import { mlSettings } from "../ml";
+import { ConnectionStatus } from "../connect-status-hooks";
 
 const smoothenDataPoint = (curr: number, next: number) => {
   // TODO: Factor out so that recording graph can do the same
@@ -15,7 +16,7 @@ const smoothenDataPoint = (curr: number, next: number) => {
 };
 
 const LiveGraph = () => {
-  const { isConnected } = useConnectionStage();
+  const { isConnected, status } = useConnectionStage();
   const [{ stage }] = useMlStatus();
   const connectActions = useConnectActions();
 
@@ -70,12 +71,12 @@ const LiveGraph = () => {
   }, [lineX, lineY, lineZ, recordLines]);
 
   useEffect(() => {
-    if (isConnected) {
+    if (isConnected || status === ConnectionStatus.ReconnectingAutomatically) {
       chart?.start();
     } else {
       chart?.stop();
     }
-  }, [chart, isConnected]);
+  }, [chart, isConnected, status]);
 
   // Draw on graph to display that users are recording
   const [isRecording, setIsRecording] = useState<boolean>(false);

--- a/src/components/LiveGraphPanel.tsx
+++ b/src/components/LiveGraphPanel.tsx
@@ -10,7 +10,9 @@ import { ConnectionStatus } from "../connect-status-hooks";
 const LiveGraphPanel = () => {
   const { actions, status } = useConnectionStage();
   const parentPortalRef = useRef(null);
-
+  const isReconnecting =
+    status === ConnectionStatus.ReconnectingAutomatically ||
+    status === ConnectionStatus.ReconnectingExplicitly;
   const connectBtnConfig = useMemo(() => {
     return status === ConnectionStatus.NotConnected ||
       status === ConnectionStatus.Connecting ||
@@ -55,15 +57,14 @@ const LiveGraphPanel = () => {
                 variant="primary"
                 size="sm"
                 isDisabled={
-                  status === ConnectionStatus.Reconnecting ||
-                  status === ConnectionStatus.Connecting
+                  isReconnecting || status === ConnectionStatus.Connecting
                 }
                 onClick={connectBtnConfig.onClick}
               >
                 <FormattedMessage id={connectBtnConfig.textId} />
               </Button>
             )}
-            {status === ConnectionStatus.Reconnecting && (
+            {isReconnecting && (
               <Text rounded="4xl" bg="white" py="1px" fontWeight="bold">
                 <FormattedMessage id="connectMB.reconnecting" />
               </Text>

--- a/src/components/LiveGraphPanel.tsx
+++ b/src/components/LiveGraphPanel.tsx
@@ -5,11 +5,10 @@ import { FormattedMessage } from "react-intl";
 import { useConnectionStage } from "../connection-stage-hooks";
 import InfoToolTip from "./InfoToolTip";
 import LiveGraph from "./LiveGraph";
-import { ConnectionStatus, useConnectStatus } from "../connect-status-hooks";
+import { ConnectionStatus } from "../connect-status-hooks";
 
 const LiveGraphPanel = () => {
-  const { actions } = useConnectionStage();
-  const status = useConnectStatus();
+  const { actions, status } = useConnectionStage();
   const parentPortalRef = useRef(null);
 
   const connectBtnConfig = useMemo(() => {

--- a/src/components/StartResumeActions.tsx
+++ b/src/components/StartResumeActions.tsx
@@ -34,6 +34,7 @@ const StartResumeActions = ({ ...props }: Partial<StackProps>) => {
     if (hasExistingSession) {
       startOverWarningDialogDisclosure.onOpen();
     } else {
+      startOverWarningDialogDisclosure.onClose();
       handleStartNewSession();
     }
   }, [

--- a/src/components/StartResumeActions.tsx
+++ b/src/components/StartResumeActions.tsx
@@ -22,19 +22,25 @@ const StartResumeActions = ({ ...props }: Partial<StackProps>) => {
   }, [navigate]);
 
   const handleStartNewSession = useCallback(() => {
+    startOverWarningDialogDisclosure.onClose();
     gestureActions.deleteAllGestures();
     if (isConnected) {
       handleNavigateToAddData();
     } else {
       connStageActions.start();
     }
-  }, [gestureActions, connStageActions, handleNavigateToAddData, isConnected]);
+  }, [
+    startOverWarningDialogDisclosure,
+    gestureActions,
+    isConnected,
+    handleNavigateToAddData,
+    connStageActions,
+  ]);
 
   const onClickStartNewSession = useCallback(() => {
     if (hasExistingSession) {
       startOverWarningDialogDisclosure.onOpen();
     } else {
-      startOverWarningDialogDisclosure.onClose();
       handleStartNewSession();
     }
   }, [

--- a/src/components/TryAgainDialog.tsx
+++ b/src/components/TryAgainDialog.tsx
@@ -68,11 +68,11 @@ const configs = {
     headingId: "connectMB.usbTryAgain.heading",
     children: <CloseTabsContent />,
   },
-  [ConnectionFlowStep.TryAgainSelectMicrobit]: {
+  [ConnectionFlowStep.TryAgainWebUsbSelectMicrobit]: {
     headingId: "connectMB.usbTryAgain.heading",
     children: <OneLineContent textId="connectMB.usbTryAgain.selectMicrobit" />,
   },
-  [ConnectionFlowStep.TryAgainBluetoothConnect]: {
+  [ConnectionFlowStep.TryAgainBluetoothSelectMicrobit]: {
     headingId: "connectMB.bluetooth.heading",
     children: (
       <OneLineContent textId="connectMB.bluetooth.cancelledConnection" />
@@ -80,23 +80,23 @@ const configs = {
   },
 };
 
-interface TryAgainWebUsbDialogProps {
+interface TryAgainDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onTryAgain: () => void;
   type:
     | ConnectionFlowStep.TryAgainReplugMicrobit
     | ConnectionFlowStep.TryAgainCloseTabs
-    | ConnectionFlowStep.TryAgainSelectMicrobit
-    | ConnectionFlowStep.TryAgainBluetoothConnect;
+    | ConnectionFlowStep.TryAgainWebUsbSelectMicrobit
+    | ConnectionFlowStep.TryAgainBluetoothSelectMicrobit;
 }
 
-const TryAgainWebUsbDialog = ({
+const TryAgainDialog = ({
   type,
   isOpen,
   onClose,
   onTryAgain,
-}: TryAgainWebUsbDialogProps) => {
+}: TryAgainDialogProps) => {
   const config = configs[type];
   return (
     <Modal
@@ -135,4 +135,4 @@ const TryAgainWebUsbDialog = ({
   );
 };
 
-export default TryAgainWebUsbDialog;
+export default TryAgainDialog;

--- a/src/connect-actions-hooks.tsx
+++ b/src/connect-actions-hooks.tsx
@@ -29,13 +29,11 @@ interface ConnectProviderProps {
 export const ConnectProvider = ({ children }: ConnectProviderProps) => {
   const usb = useMemo(() => new MicrobitWebUSBConnection(), []);
   const bluetooth = useMemo(() => new MicrobitWebBluetoothConnection(), []);
-  const logging = useLogging();
+  // TODO: Reinstate logging
+  // const logging = useLogging();
   const radioBridge = useMemo(
-    () =>
-      new MicrobitRadioBridgeConnection(usb, {
-        logging,
-      }),
-    [logging, usb]
+    () => new MicrobitRadioBridgeConnection(usb),
+    [usb]
   );
   const isInitialized = useRef<boolean>(false);
 

--- a/src/connect-actions-hooks.tsx
+++ b/src/connect-actions-hooks.tsx
@@ -29,11 +29,13 @@ interface ConnectProviderProps {
 export const ConnectProvider = ({ children }: ConnectProviderProps) => {
   const usb = useMemo(() => new MicrobitWebUSBConnection(), []);
   const bluetooth = useMemo(() => new MicrobitWebBluetoothConnection(), []);
-  // TODO: Reinstate logging
-  // const logging = useLogging();
+  const logging = useLogging();
   const radioBridge = useMemo(
-    () => new MicrobitRadioBridgeConnection(usb),
-    [usb]
+    () =>
+      new MicrobitRadioBridgeConnection(usb, {
+        logging,
+      }),
+    [logging, usb]
   );
   const isInitialized = useRef<boolean>(false);
 

--- a/src/connect-status-hooks.tsx
+++ b/src/connect-status-hooks.tsx
@@ -26,9 +26,14 @@ export enum ConnectionStatus {
    */
   Connected = "Connected",
   /**
-   * Reconnecting occurs for the subsequent connections after the initial one.
+   * Reconnecting explicitly occurs when a reconnection is triggered by the user.
    */
-  Reconnecting = "Reconnecting",
+  ReconnectingExplicitly = "ReconnectingExplicitly",
+  /**
+   * Reconnecting automatically occurs when a reconnection is triggered automatically.
+   * This happens before a connection lost is declared.
+   */
+  ReconnectingAutomatically = "ReconnectingAutomatically",
   /**
    * Disconnected. The disconnection is triggered by the user.
    */

--- a/src/connect-status-hooks.tsx
+++ b/src/connect-status-hooks.tsx
@@ -1,17 +1,17 @@
-import {
-  ConnectionStatusEvent,
-  ConnectionStatus as DeviceConnectionStatus,
-} from "@microbit/microbit-connection";
+import { ConnectionStatus as DeviceConnectionStatus } from "@microbit/microbit-connection";
 import {
   MutableRefObject,
   ReactNode,
   createContext,
+  useCallback,
   useContext,
   useEffect,
   useRef,
   useState,
 } from "react";
+import { StatusListener, StatusListenerType } from "./connect-actions";
 import { useConnectActions } from "./connect-actions-hooks";
+import { ConnectionFlowType } from "./connection-stage-hooks";
 
 export enum ConnectionStatus {
   /**
@@ -73,8 +73,16 @@ export const ConnectStatusProvider = ({
   const connectStatusContextValue = useState<ConnectionStatus>(
     ConnectionStatus.NotConnected
   );
+
+  const set = useCallback(
+    (s: ConnectionStatus) => {
+      console.log(s);
+      connectStatusContextValue[1](s);
+    },
+    [connectStatusContextValue]
+  );
   return (
-    <ConnectStatusContext.Provider value={connectStatusContextValue}>
+    <ConnectStatusContext.Provider value={[connectStatusContextValue[0], set]}>
       {children}
     </ConnectStatusContext.Provider>
   );
@@ -91,99 +99,127 @@ export const useSetConnectStatus = (): ((status: ConnectionStatus) => void) => {
 };
 
 export const useConnectStatus = (
-  handleStatus?: (status: ConnectionStatus) => void
+  handleStatus?: (status: ConnectionStatus, type?: ConnectionFlowType) => void
 ): ConnectionStatus => {
   const connectStatusContextValue = useContext(ConnectStatusContext);
   if (!connectStatusContextValue) {
     throw new Error("Missing provider");
   }
-  const [status, setStatus] = connectStatusContextValue;
+  const [connectionStatus, setConnectionStatus] = connectStatusContextValue;
   const connectActions = useConnectActions();
   const prevDeviceStatus = useRef<DeviceConnectionStatus | null>(null);
   const hasAttempedReconnect = useRef<boolean>(false);
+  const hasRadioConnected = useRef<boolean>(false);
 
   useEffect(() => {
-    const listener = ({ status: deviceStatus }: ConnectionStatusEvent) => {
-      const newStatus = getNextConnectionStatus(
-        status,
+    const listener: StatusListener = ({ status: deviceStatus, type }) => {
+      const nextState = getNextConnectionState(
+        connectionStatus,
         deviceStatus,
         prevDeviceStatus.current,
-        hasAttempedReconnect
+        type,
+        hasAttempedReconnect,
+        hasRadioConnected
       );
       prevDeviceStatus.current = deviceStatus;
-      if (newStatus) {
-        handleStatus && handleStatus(newStatus);
-        setStatus(newStatus);
+      if (nextState) {
+        handleStatus && handleStatus(nextState.status, nextState.flowType);
+        setConnectionStatus(nextState.status);
       }
     };
     connectActions.addStatusListener(listener);
     return () => {
-      connectActions.removeStatusListener(listener);
+      connectActions.removeStatusListener();
     };
-  }, [connectActions, handleStatus, setStatus, status]);
+  }, [connectActions, connectionStatus, handleStatus, setConnectionStatus]);
 
-  return status;
+  return connectionStatus;
 };
 
-const getNextConnectionStatus = (
-  status: ConnectionStatus,
+const getNextConnectionState = (
+  currStatus: ConnectionStatus,
   deviceStatus: DeviceConnectionStatus,
   prevDeviceStatus: DeviceConnectionStatus | null,
-  hasAttempedReconnect: MutableRefObject<boolean>
-) => {
+  type: StatusListenerType,
+  hasAttempedReconnect: MutableRefObject<boolean>,
+  hasRadioConnected: MutableRefObject<boolean>
+): { status: ConnectionStatus; flowType: ConnectionFlowType } | undefined => {
+  console.log(type, deviceStatus);
+  // We are using usb status to infer the radio bridge device status.
+  // Ignore USB status updates when radio connection is not established.
+  if (!hasRadioConnected.current && type === "usb") {
+    return undefined;
+  }
+  const flowType =
+    type === "usb"
+      ? ConnectionFlowType.RadioBridge
+      : type === "radioRemote"
+      ? ConnectionFlowType.RadioRemote
+      : ConnectionFlowType.Bluetooth;
   if (
     // Disconnection happens for newly started / restarted
     // connection flows when clearing device
     deviceStatus === DeviceConnectionStatus.DISCONNECTED &&
-    status === ConnectionStatus.NotConnected
+    currStatus === ConnectionStatus.NotConnected
   ) {
-    return ConnectionStatus.NotConnected;
+    hasRadioConnected.current = false;
+    return { status: ConnectionStatus.NotConnected, flowType };
   }
   if (deviceStatus === DeviceConnectionStatus.CONNECTED) {
     hasAttempedReconnect.current = false;
-    return ConnectionStatus.Connected;
+    if (type === "radioRemote") {
+      hasRadioConnected.current = true;
+    }
+    return { status: ConnectionStatus.Connected, flowType };
   }
   if (
-    (status === ConnectionStatus.Connecting &&
-      deviceStatus === DeviceConnectionStatus.DISCONNECTED) ||
-    // If user does not select a device
-    (deviceStatus === DeviceConnectionStatus.NO_AUTHORIZED_DEVICE &&
-      prevDeviceStatus === DeviceConnectionStatus.NO_AUTHORIZED_DEVICE)
+    currStatus === ConnectionStatus.Connecting &&
+    deviceStatus === DeviceConnectionStatus.DISCONNECTED
   ) {
-    return ConnectionStatus.FailedToConnect;
+    return { status: ConnectionStatus.FailedToConnect, flowType };
+  }
+  if (
+    // If user does not select a device for bluetooth connection
+    type === "bluetooth" &&
+    deviceStatus === DeviceConnectionStatus.NO_AUTHORIZED_DEVICE &&
+    prevDeviceStatus === DeviceConnectionStatus.NO_AUTHORIZED_DEVICE
+  ) {
+    return { status: ConnectionStatus.FailedToConnect, flowType };
   }
   if (
     hasAttempedReconnect.current &&
     deviceStatus === DeviceConnectionStatus.DISCONNECTED &&
     prevDeviceStatus === DeviceConnectionStatus.CONNECTING
   ) {
-    return ConnectionStatus.FailedToReconnectTwice;
+    return { status: ConnectionStatus.FailedToReconnectTwice, flowType };
   }
   if (
     deviceStatus === DeviceConnectionStatus.DISCONNECTED &&
     prevDeviceStatus === DeviceConnectionStatus.CONNECTING
   ) {
     hasAttempedReconnect.current = true;
-    return ConnectionStatus.FailedToReconnect;
+    return { status: ConnectionStatus.FailedToReconnect, flowType };
   }
   if (
     deviceStatus === DeviceConnectionStatus.DISCONNECTED &&
     prevDeviceStatus === DeviceConnectionStatus.RECONNECTING
   ) {
     hasAttempedReconnect.current = true;
-    return ConnectionStatus.ConnectionLost;
+    return { status: ConnectionStatus.ConnectionLost, flowType };
   }
   if (deviceStatus === DeviceConnectionStatus.DISCONNECTED) {
-    return ConnectionStatus.Disconnected;
+    return { status: ConnectionStatus.Disconnected, flowType };
   }
   if (
     deviceStatus === DeviceConnectionStatus.RECONNECTING ||
     deviceStatus === DeviceConnectionStatus.CONNECTING
   ) {
-    return status === ConnectionStatus.NotConnected ||
-      status === ConnectionStatus.FailedToConnect
-      ? ConnectionStatus.Connecting
-      : ConnectionStatus.Reconnecting;
+    const newStatus =
+      currStatus === ConnectionStatus.NotConnected ||
+      currStatus === ConnectionStatus.FailedToConnect
+        ? ConnectionStatus.Connecting
+        : ConnectionStatus.Reconnecting;
+    return { status: newStatus, flowType };
   }
   return undefined;
 };

--- a/src/connect-status-hooks.tsx
+++ b/src/connect-status-hooks.tsx
@@ -39,6 +39,10 @@ export enum ConnectionStatus {
    */
   Disconnected = "Disconnected",
   /**
+   * Failure to select a device by the user.
+   */
+  FailedToSelectBluetoothDevice = "FailedToSelectDevice",
+  /**
    * Failure to establish initial connection triggered by the user.
    */
   FailedToConnect = "FailedToConnect",
@@ -107,6 +111,8 @@ export const useConnectStatus = (
   const prevDeviceStatus = useRef<DeviceConnectionStatus | null>(null);
   const [hasAttempedReconnect, setHasAttemptedReconnect] =
     useState<boolean>(false);
+  const [onFirstConnectAttempt, setOnFirstConnectAttempt] =
+    useState<boolean>(true);
 
   useEffect(() => {
     const listener: StatusListener = ({ status: deviceStatus, type }) => {
@@ -118,6 +124,8 @@ export const useConnectStatus = (
         type,
         hasAttempedReconnect,
         setHasAttemptedReconnect,
+        onFirstConnectAttempt,
+        setOnFirstConnectAttempt,
       });
       prevDeviceStatus.current = deviceStatus;
       if (nextState) {
@@ -135,6 +143,7 @@ export const useConnectStatus = (
     currConnType,
     handleStatus,
     hasAttempedReconnect,
+    onFirstConnectAttempt,
     setConnectionStatus,
   ]);
 

--- a/src/connect-status-hooks.tsx
+++ b/src/connect-status-hooks.tsx
@@ -2,7 +2,6 @@ import { ConnectionStatus as DeviceConnectionStatus } from "@microbit/microbit-c
 import {
   ReactNode,
   createContext,
-  useCallback,
   useContext,
   useEffect,
   useRef,
@@ -73,16 +72,8 @@ export const ConnectStatusProvider = ({
   const connectStatusContextValue = useState<ConnectionStatus>(
     ConnectionStatus.NotConnected
   );
-
-  const set = useCallback(
-    (s: ConnectionStatus) => {
-      console.log(s);
-      connectStatusContextValue[1](s);
-    },
-    [connectStatusContextValue]
-  );
   return (
-    <ConnectStatusContext.Provider value={[connectStatusContextValue[0], set]}>
+    <ConnectStatusContext.Provider value={connectStatusContextValue}>
       {children}
     </ConnectStatusContext.Provider>
   );

--- a/src/connect-status-hooks.tsx
+++ b/src/connect-status-hooks.tsx
@@ -111,7 +111,6 @@ export const useConnectStatus = (
   const prevDeviceStatus = useRef<DeviceConnectionStatus | null>(null);
   const [hasAttempedReconnect, setHasAttemptedReconnect] =
     useState<boolean>(false);
-  const [hasRadioConnected, setHasRadioConnected] = useState<boolean>(false);
 
   useEffect(() => {
     const listener: StatusListener = ({ status: deviceStatus, type }) => {
@@ -123,8 +122,6 @@ export const useConnectStatus = (
         type,
         hasAttempedReconnect,
         setHasAttemptedReconnect,
-        hasRadioConnected,
-        setHasRadioConnected,
       });
       prevDeviceStatus.current = deviceStatus;
       if (nextState) {
@@ -142,7 +139,6 @@ export const useConnectStatus = (
     currConnType,
     handleStatus,
     hasAttempedReconnect,
-    hasRadioConnected,
     setConnectionStatus,
   ]);
 

--- a/src/connect-status-hooks.tsx
+++ b/src/connect-status-hooks.tsx
@@ -88,25 +88,22 @@ export const ConnectStatusProvider = ({
   );
 };
 
-export const useSetConnectStatus = (): ((status: ConnectionStatus) => void) => {
+export const useConnectStatus = (): [
+  ConnectionStatus,
+  (status: ConnectionStatus) => void
+] => {
   const connectStatusContextValue = useContext(ConnectStatusContext);
   if (!connectStatusContextValue) {
     throw new Error("Missing provider");
   }
-  const [, setStatus] = connectStatusContextValue;
-
-  return setStatus;
+  return connectStatusContextValue;
 };
 
-export const useConnectStatus = (
+export const useConnectStatusUpdater = (
   currConnType: ConnectionType,
   handleStatus: (status: ConnectionStatus, type: ConnectionFlowType) => void
 ): ConnectionStatus => {
-  const connectStatusContextValue = useContext(ConnectStatusContext);
-  if (!connectStatusContextValue) {
-    throw new Error("Missing provider");
-  }
-  const [connectionStatus, setConnectionStatus] = connectStatusContextValue;
+  const [connectionStatus, setConnectionStatus] = useConnectStatus();
   const connectActions = useConnectActions();
   const prevDeviceStatus = useRef<DeviceConnectionStatus | null>(null);
   const [hasAttempedReconnect, setHasAttemptedReconnect] =

--- a/src/connection-stage-actions.ts
+++ b/src/connection-stage-actions.ts
@@ -198,6 +198,7 @@ export class ConnectionStageActions {
       case ConnectionStatus.FailedToReconnectTwice: {
         return this.setStage({
           ...this.stage,
+          flowType,
           hasFailedToReconnectTwice: true,
           flowStep: ConnectionFlowStep.ReconnectFailedTwice,
         });

--- a/src/connection-stage-actions.ts
+++ b/src/connection-stage-actions.ts
@@ -248,15 +248,13 @@ export class ConnectionStageActions {
   };
 
   private getStagesOrder = () => {
-    if (this.stage.flowType === ConnectionFlowType.Bluetooth) {
-      return bluetoothFlow({
-        isManualFlashing:
-          !this.stage.isWebUsbSupported ||
-          this.stage.flowStep === ConnectionFlowStep.ManualFlashingTutorial,
-        isRestartAgain: this.stage.hasFailedToReconnectTwice,
-      });
-    }
-    return radioFlow();
+    const isRestartAgain = this.stage.hasFailedToReconnectTwice;
+    const isManualFlashing =
+      !this.stage.isWebUsbSupported ||
+      this.stage.flowStep === ConnectionFlowStep.ManualFlashingTutorial;
+    return this.stage.flowType === ConnectionFlowType.Bluetooth
+      ? bluetoothFlow({ isManualFlashing, isRestartAgain })
+      : radioFlow({ isRestartAgain });
   };
 
   private setFlowStage = (flowStage: FlowStage) => {
@@ -318,9 +316,11 @@ const bluetoothFlow = ({
   },
 ];
 
-const radioFlow = () => [
+const radioFlow = ({ isRestartAgain }: { isRestartAgain: boolean }) => [
   {
-    flowStep: ConnectionFlowStep.Start,
+    flowStep: isRestartAgain
+      ? ConnectionFlowStep.ReconnectFailedTwice
+      : ConnectionFlowStep.Start,
     flowType: ConnectionFlowType.RadioRemote,
   },
   {

--- a/src/connection-stage-actions.ts
+++ b/src/connection-stage-actions.ts
@@ -147,14 +147,13 @@ export class ConnectionStageActions {
   };
 
   connectMicrobits = async () => {
-    if (this.stage.connType === "radio" && this.stage.radioRemoteDeviceId) {
-      const result = await this.actions.connectMicrobitsSerial(
-        this.stage.radioRemoteDeviceId
-      );
-      this.handleConnectResult(result);
-    } else {
-      this.setFlowStep(ConnectionFlowStep.TryAgainReplugMicrobit);
+    if (!this.stage.radioRemoteDeviceId) {
+      throw new Error("Radio bridge device id not set");
     }
+    const result = await this.actions.connectMicrobitsSerial(
+      this.stage.radioRemoteDeviceId
+    );
+    this.handleConnectResult(result);
   };
 
   private getConnectingStage = (connType: ConnectionType) => {

--- a/src/connection-stage-actions.ts
+++ b/src/connection-stage-actions.ts
@@ -215,9 +215,6 @@ export class ConnectionStageActions {
           flowType,
         });
       }
-      case ConnectionStatus.Reconnecting: {
-        return;
-      }
     }
     return;
   };

--- a/src/connection-stage-actions.ts
+++ b/src/connection-stage-actions.ts
@@ -216,7 +216,7 @@ export class ConnectionStageActions {
         });
       }
       case ConnectionStatus.Reconnecting: {
-        return this.setStage(this.getConnectingStage(this.stage.connType));
+        return;
       }
     }
     return;

--- a/src/connection-stage-actions.ts
+++ b/src/connection-stage-actions.ts
@@ -114,7 +114,9 @@ export class ConnectionStageActions {
       case ConnectAndFlashResult.ErrorBadFirmware:
         return this.setFlowStep(ConnectionFlowStep.BadFirmware);
       case ConnectAndFlashResult.ErrorNoDeviceSelected:
-        return this.setFlowStep(ConnectionFlowStep.TryAgainSelectMicrobit);
+        return this.setFlowStep(
+          ConnectionFlowStep.TryAgainWebUsbSelectMicrobit
+        );
       case ConnectAndFlashResult.ErrorUnableToClaimInterface:
         return this.setFlowStep(ConnectionFlowStep.TryAgainCloseTabs);
       default:
@@ -168,11 +170,7 @@ export class ConnectionStageActions {
   };
 
   private handleConnectFail = () => {
-    this.setFlowStep(
-      this.stage.flowType === ConnectionFlowType.Bluetooth
-        ? ConnectionFlowStep.TryAgainBluetoothConnect
-        : ConnectionFlowStep.TryAgainReplugMicrobit
-    );
+    this.setFlowStep(ConnectionFlowStep.ConnectFailed);
   };
 
   private onConnected = () => {
@@ -191,6 +189,11 @@ export class ConnectionStageActions {
     switch (status) {
       case ConnectionStatus.Connected: {
         return this.onConnected();
+      }
+      case ConnectionStatus.FailedToSelectBluetoothDevice: {
+        return this.setFlowStep(
+          ConnectionFlowStep.TryAgainBluetoothSelectMicrobit
+        );
       }
       case ConnectionStatus.FailedToConnect: {
         return this.handleConnectFail();
@@ -269,7 +272,7 @@ export class ConnectionStageActions {
 
   onTryAgain = () => {
     this.setFlowStep(
-      this.stage.flowStep === ConnectionFlowStep.TryAgainBluetoothConnect
+      this.stage.flowStep === ConnectionFlowStep.TryAgainBluetoothSelectMicrobit
         ? ConnectionFlowStep.EnterBluetoothPattern
         : ConnectionFlowStep.ConnectCable
     );

--- a/src/connection-stage-hooks.tsx
+++ b/src/connection-stage-hooks.tsx
@@ -45,8 +45,9 @@ export enum ConnectionFlowStep {
   // Failure stages
   TryAgainReplugMicrobit = "TryAgainReplugMicrobit",
   TryAgainCloseTabs = "TryAgainCloseTabs",
-  TryAgainSelectMicrobit = "TryAgainSelectMicrobit",
-  TryAgainBluetoothConnect = "TryAgainBluetoothConnect",
+  TryAgainWebUsbSelectMicrobit = "TryAgainWebUsbSelectMicrobit",
+  TryAgainBluetoothSelectMicrobit = "TryAgainBluetoothSelectMicrobit",
+  ConnectFailed = "ConnectFailed",
   BadFirmware = "BadFirmware",
   MicrobitUnsupported = "MicrobitUnsupported",
   WebUsbBluetoothUnsupported = "WebUsbBluetoothUnsupported",

--- a/src/connection-stage-hooks.tsx
+++ b/src/connection-stage-hooks.tsx
@@ -86,12 +86,18 @@ interface ConnectionStageProviderProps {
   children: ReactNode;
 }
 
+interface StoredConnectionConfig {
+  bluetoothMicrobitName?: string;
+  radioRemoteDeviceId?: number;
+}
+
 const getInitialConnectionStageValue = (
-  microbitName: string | undefined
+  config: StoredConnectionConfig
 ): ConnectionStage => ({
   flowStep: ConnectionFlowStep.None,
   flowType: ConnectionFlowType.Bluetooth,
-  bluetoothMicrobitName: microbitName,
+  bluetoothMicrobitName: config.bluetoothMicrobitName,
+  radioRemoteDeviceId: config.radioRemoteDeviceId,
   connType: "bluetooth",
   isWebBluetoothSupported: true,
   isWebUsbSupported: true,
@@ -101,18 +107,23 @@ const getInitialConnectionStageValue = (
 export const ConnectionStageProvider = ({
   children,
 }: ConnectionStageProviderProps) => {
-  const [val, setMicrobitName] = useStorage<{
-    value?: string;
-  }>("local", "microbitName", { value: undefined });
+  const [config, setConfig] = useStorage<StoredConnectionConfig>(
+    "local",
+    "connectionConfig",
+    { bluetoothMicrobitName: undefined, radioRemoteDeviceId: undefined }
+  );
   const [connectionStage, setConnStage] = useState<ConnectionStage>(
-    getInitialConnectionStageValue(val.value)
+    getInitialConnectionStageValue(config)
   );
   const setConnectionStage = useCallback(
     (connStage: ConnectionStage) => {
-      setMicrobitName({ value: connStage.bluetoothMicrobitName });
+      setConfig({
+        bluetoothMicrobitName: connStage.bluetoothMicrobitName,
+        radioRemoteDeviceId: connStage.radioRemoteDeviceId,
+      });
       setConnStage(connStage);
     },
-    [setMicrobitName]
+    [setConfig]
   );
 
   return (

--- a/src/connection-stage-hooks.tsx
+++ b/src/connection-stage-hooks.tsx
@@ -14,7 +14,7 @@ import { useStorage } from "./hooks/use-storage";
 import {
   ConnectionStatus,
   useConnectStatus,
-  useSetConnectStatus,
+  useConnectStatusUpdater,
 } from "./connect-status-hooks";
 
 export enum ConnectionFlowType {
@@ -150,7 +150,7 @@ export const useConnectionStage = (): {
   const [stage, setStage] = connectionStageContextValue;
   const navigate = useNavigate();
   const connectActions = useConnectActions();
-  const setStatus = useSetConnectStatus();
+  const [, setStatus] = useConnectStatus();
 
   const actions = useMemo(() => {
     return new ConnectionStageActions(
@@ -162,7 +162,7 @@ export const useConnectionStage = (): {
     );
   }, [connectActions, navigate, stage, setStage, setStatus]);
 
-  const status = useConnectStatus(
+  const status = useConnectStatusUpdater(
     stage.connType,
     actions.handleConnectionStatus
   );

--- a/src/connection-stage-hooks.tsx
+++ b/src/connection-stage-hooks.tsx
@@ -136,6 +136,7 @@ export const ConnectionStageProvider = ({
 };
 
 export const useConnectionStage = (): {
+  status: ConnectionStatus;
   stage: ConnectionStage;
   actions: ConnectionStageActions;
   isConnected: boolean;
@@ -167,6 +168,7 @@ export const useConnectionStage = (): {
   const isConnected = status === ConnectionStatus.Connected;
 
   return {
+    status,
     stage,
     actions,
     isConnected,

--- a/src/connection-stage-hooks.tsx
+++ b/src/connection-stage-hooks.tsx
@@ -160,7 +160,10 @@ export const useConnectionStage = (): {
     );
   }, [connectActions, navigate, stage, setStage, setStatus]);
 
-  const status = useConnectStatus(actions.handleConnectionStatus);
+  const status = useConnectStatus(
+    stage.connType,
+    actions.handleConnectionStatus
+  );
   const isConnected = status === ConnectionStatus.Connected;
 
   return {

--- a/src/get-next-connection-state.test.ts
+++ b/src/get-next-connection-state.test.ts
@@ -110,6 +110,23 @@ describe("getNextConnectionState for radio connection", () => {
       },
     });
   });
+  test("radio disconnect", () => {
+    testGetNextConnectionState({
+      input: {
+        currConnType: "radio",
+        currStatus: ConnectionStatus.Disconnected,
+        deviceStatus: DeviceConnectionStatus.DISCONNECTED,
+        prevDeviceStatus: DeviceConnectionStatus.CONNECTED,
+        type: "radioRemote",
+      },
+      initialHasAttemptedReconnect: false,
+      expectedHasAttemptedReconnect: false,
+      expectedNextConnectionState: {
+        status: ConnectionStatus.Disconnected,
+        flowType: ConnectionFlowType.RadioRemote,
+      },
+    });
+  });
   test("radio connect fail", () => {
     testGetNextConnectionState({
       input: {
@@ -296,6 +313,23 @@ describe("getNextConnectionState for bluetooth connection", () => {
       expectedHasAttemptedReconnect: false,
       expectedNextConnectionState: {
         status: ConnectionStatus.Connected,
+        flowType: ConnectionFlowType.Bluetooth,
+      },
+    });
+  });
+  test("bluetooth disconnect", () => {
+    testGetNextConnectionState({
+      input: {
+        currConnType: "bluetooth",
+        currStatus: ConnectionStatus.Disconnected,
+        deviceStatus: DeviceConnectionStatus.DISCONNECTED,
+        prevDeviceStatus: DeviceConnectionStatus.CONNECTED,
+        type: "bluetooth",
+      },
+      initialHasAttemptedReconnect: false,
+      expectedHasAttemptedReconnect: false,
+      expectedNextConnectionState: {
+        status: ConnectionStatus.Disconnected,
         flowType: ConnectionFlowType.Bluetooth,
       },
     });

--- a/src/get-next-connection-state.test.ts
+++ b/src/get-next-connection-state.test.ts
@@ -9,440 +9,380 @@
 
 import { ConnectionStatus } from "./connect-status-hooks";
 import {
-  ConnectionState,
+  GetNextConnectionStateInput,
+  NextConnectionState,
   getNextConnectionState,
 } from "./get-next-connection-state";
 import { ConnectionStatus as DeviceConnectionStatus } from "@microbit/microbit-connection";
 import { ConnectionFlowType } from "./connection-stage-hooks";
 
 type Input = Pick<
-  ConnectionState,
+  GetNextConnectionStateInput,
   "currConnType" | "currStatus" | "deviceStatus" | "prevDeviceStatus" | "type"
 >;
+
 const testGetNextConnectionState = ({
   input,
   initialHasAttemptedReconnect,
-  initialHasRadioConnected,
+  expectedNextConnectionState,
+  expectedHasAttemptedReconnect,
 }: {
   input: Input;
   initialHasAttemptedReconnect: boolean;
-  initialHasRadioConnected: boolean;
+  expectedNextConnectionState: NextConnectionState;
+  expectedHasAttemptedReconnect: boolean;
 }) => {
   let hasAttempedReconnect = initialHasAttemptedReconnect;
-  let hasRadioConnected = initialHasRadioConnected;
   const result = getNextConnectionState({
     ...input,
     hasAttempedReconnect,
     setHasAttemptedReconnect: (val: boolean) => {
       hasAttempedReconnect = val;
     },
-    hasRadioConnected,
-    setHasRadioConnected: (val: boolean) => {
-      hasRadioConnected = val;
-    },
   });
-  return {
-    result,
-    hasAttempedReconnect,
-    hasRadioConnected,
-  };
+  expect(result).toEqual(expectedNextConnectionState);
+  expect(hasAttempedReconnect).toEqual(expectedHasAttemptedReconnect);
 };
 
 describe("getNextConnectionState for radio connection", () => {
   test("radio usb flashing", () => {
-    const { result, hasAttempedReconnect, hasRadioConnected } =
-      testGetNextConnectionState({
-        input: {
-          currConnType: "radio",
-          currStatus: ConnectionStatus.NotConnected,
-          deviceStatus: DeviceConnectionStatus.CONNECTING,
-          prevDeviceStatus: DeviceConnectionStatus.NO_AUTHORIZED_DEVICE,
-          type: "usb",
-        },
-        initialHasAttemptedReconnect: false,
-        initialHasRadioConnected: false,
-      });
-    expect(result).toEqual(undefined);
-    expect(hasAttempedReconnect).toEqual(false);
-    expect(hasRadioConnected).toEqual(false);
+    testGetNextConnectionState({
+      input: {
+        currConnType: "radio",
+        currStatus: ConnectionStatus.NotConnected,
+        deviceStatus: DeviceConnectionStatus.CONNECTING,
+        prevDeviceStatus: DeviceConnectionStatus.NO_AUTHORIZED_DEVICE,
+        type: "usb",
+      },
+      initialHasAttemptedReconnect: false,
+      expectedHasAttemptedReconnect: false,
+      expectedNextConnectionState: undefined,
+    });
   });
   test("radio connecting", () => {
-    const { result, hasAttempedReconnect, hasRadioConnected } =
-      testGetNextConnectionState({
-        input: {
-          currConnType: "radio",
-          currStatus: ConnectionStatus.NotConnected,
-          deviceStatus: DeviceConnectionStatus.CONNECTING,
-          prevDeviceStatus: DeviceConnectionStatus.NO_AUTHORIZED_DEVICE,
-          type: "radioRemote",
-        },
-        initialHasAttemptedReconnect: false,
-        initialHasRadioConnected: false,
-      });
-    expect(result).toEqual({
-      status: ConnectionStatus.Connecting,
-      flowType: ConnectionFlowType.RadioRemote,
+    testGetNextConnectionState({
+      input: {
+        currConnType: "radio",
+        currStatus: ConnectionStatus.NotConnected,
+        deviceStatus: DeviceConnectionStatus.CONNECTING,
+        prevDeviceStatus: DeviceConnectionStatus.NO_AUTHORIZED_DEVICE,
+        type: "radioRemote",
+      },
+      initialHasAttemptedReconnect: false,
+      expectedHasAttemptedReconnect: false,
+      expectedNextConnectionState: {
+        status: ConnectionStatus.Connecting,
+        flowType: ConnectionFlowType.RadioRemote,
+      },
     });
-    expect(hasAttempedReconnect).toEqual(false);
-    expect(hasRadioConnected).toEqual(false);
   });
   test("radio connected for the first time", () => {
-    const { result, hasAttempedReconnect, hasRadioConnected } =
-      testGetNextConnectionState({
-        input: {
-          currConnType: "radio",
-          currStatus: ConnectionStatus.NotConnected,
-          deviceStatus: DeviceConnectionStatus.CONNECTED,
-          prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
-          type: "radioRemote",
-        },
-        initialHasAttemptedReconnect: false,
-        initialHasRadioConnected: false,
-      });
-    expect(result).toEqual({
-      status: ConnectionStatus.Connected,
-      flowType: ConnectionFlowType.RadioRemote,
+    testGetNextConnectionState({
+      input: {
+        currConnType: "radio",
+        currStatus: ConnectionStatus.NotConnected,
+        deviceStatus: DeviceConnectionStatus.CONNECTED,
+        prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
+        type: "radioRemote",
+      },
+      initialHasAttemptedReconnect: false,
+      expectedHasAttemptedReconnect: false,
+      expectedNextConnectionState: {
+        status: ConnectionStatus.Connected,
+        flowType: ConnectionFlowType.RadioRemote,
+      },
     });
-    expect(hasAttempedReconnect).toEqual(false);
-    expect(hasRadioConnected).toEqual(true);
   });
   test("radio connected subsequent times", () => {
-    const { result, hasAttempedReconnect, hasRadioConnected } =
-      testGetNextConnectionState({
-        input: {
-          currConnType: "radio",
-          currStatus: ConnectionStatus.Disconnected,
-          deviceStatus: DeviceConnectionStatus.CONNECTED,
-          prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
-          type: "radioRemote",
-        },
-        initialHasAttemptedReconnect: false,
-        initialHasRadioConnected: false,
-      });
-    expect(result).toEqual({
-      status: ConnectionStatus.Connected,
-      flowType: ConnectionFlowType.RadioRemote,
+    testGetNextConnectionState({
+      input: {
+        currConnType: "radio",
+        currStatus: ConnectionStatus.Disconnected,
+        deviceStatus: DeviceConnectionStatus.CONNECTED,
+        prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
+        type: "radioRemote",
+      },
+      initialHasAttemptedReconnect: true,
+      expectedHasAttemptedReconnect: false,
+      expectedNextConnectionState: {
+        status: ConnectionStatus.Connected,
+        flowType: ConnectionFlowType.RadioRemote,
+      },
     });
-    expect(hasAttempedReconnect).toEqual(false);
-    expect(hasRadioConnected).toEqual(true);
   });
   test("radio connect fail", () => {
-    const { result, hasAttempedReconnect, hasRadioConnected } =
-      testGetNextConnectionState({
-        input: {
-          currConnType: "radio",
-          currStatus: ConnectionStatus.Connecting,
-          deviceStatus: DeviceConnectionStatus.DISCONNECTED,
-          prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
-          type: "radioRemote",
-        },
-        initialHasAttemptedReconnect: false,
-        initialHasRadioConnected: false,
-      });
-    expect(result).toEqual({
-      status: ConnectionStatus.FailedToConnect,
-      flowType: ConnectionFlowType.RadioRemote,
+    testGetNextConnectionState({
+      input: {
+        currConnType: "radio",
+        currStatus: ConnectionStatus.Connecting,
+        deviceStatus: DeviceConnectionStatus.DISCONNECTED,
+        prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
+        type: "radioRemote",
+      },
+      initialHasAttemptedReconnect: false,
+      expectedHasAttemptedReconnect: false,
+      expectedNextConnectionState: {
+        status: ConnectionStatus.FailedToConnect,
+        flowType: ConnectionFlowType.RadioRemote,
+      },
     });
-    expect(hasAttempedReconnect).toEqual(false);
-    expect(hasRadioConnected).toEqual(false);
   });
   test("radio reconnecting", () => {
-    const { result, hasAttempedReconnect, hasRadioConnected } =
-      testGetNextConnectionState({
-        input: {
-          currConnType: "radio",
-          currStatus: ConnectionStatus.Disconnected,
-          deviceStatus: DeviceConnectionStatus.CONNECTING,
-          prevDeviceStatus: DeviceConnectionStatus.DISCONNECTED,
-          type: "radioRemote",
-        },
-        initialHasAttemptedReconnect: false,
-        initialHasRadioConnected: false,
-      });
-    expect(result).toEqual({
-      status: ConnectionStatus.Reconnecting,
-      flowType: ConnectionFlowType.RadioRemote,
+    testGetNextConnectionState({
+      input: {
+        currConnType: "radio",
+        currStatus: ConnectionStatus.Disconnected,
+        deviceStatus: DeviceConnectionStatus.CONNECTING,
+        prevDeviceStatus: DeviceConnectionStatus.DISCONNECTED,
+        type: "radioRemote",
+      },
+      initialHasAttemptedReconnect: false,
+      expectedHasAttemptedReconnect: false,
+      expectedNextConnectionState: {
+        status: ConnectionStatus.Reconnecting,
+        flowType: ConnectionFlowType.RadioRemote,
+      },
     });
-    expect(hasAttempedReconnect).toEqual(false);
-    expect(hasRadioConnected).toEqual(false);
   });
   test("radio bridge device connection lost by unplugging device", () => {
-    const { result, hasAttempedReconnect, hasRadioConnected } =
-      testGetNextConnectionState({
-        input: {
-          currConnType: "radio",
-          currStatus: ConnectionStatus.Connected,
-          deviceStatus: DeviceConnectionStatus.DISCONNECTED,
-          prevDeviceStatus: DeviceConnectionStatus.CONNECTED,
-          type: "usb",
-        },
-        initialHasAttemptedReconnect: false,
-        initialHasRadioConnected: false,
-      });
-    expect(result).toEqual({
-      status: ConnectionStatus.ConnectionLost,
-      flowType: ConnectionFlowType.RadioBridge,
+    testGetNextConnectionState({
+      input: {
+        currConnType: "radio",
+        currStatus: ConnectionStatus.Connected,
+        deviceStatus: DeviceConnectionStatus.DISCONNECTED,
+        prevDeviceStatus: DeviceConnectionStatus.NO_AUTHORIZED_DEVICE,
+        type: "usb",
+      },
+      initialHasAttemptedReconnect: false,
+      expectedHasAttemptedReconnect: true,
+      expectedNextConnectionState: {
+        status: ConnectionStatus.ConnectionLost,
+        flowType: ConnectionFlowType.RadioBridge,
+      },
     });
-    expect(hasAttempedReconnect).toEqual(true);
-    expect(hasRadioConnected).toEqual(false);
   });
   test("radio bridge device reconnect fail", () => {
-    const { result, hasAttempedReconnect, hasRadioConnected } =
-      testGetNextConnectionState({
-        input: {
-          currConnType: "radio",
-          currStatus: ConnectionStatus.Reconnecting,
-          deviceStatus: DeviceConnectionStatus.DISCONNECTED,
-          prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
-          type: "usb",
-        },
-        initialHasAttemptedReconnect: false,
-        initialHasRadioConnected: false,
-      });
-    expect(result).toEqual({
-      status: ConnectionStatus.FailedToReconnect,
-      flowType: ConnectionFlowType.RadioBridge,
+    testGetNextConnectionState({
+      input: {
+        currConnType: "radio",
+        currStatus: ConnectionStatus.Disconnected,
+        deviceStatus: DeviceConnectionStatus.DISCONNECTED,
+        prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
+        type: "usb",
+      },
+      initialHasAttemptedReconnect: false,
+      expectedHasAttemptedReconnect: true,
+      expectedNextConnectionState: {
+        status: ConnectionStatus.FailedToReconnect,
+        flowType: ConnectionFlowType.RadioBridge,
+      },
     });
-    expect(hasAttempedReconnect).toEqual(true);
-    expect(hasRadioConnected).toEqual(false);
   });
   test("radio bridge device reconnect fail twice from connection loss", () => {
-    const { result, hasAttempedReconnect, hasRadioConnected } =
-      testGetNextConnectionState({
-        input: {
-          currConnType: "radio",
-          currStatus: ConnectionStatus.Connected,
-          deviceStatus: DeviceConnectionStatus.DISCONNECTED,
-          prevDeviceStatus: DeviceConnectionStatus.DISCONNECTED,
-          type: "usb",
-        },
-        initialHasAttemptedReconnect: true,
-        initialHasRadioConnected: false,
-      });
-    expect(result).toEqual({
-      status: ConnectionStatus.FailedToReconnectTwice,
-      flowType: ConnectionFlowType.RadioBridge,
+    testGetNextConnectionState({
+      input: {
+        currConnType: "radio",
+        currStatus: ConnectionStatus.Connected,
+        deviceStatus: DeviceConnectionStatus.DISCONNECTED,
+        prevDeviceStatus: DeviceConnectionStatus.DISCONNECTED,
+        type: "usb",
+      },
+      initialHasAttemptedReconnect: true,
+      expectedHasAttemptedReconnect: true,
+      expectedNextConnectionState: {
+        status: ConnectionStatus.FailedToReconnectTwice,
+        flowType: ConnectionFlowType.RadioRemote,
+      },
     });
-    expect(hasAttempedReconnect).toEqual(true);
-    expect(hasRadioConnected).toEqual(false);
   });
   test("radio remote connection lost by unplugging device", () => {
-    const { result, hasAttempedReconnect, hasRadioConnected } =
-      testGetNextConnectionState({
-        input: {
-          currConnType: "radio",
-          currStatus: ConnectionStatus.Reconnecting,
-          deviceStatus: DeviceConnectionStatus.DISCONNECTED,
-          prevDeviceStatus: DeviceConnectionStatus.RECONNECTING,
-          type: "radioRemote",
-        },
-        initialHasAttemptedReconnect: false,
-        initialHasRadioConnected: false,
-      });
-    expect(result).toEqual({
-      status: ConnectionStatus.ConnectionLost,
-      flowType: ConnectionFlowType.RadioRemote,
+    testGetNextConnectionState({
+      input: {
+        currConnType: "radio",
+        currStatus: ConnectionStatus.Reconnecting,
+        deviceStatus: DeviceConnectionStatus.DISCONNECTED,
+        prevDeviceStatus: DeviceConnectionStatus.RECONNECTING,
+        type: "radioRemote",
+      },
+      initialHasAttemptedReconnect: false,
+      expectedHasAttemptedReconnect: true,
+      expectedNextConnectionState: {
+        status: ConnectionStatus.ConnectionLost,
+        flowType: ConnectionFlowType.RadioRemote,
+      },
     });
-    expect(hasAttempedReconnect).toEqual(true);
-    expect(hasRadioConnected).toEqual(false);
   });
   test("radio remote reconnect fail", () => {
-    const { result, hasAttempedReconnect, hasRadioConnected } =
-      testGetNextConnectionState({
-        input: {
-          currConnType: "radio",
-          currStatus: ConnectionStatus.Reconnecting,
-          deviceStatus: DeviceConnectionStatus.DISCONNECTED,
-          prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
-          type: "radioRemote",
-        },
-        initialHasAttemptedReconnect: false,
-        initialHasRadioConnected: false,
-      });
-    expect(result).toEqual({
-      status: ConnectionStatus.FailedToReconnect,
-      flowType: ConnectionFlowType.RadioRemote,
+    testGetNextConnectionState({
+      input: {
+        currConnType: "radio",
+        currStatus: ConnectionStatus.Reconnecting,
+        deviceStatus: DeviceConnectionStatus.DISCONNECTED,
+        prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
+        type: "radioRemote",
+      },
+      initialHasAttemptedReconnect: false,
+      expectedHasAttemptedReconnect: true,
+      expectedNextConnectionState: {
+        status: ConnectionStatus.FailedToReconnect,
+        flowType: ConnectionFlowType.RadioRemote,
+      },
     });
-    expect(hasAttempedReconnect).toEqual(true);
-    expect(hasRadioConnected).toEqual(false);
   });
   test("radio remote reconnect fail twice", () => {
-    const { result, hasAttempedReconnect, hasRadioConnected } =
-      testGetNextConnectionState({
-        input: {
-          currConnType: "radio",
-          currStatus: ConnectionStatus.Reconnecting,
-          deviceStatus: DeviceConnectionStatus.DISCONNECTED,
-          prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
-          type: "radioRemote",
-        },
-        initialHasAttemptedReconnect: true,
-        initialHasRadioConnected: false,
-      });
-    expect(result).toEqual({
-      status: ConnectionStatus.FailedToReconnectTwice,
-      flowType: ConnectionFlowType.RadioRemote,
+    testGetNextConnectionState({
+      input: {
+        currConnType: "radio",
+        currStatus: ConnectionStatus.Reconnecting,
+        deviceStatus: DeviceConnectionStatus.DISCONNECTED,
+        prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
+        type: "radioRemote",
+      },
+      initialHasAttemptedReconnect: true,
+      expectedHasAttemptedReconnect: true,
+      expectedNextConnectionState: {
+        status: ConnectionStatus.FailedToReconnectTwice,
+        flowType: ConnectionFlowType.RadioRemote,
+      },
     });
-    expect(hasAttempedReconnect).toEqual(true);
-    expect(hasRadioConnected).toEqual(false);
   });
 });
 
-const bluetoothReconnectFailInput: Input = {
-  currConnType: "bluetooth",
-  currStatus: ConnectionStatus.Reconnecting,
-  deviceStatus: DeviceConnectionStatus.DISCONNECTED,
-  prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
-  type: "bluetooth",
-};
-
 describe("getNextConnectionState for bluetooth connection", () => {
   test("bluetooth connecting", () => {
-    const { result, hasAttempedReconnect, hasRadioConnected } =
-      testGetNextConnectionState({
-        input: {
-          currConnType: "bluetooth",
-          currStatus: ConnectionStatus.NotConnected,
-          deviceStatus: DeviceConnectionStatus.CONNECTING,
-          prevDeviceStatus: DeviceConnectionStatus.NO_AUTHORIZED_DEVICE,
-          type: "bluetooth",
-        },
-        initialHasAttemptedReconnect: false,
-        initialHasRadioConnected: false,
-      });
-    expect(result).toEqual({
-      status: ConnectionStatus.Connecting,
-      flowType: ConnectionFlowType.Bluetooth,
+    testGetNextConnectionState({
+      input: {
+        currConnType: "bluetooth",
+        currStatus: ConnectionStatus.NotConnected,
+        deviceStatus: DeviceConnectionStatus.CONNECTING,
+        prevDeviceStatus: DeviceConnectionStatus.NO_AUTHORIZED_DEVICE,
+        type: "bluetooth",
+      },
+      initialHasAttemptedReconnect: false,
+      expectedHasAttemptedReconnect: false,
+      expectedNextConnectionState: {
+        status: ConnectionStatus.Connecting,
+        flowType: ConnectionFlowType.Bluetooth,
+      },
     });
-    expect(hasAttempedReconnect).toEqual(false);
-    expect(hasRadioConnected).toEqual(false);
   });
   test("bluetooth connected for the first time", () => {
-    const { result, hasAttempedReconnect, hasRadioConnected } =
-      testGetNextConnectionState({
-        input: {
-          currConnType: "bluetooth",
-          currStatus: ConnectionStatus.NotConnected,
-          deviceStatus: DeviceConnectionStatus.CONNECTED,
-          prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
-          type: "bluetooth",
-        },
-        initialHasAttemptedReconnect: false,
-        initialHasRadioConnected: false,
-      });
-    expect(result).toEqual({
-      status: ConnectionStatus.Connected,
-      flowType: ConnectionFlowType.Bluetooth,
+    testGetNextConnectionState({
+      input: {
+        currConnType: "bluetooth",
+        currStatus: ConnectionStatus.NotConnected,
+        deviceStatus: DeviceConnectionStatus.CONNECTED,
+        prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
+        type: "bluetooth",
+      },
+      initialHasAttemptedReconnect: false,
+      expectedHasAttemptedReconnect: false,
+      expectedNextConnectionState: {
+        status: ConnectionStatus.Connected,
+        flowType: ConnectionFlowType.Bluetooth,
+      },
     });
-    expect(hasAttempedReconnect).toEqual(false);
-    expect(hasRadioConnected).toEqual(false);
   });
   test("bluetooth connected subsequent times", () => {
-    const { result, hasAttempedReconnect, hasRadioConnected } =
-      testGetNextConnectionState({
-        input: {
-          currConnType: "bluetooth",
-          currStatus: ConnectionStatus.Disconnected,
-          deviceStatus: DeviceConnectionStatus.CONNECTED,
-          prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
-          type: "bluetooth",
-        },
-        initialHasAttemptedReconnect: false,
-        initialHasRadioConnected: false,
-      });
-    expect(result).toEqual({
-      status: ConnectionStatus.Connected,
-      flowType: ConnectionFlowType.Bluetooth,
+    testGetNextConnectionState({
+      input: {
+        currConnType: "bluetooth",
+        currStatus: ConnectionStatus.Disconnected,
+        deviceStatus: DeviceConnectionStatus.CONNECTED,
+        prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
+        type: "bluetooth",
+      },
+      initialHasAttemptedReconnect: false,
+      expectedHasAttemptedReconnect: false,
+      expectedNextConnectionState: {
+        status: ConnectionStatus.Connected,
+        flowType: ConnectionFlowType.Bluetooth,
+      },
     });
-    expect(hasAttempedReconnect).toEqual(false);
-    expect(hasRadioConnected).toEqual(false);
   });
   test("bluetooth connect fail", () => {
-    const { result, hasAttempedReconnect, hasRadioConnected } =
-      testGetNextConnectionState({
-        input: {
-          currConnType: "bluetooth",
-          currStatus: ConnectionStatus.Connecting,
-          deviceStatus: DeviceConnectionStatus.DISCONNECTED,
-          prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
-          type: "bluetooth",
-        },
-        initialHasAttemptedReconnect: false,
-        initialHasRadioConnected: false,
-      });
-    expect(result).toEqual({
-      status: ConnectionStatus.FailedToConnect,
-      flowType: ConnectionFlowType.Bluetooth,
+    testGetNextConnectionState({
+      input: {
+        currConnType: "bluetooth",
+        currStatus: ConnectionStatus.Connecting,
+        deviceStatus: DeviceConnectionStatus.DISCONNECTED,
+        prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
+        type: "bluetooth",
+      },
+      initialHasAttemptedReconnect: false,
+      expectedHasAttemptedReconnect: false,
+      expectedNextConnectionState: {
+        status: ConnectionStatus.FailedToConnect,
+        flowType: ConnectionFlowType.Bluetooth,
+      },
     });
-    expect(hasAttempedReconnect).toEqual(false);
-    expect(hasRadioConnected).toEqual(false);
   });
   test("bluetooth reconnecting", () => {
-    const { result, hasAttempedReconnect, hasRadioConnected } =
-      testGetNextConnectionState({
-        input: {
-          currConnType: "bluetooth",
-          currStatus: ConnectionStatus.Disconnected,
-          deviceStatus: DeviceConnectionStatus.CONNECTING,
-          prevDeviceStatus: DeviceConnectionStatus.DISCONNECTED,
-          type: "bluetooth",
-        },
-        initialHasAttemptedReconnect: false,
-        initialHasRadioConnected: false,
-      });
-    expect(result).toEqual({
-      status: ConnectionStatus.Reconnecting,
-      flowType: ConnectionFlowType.Bluetooth,
+    testGetNextConnectionState({
+      input: {
+        currConnType: "bluetooth",
+        currStatus: ConnectionStatus.Disconnected,
+        deviceStatus: DeviceConnectionStatus.CONNECTING,
+        prevDeviceStatus: DeviceConnectionStatus.DISCONNECTED,
+        type: "bluetooth",
+      },
+      initialHasAttemptedReconnect: false,
+      expectedHasAttemptedReconnect: false,
+      expectedNextConnectionState: {
+        status: ConnectionStatus.Reconnecting,
+        flowType: ConnectionFlowType.Bluetooth,
+      },
     });
-    expect(hasAttempedReconnect).toEqual(false);
-    expect(hasRadioConnected).toEqual(false);
   });
   test("bluetooth connection lost by unplugging device", () => {
-    const { result, hasAttempedReconnect, hasRadioConnected } =
-      testGetNextConnectionState({
-        input: {
-          currConnType: "bluetooth",
-          currStatus: ConnectionStatus.Connected,
-          deviceStatus: DeviceConnectionStatus.DISCONNECTED,
-          prevDeviceStatus: DeviceConnectionStatus.RECONNECTING,
-          type: "bluetooth",
-        },
-        initialHasAttemptedReconnect: false,
-        initialHasRadioConnected: false,
-      });
-    expect(result).toEqual({
-      status: ConnectionStatus.ConnectionLost,
-      flowType: ConnectionFlowType.Bluetooth,
+    testGetNextConnectionState({
+      input: {
+        currConnType: "bluetooth",
+        currStatus: ConnectionStatus.Connected,
+        deviceStatus: DeviceConnectionStatus.DISCONNECTED,
+        prevDeviceStatus: DeviceConnectionStatus.RECONNECTING,
+        type: "bluetooth",
+      },
+      initialHasAttemptedReconnect: false,
+      expectedHasAttemptedReconnect: true,
+      expectedNextConnectionState: {
+        status: ConnectionStatus.ConnectionLost,
+        flowType: ConnectionFlowType.Bluetooth,
+      },
     });
-    expect(hasAttempedReconnect).toEqual(true);
-    expect(hasRadioConnected).toEqual(false);
   });
   test("bluetooth reconnect fail", () => {
-    const { result, hasAttempedReconnect, hasRadioConnected } =
-      testGetNextConnectionState({
-        input: bluetoothReconnectFailInput,
-        initialHasAttemptedReconnect: false,
-        initialHasRadioConnected: false,
-      });
-    expect(result).toEqual({
-      status: ConnectionStatus.FailedToReconnect,
-      flowType: ConnectionFlowType.Bluetooth,
+    testGetNextConnectionState({
+      input: {
+        currConnType: "bluetooth",
+        currStatus: ConnectionStatus.Reconnecting,
+        deviceStatus: DeviceConnectionStatus.DISCONNECTED,
+        prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
+        type: "bluetooth",
+      },
+      initialHasAttemptedReconnect: false,
+      expectedHasAttemptedReconnect: true,
+      expectedNextConnectionState: {
+        status: ConnectionStatus.FailedToReconnect,
+        flowType: ConnectionFlowType.Bluetooth,
+      },
     });
-    expect(hasAttempedReconnect).toEqual(true);
-    expect(hasRadioConnected).toEqual(false);
   });
   test("bluetooth reconnect fail twice", () => {
-    const { result, hasAttempedReconnect, hasRadioConnected } =
-      testGetNextConnectionState({
-        input: bluetoothReconnectFailInput,
-        initialHasAttemptedReconnect: true,
-        initialHasRadioConnected: false,
-      });
-    expect(result).toEqual({
-      status: ConnectionStatus.FailedToReconnectTwice,
-      flowType: ConnectionFlowType.Bluetooth,
+    testGetNextConnectionState({
+      input: {
+        currConnType: "bluetooth",
+        currStatus: ConnectionStatus.Reconnecting,
+        deviceStatus: DeviceConnectionStatus.DISCONNECTED,
+        prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
+        type: "bluetooth",
+      },
+      initialHasAttemptedReconnect: true,
+      expectedHasAttemptedReconnect: true,
+      expectedNextConnectionState: {
+        status: ConnectionStatus.FailedToReconnectTwice,
+        flowType: ConnectionFlowType.Bluetooth,
+      },
     });
-    expect(hasAttempedReconnect).toEqual(true);
-    expect(hasRadioConnected).toEqual(false);
   });
 });

--- a/src/get-next-connection-state.test.ts
+++ b/src/get-next-connection-state.test.ts
@@ -144,7 +144,7 @@ describe("getNextConnectionState for radio connection", () => {
       },
     });
   });
-  test("radio reconnecting", () => {
+  test("radio reconnecting explicitly", () => {
     testGetNextConnectionState({
       input: {
         currConnType: "radio",
@@ -156,7 +156,24 @@ describe("getNextConnectionState for radio connection", () => {
       initialHasAttemptedReconnect: false,
       expectedHasAttemptedReconnect: false,
       expectedNextConnectionState: {
-        status: ConnectionStatus.Reconnecting,
+        status: ConnectionStatus.ReconnectingExplicitly,
+        flowType: ConnectionFlowType.RadioRemote,
+      },
+    });
+  });
+  test("radio reconnecting automatically", () => {
+    testGetNextConnectionState({
+      input: {
+        currConnType: "radio",
+        currStatus: ConnectionStatus.Connected,
+        deviceStatus: DeviceConnectionStatus.RECONNECTING,
+        prevDeviceStatus: DeviceConnectionStatus.CONNECTED,
+        type: "radioRemote",
+      },
+      initialHasAttemptedReconnect: false,
+      expectedHasAttemptedReconnect: false,
+      expectedNextConnectionState: {
+        status: ConnectionStatus.ReconnectingAutomatically,
         flowType: ConnectionFlowType.RadioRemote,
       },
     });
@@ -216,7 +233,7 @@ describe("getNextConnectionState for radio connection", () => {
     testGetNextConnectionState({
       input: {
         currConnType: "radio",
-        currStatus: ConnectionStatus.Reconnecting,
+        currStatus: ConnectionStatus.ReconnectingExplicitly,
         deviceStatus: DeviceConnectionStatus.DISCONNECTED,
         prevDeviceStatus: DeviceConnectionStatus.RECONNECTING,
         type: "radioRemote",
@@ -233,7 +250,7 @@ describe("getNextConnectionState for radio connection", () => {
     testGetNextConnectionState({
       input: {
         currConnType: "radio",
-        currStatus: ConnectionStatus.Reconnecting,
+        currStatus: ConnectionStatus.ReconnectingExplicitly,
         deviceStatus: DeviceConnectionStatus.DISCONNECTED,
         prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
         type: "radioRemote",
@@ -250,7 +267,7 @@ describe("getNextConnectionState for radio connection", () => {
     testGetNextConnectionState({
       input: {
         currConnType: "radio",
-        currStatus: ConnectionStatus.Reconnecting,
+        currStatus: ConnectionStatus.ReconnectingExplicitly,
         deviceStatus: DeviceConnectionStatus.DISCONNECTED,
         prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
         type: "radioRemote",
@@ -351,7 +368,7 @@ describe("getNextConnectionState for bluetooth connection", () => {
       },
     });
   });
-  test("bluetooth reconnecting", () => {
+  test("bluetooth reconnecting explicitly", () => {
     testGetNextConnectionState({
       input: {
         currConnType: "bluetooth",
@@ -363,7 +380,24 @@ describe("getNextConnectionState for bluetooth connection", () => {
       initialHasAttemptedReconnect: false,
       expectedHasAttemptedReconnect: false,
       expectedNextConnectionState: {
-        status: ConnectionStatus.Reconnecting,
+        status: ConnectionStatus.ReconnectingExplicitly,
+        flowType: ConnectionFlowType.Bluetooth,
+      },
+    });
+  });
+  test("bluetooth reconnecting automatically", () => {
+    testGetNextConnectionState({
+      input: {
+        currConnType: "bluetooth",
+        currStatus: ConnectionStatus.Connected,
+        deviceStatus: DeviceConnectionStatus.RECONNECTING,
+        prevDeviceStatus: DeviceConnectionStatus.CONNECTED,
+        type: "bluetooth",
+      },
+      initialHasAttemptedReconnect: false,
+      expectedHasAttemptedReconnect: false,
+      expectedNextConnectionState: {
+        status: ConnectionStatus.ReconnectingAutomatically,
         flowType: ConnectionFlowType.Bluetooth,
       },
     });
@@ -389,7 +423,7 @@ describe("getNextConnectionState for bluetooth connection", () => {
     testGetNextConnectionState({
       input: {
         currConnType: "bluetooth",
-        currStatus: ConnectionStatus.Reconnecting,
+        currStatus: ConnectionStatus.ReconnectingExplicitly,
         deviceStatus: DeviceConnectionStatus.DISCONNECTED,
         prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
         type: "bluetooth",
@@ -406,7 +440,7 @@ describe("getNextConnectionState for bluetooth connection", () => {
     testGetNextConnectionState({
       input: {
         currConnType: "bluetooth",
-        currStatus: ConnectionStatus.Reconnecting,
+        currStatus: ConnectionStatus.ReconnectingExplicitly,
         deviceStatus: DeviceConnectionStatus.DISCONNECTED,
         prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
         type: "bluetooth",

--- a/src/get-next-connection-state.test.ts
+++ b/src/get-next-connection-state.test.ts
@@ -227,7 +227,7 @@ describe("getNextConnectionState for radio connection", () => {
     testGetNextConnectionState({
       input: {
         currConnType: "radio",
-        currStatus: ConnectionStatus.Disconnected,
+        currStatus: ConnectionStatus.Connecting,
         deviceStatus: DeviceConnectionStatus.DISCONNECTED,
         prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
         type: "usb",
@@ -265,7 +265,7 @@ describe("getNextConnectionState for radio connection", () => {
     testGetNextConnectionState({
       input: {
         currConnType: "radio",
-        currStatus: ConnectionStatus.ReconnectingExplicitly,
+        currStatus: ConnectionStatus.ReconnectingAutomatically,
         deviceStatus: DeviceConnectionStatus.DISCONNECTED,
         prevDeviceStatus: DeviceConnectionStatus.RECONNECTING,
         type: "radioRemote",
@@ -477,7 +477,7 @@ describe("getNextConnectionState for bluetooth connection", () => {
     testGetNextConnectionState({
       input: {
         currConnType: "bluetooth",
-        currStatus: ConnectionStatus.Connected,
+        currStatus: ConnectionStatus.ReconnectingAutomatically,
         deviceStatus: DeviceConnectionStatus.DISCONNECTED,
         prevDeviceStatus: DeviceConnectionStatus.RECONNECTING,
         type: "bluetooth",

--- a/src/get-next-connection-state.test.ts
+++ b/src/get-next-connection-state.test.ts
@@ -1,0 +1,448 @@
+/**
+ * @vitest-environment jsdom
+ */
+/**
+ * (c) 2023, Center for Computational Thinking and Design at Aarhus University and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+import { ConnectionStatus } from "./connect-status-hooks";
+import {
+  ConnectionState,
+  getNextConnectionState,
+} from "./get-next-connection-state";
+import { ConnectionStatus as DeviceConnectionStatus } from "@microbit/microbit-connection";
+import { ConnectionFlowType } from "./connection-stage-hooks";
+
+type Input = Pick<
+  ConnectionState,
+  "currConnType" | "currStatus" | "deviceStatus" | "prevDeviceStatus" | "type"
+>;
+const testGetNextConnectionState = ({
+  input,
+  initialHasAttemptedReconnect,
+  initialHasRadioConnected,
+}: {
+  input: Input;
+  initialHasAttemptedReconnect: boolean;
+  initialHasRadioConnected: boolean;
+}) => {
+  let hasAttempedReconnect = initialHasAttemptedReconnect;
+  let hasRadioConnected = initialHasRadioConnected;
+  const result = getNextConnectionState({
+    ...input,
+    hasAttempedReconnect,
+    setHasAttemptedReconnect: (val: boolean) => {
+      hasAttempedReconnect = val;
+    },
+    hasRadioConnected,
+    setHasRadioConnected: (val: boolean) => {
+      hasRadioConnected = val;
+    },
+  });
+  return {
+    result,
+    hasAttempedReconnect,
+    hasRadioConnected,
+  };
+};
+
+describe("getNextConnectionState for radio connection", () => {
+  test("radio usb flashing", () => {
+    const { result, hasAttempedReconnect, hasRadioConnected } =
+      testGetNextConnectionState({
+        input: {
+          currConnType: "radio",
+          currStatus: ConnectionStatus.NotConnected,
+          deviceStatus: DeviceConnectionStatus.CONNECTING,
+          prevDeviceStatus: DeviceConnectionStatus.NO_AUTHORIZED_DEVICE,
+          type: "usb",
+        },
+        initialHasAttemptedReconnect: false,
+        initialHasRadioConnected: false,
+      });
+    expect(result).toEqual(undefined);
+    expect(hasAttempedReconnect).toEqual(false);
+    expect(hasRadioConnected).toEqual(false);
+  });
+  test("radio connecting", () => {
+    const { result, hasAttempedReconnect, hasRadioConnected } =
+      testGetNextConnectionState({
+        input: {
+          currConnType: "radio",
+          currStatus: ConnectionStatus.NotConnected,
+          deviceStatus: DeviceConnectionStatus.CONNECTING,
+          prevDeviceStatus: DeviceConnectionStatus.NO_AUTHORIZED_DEVICE,
+          type: "radioRemote",
+        },
+        initialHasAttemptedReconnect: false,
+        initialHasRadioConnected: false,
+      });
+    expect(result).toEqual({
+      status: ConnectionStatus.Connecting,
+      flowType: ConnectionFlowType.RadioRemote,
+    });
+    expect(hasAttempedReconnect).toEqual(false);
+    expect(hasRadioConnected).toEqual(false);
+  });
+  test("radio connected for the first time", () => {
+    const { result, hasAttempedReconnect, hasRadioConnected } =
+      testGetNextConnectionState({
+        input: {
+          currConnType: "radio",
+          currStatus: ConnectionStatus.NotConnected,
+          deviceStatus: DeviceConnectionStatus.CONNECTED,
+          prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
+          type: "radioRemote",
+        },
+        initialHasAttemptedReconnect: false,
+        initialHasRadioConnected: false,
+      });
+    expect(result).toEqual({
+      status: ConnectionStatus.Connected,
+      flowType: ConnectionFlowType.RadioRemote,
+    });
+    expect(hasAttempedReconnect).toEqual(false);
+    expect(hasRadioConnected).toEqual(true);
+  });
+  test("radio connected subsequent times", () => {
+    const { result, hasAttempedReconnect, hasRadioConnected } =
+      testGetNextConnectionState({
+        input: {
+          currConnType: "radio",
+          currStatus: ConnectionStatus.Disconnected,
+          deviceStatus: DeviceConnectionStatus.CONNECTED,
+          prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
+          type: "radioRemote",
+        },
+        initialHasAttemptedReconnect: false,
+        initialHasRadioConnected: false,
+      });
+    expect(result).toEqual({
+      status: ConnectionStatus.Connected,
+      flowType: ConnectionFlowType.RadioRemote,
+    });
+    expect(hasAttempedReconnect).toEqual(false);
+    expect(hasRadioConnected).toEqual(true);
+  });
+  test("radio connect fail", () => {
+    const { result, hasAttempedReconnect, hasRadioConnected } =
+      testGetNextConnectionState({
+        input: {
+          currConnType: "radio",
+          currStatus: ConnectionStatus.Connecting,
+          deviceStatus: DeviceConnectionStatus.DISCONNECTED,
+          prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
+          type: "radioRemote",
+        },
+        initialHasAttemptedReconnect: false,
+        initialHasRadioConnected: false,
+      });
+    expect(result).toEqual({
+      status: ConnectionStatus.FailedToConnect,
+      flowType: ConnectionFlowType.RadioRemote,
+    });
+    expect(hasAttempedReconnect).toEqual(false);
+    expect(hasRadioConnected).toEqual(false);
+  });
+  test("radio reconnecting", () => {
+    const { result, hasAttempedReconnect, hasRadioConnected } =
+      testGetNextConnectionState({
+        input: {
+          currConnType: "radio",
+          currStatus: ConnectionStatus.Disconnected,
+          deviceStatus: DeviceConnectionStatus.CONNECTING,
+          prevDeviceStatus: DeviceConnectionStatus.DISCONNECTED,
+          type: "radioRemote",
+        },
+        initialHasAttemptedReconnect: false,
+        initialHasRadioConnected: false,
+      });
+    expect(result).toEqual({
+      status: ConnectionStatus.Reconnecting,
+      flowType: ConnectionFlowType.RadioRemote,
+    });
+    expect(hasAttempedReconnect).toEqual(false);
+    expect(hasRadioConnected).toEqual(false);
+  });
+  test("radio bridge device connection lost by unplugging device", () => {
+    const { result, hasAttempedReconnect, hasRadioConnected } =
+      testGetNextConnectionState({
+        input: {
+          currConnType: "radio",
+          currStatus: ConnectionStatus.Connected,
+          deviceStatus: DeviceConnectionStatus.DISCONNECTED,
+          prevDeviceStatus: DeviceConnectionStatus.CONNECTED,
+          type: "usb",
+        },
+        initialHasAttemptedReconnect: false,
+        initialHasRadioConnected: false,
+      });
+    expect(result).toEqual({
+      status: ConnectionStatus.ConnectionLost,
+      flowType: ConnectionFlowType.RadioBridge,
+    });
+    expect(hasAttempedReconnect).toEqual(true);
+    expect(hasRadioConnected).toEqual(false);
+  });
+  test("radio bridge device reconnect fail", () => {
+    const { result, hasAttempedReconnect, hasRadioConnected } =
+      testGetNextConnectionState({
+        input: {
+          currConnType: "radio",
+          currStatus: ConnectionStatus.Reconnecting,
+          deviceStatus: DeviceConnectionStatus.DISCONNECTED,
+          prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
+          type: "usb",
+        },
+        initialHasAttemptedReconnect: false,
+        initialHasRadioConnected: false,
+      });
+    expect(result).toEqual({
+      status: ConnectionStatus.FailedToReconnect,
+      flowType: ConnectionFlowType.RadioBridge,
+    });
+    expect(hasAttempedReconnect).toEqual(true);
+    expect(hasRadioConnected).toEqual(false);
+  });
+  test("radio bridge device reconnect fail twice from connection loss", () => {
+    const { result, hasAttempedReconnect, hasRadioConnected } =
+      testGetNextConnectionState({
+        input: {
+          currConnType: "radio",
+          currStatus: ConnectionStatus.Connected,
+          deviceStatus: DeviceConnectionStatus.DISCONNECTED,
+          prevDeviceStatus: DeviceConnectionStatus.DISCONNECTED,
+          type: "usb",
+        },
+        initialHasAttemptedReconnect: true,
+        initialHasRadioConnected: false,
+      });
+    expect(result).toEqual({
+      status: ConnectionStatus.FailedToReconnectTwice,
+      flowType: ConnectionFlowType.RadioBridge,
+    });
+    expect(hasAttempedReconnect).toEqual(true);
+    expect(hasRadioConnected).toEqual(false);
+  });
+  test("radio remote connection lost by unplugging device", () => {
+    const { result, hasAttempedReconnect, hasRadioConnected } =
+      testGetNextConnectionState({
+        input: {
+          currConnType: "radio",
+          currStatus: ConnectionStatus.Reconnecting,
+          deviceStatus: DeviceConnectionStatus.DISCONNECTED,
+          prevDeviceStatus: DeviceConnectionStatus.RECONNECTING,
+          type: "radioRemote",
+        },
+        initialHasAttemptedReconnect: false,
+        initialHasRadioConnected: false,
+      });
+    expect(result).toEqual({
+      status: ConnectionStatus.ConnectionLost,
+      flowType: ConnectionFlowType.RadioRemote,
+    });
+    expect(hasAttempedReconnect).toEqual(true);
+    expect(hasRadioConnected).toEqual(false);
+  });
+  test("radio remote reconnect fail", () => {
+    const { result, hasAttempedReconnect, hasRadioConnected } =
+      testGetNextConnectionState({
+        input: {
+          currConnType: "radio",
+          currStatus: ConnectionStatus.Reconnecting,
+          deviceStatus: DeviceConnectionStatus.DISCONNECTED,
+          prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
+          type: "radioRemote",
+        },
+        initialHasAttemptedReconnect: false,
+        initialHasRadioConnected: false,
+      });
+    expect(result).toEqual({
+      status: ConnectionStatus.FailedToReconnect,
+      flowType: ConnectionFlowType.RadioRemote,
+    });
+    expect(hasAttempedReconnect).toEqual(true);
+    expect(hasRadioConnected).toEqual(false);
+  });
+  test("radio remote reconnect fail twice", () => {
+    const { result, hasAttempedReconnect, hasRadioConnected } =
+      testGetNextConnectionState({
+        input: {
+          currConnType: "radio",
+          currStatus: ConnectionStatus.Reconnecting,
+          deviceStatus: DeviceConnectionStatus.DISCONNECTED,
+          prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
+          type: "radioRemote",
+        },
+        initialHasAttemptedReconnect: true,
+        initialHasRadioConnected: false,
+      });
+    expect(result).toEqual({
+      status: ConnectionStatus.FailedToReconnectTwice,
+      flowType: ConnectionFlowType.RadioRemote,
+    });
+    expect(hasAttempedReconnect).toEqual(true);
+    expect(hasRadioConnected).toEqual(false);
+  });
+});
+
+const bluetoothReconnectFailInput: Input = {
+  currConnType: "bluetooth",
+  currStatus: ConnectionStatus.Reconnecting,
+  deviceStatus: DeviceConnectionStatus.DISCONNECTED,
+  prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
+  type: "bluetooth",
+};
+
+describe("getNextConnectionState for bluetooth connection", () => {
+  test("bluetooth connecting", () => {
+    const { result, hasAttempedReconnect, hasRadioConnected } =
+      testGetNextConnectionState({
+        input: {
+          currConnType: "bluetooth",
+          currStatus: ConnectionStatus.NotConnected,
+          deviceStatus: DeviceConnectionStatus.CONNECTING,
+          prevDeviceStatus: DeviceConnectionStatus.NO_AUTHORIZED_DEVICE,
+          type: "bluetooth",
+        },
+        initialHasAttemptedReconnect: false,
+        initialHasRadioConnected: false,
+      });
+    expect(result).toEqual({
+      status: ConnectionStatus.Connecting,
+      flowType: ConnectionFlowType.Bluetooth,
+    });
+    expect(hasAttempedReconnect).toEqual(false);
+    expect(hasRadioConnected).toEqual(false);
+  });
+  test("bluetooth connected for the first time", () => {
+    const { result, hasAttempedReconnect, hasRadioConnected } =
+      testGetNextConnectionState({
+        input: {
+          currConnType: "bluetooth",
+          currStatus: ConnectionStatus.NotConnected,
+          deviceStatus: DeviceConnectionStatus.CONNECTED,
+          prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
+          type: "bluetooth",
+        },
+        initialHasAttemptedReconnect: false,
+        initialHasRadioConnected: false,
+      });
+    expect(result).toEqual({
+      status: ConnectionStatus.Connected,
+      flowType: ConnectionFlowType.Bluetooth,
+    });
+    expect(hasAttempedReconnect).toEqual(false);
+    expect(hasRadioConnected).toEqual(false);
+  });
+  test("bluetooth connected subsequent times", () => {
+    const { result, hasAttempedReconnect, hasRadioConnected } =
+      testGetNextConnectionState({
+        input: {
+          currConnType: "bluetooth",
+          currStatus: ConnectionStatus.Disconnected,
+          deviceStatus: DeviceConnectionStatus.CONNECTED,
+          prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
+          type: "bluetooth",
+        },
+        initialHasAttemptedReconnect: false,
+        initialHasRadioConnected: false,
+      });
+    expect(result).toEqual({
+      status: ConnectionStatus.Connected,
+      flowType: ConnectionFlowType.Bluetooth,
+    });
+    expect(hasAttempedReconnect).toEqual(false);
+    expect(hasRadioConnected).toEqual(false);
+  });
+  test("bluetooth connect fail", () => {
+    const { result, hasAttempedReconnect, hasRadioConnected } =
+      testGetNextConnectionState({
+        input: {
+          currConnType: "bluetooth",
+          currStatus: ConnectionStatus.Connecting,
+          deviceStatus: DeviceConnectionStatus.DISCONNECTED,
+          prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
+          type: "bluetooth",
+        },
+        initialHasAttemptedReconnect: false,
+        initialHasRadioConnected: false,
+      });
+    expect(result).toEqual({
+      status: ConnectionStatus.FailedToConnect,
+      flowType: ConnectionFlowType.Bluetooth,
+    });
+    expect(hasAttempedReconnect).toEqual(false);
+    expect(hasRadioConnected).toEqual(false);
+  });
+  test("bluetooth reconnecting", () => {
+    const { result, hasAttempedReconnect, hasRadioConnected } =
+      testGetNextConnectionState({
+        input: {
+          currConnType: "bluetooth",
+          currStatus: ConnectionStatus.Disconnected,
+          deviceStatus: DeviceConnectionStatus.CONNECTING,
+          prevDeviceStatus: DeviceConnectionStatus.DISCONNECTED,
+          type: "bluetooth",
+        },
+        initialHasAttemptedReconnect: false,
+        initialHasRadioConnected: false,
+      });
+    expect(result).toEqual({
+      status: ConnectionStatus.Reconnecting,
+      flowType: ConnectionFlowType.Bluetooth,
+    });
+    expect(hasAttempedReconnect).toEqual(false);
+    expect(hasRadioConnected).toEqual(false);
+  });
+  test("bluetooth connection lost by unplugging device", () => {
+    const { result, hasAttempedReconnect, hasRadioConnected } =
+      testGetNextConnectionState({
+        input: {
+          currConnType: "bluetooth",
+          currStatus: ConnectionStatus.Connected,
+          deviceStatus: DeviceConnectionStatus.DISCONNECTED,
+          prevDeviceStatus: DeviceConnectionStatus.RECONNECTING,
+          type: "bluetooth",
+        },
+        initialHasAttemptedReconnect: false,
+        initialHasRadioConnected: false,
+      });
+    expect(result).toEqual({
+      status: ConnectionStatus.ConnectionLost,
+      flowType: ConnectionFlowType.Bluetooth,
+    });
+    expect(hasAttempedReconnect).toEqual(true);
+    expect(hasRadioConnected).toEqual(false);
+  });
+  test("bluetooth reconnect fail", () => {
+    const { result, hasAttempedReconnect, hasRadioConnected } =
+      testGetNextConnectionState({
+        input: bluetoothReconnectFailInput,
+        initialHasAttemptedReconnect: false,
+        initialHasRadioConnected: false,
+      });
+    expect(result).toEqual({
+      status: ConnectionStatus.FailedToReconnect,
+      flowType: ConnectionFlowType.Bluetooth,
+    });
+    expect(hasAttempedReconnect).toEqual(true);
+    expect(hasRadioConnected).toEqual(false);
+  });
+  test("bluetooth reconnect fail twice", () => {
+    const { result, hasAttempedReconnect, hasRadioConnected } =
+      testGetNextConnectionState({
+        input: bluetoothReconnectFailInput,
+        initialHasAttemptedReconnect: true,
+        initialHasRadioConnected: false,
+      });
+    expect(result).toEqual({
+      status: ConnectionStatus.FailedToReconnectTwice,
+      flowType: ConnectionFlowType.Bluetooth,
+    });
+    expect(hasAttempedReconnect).toEqual(true);
+    expect(hasRadioConnected).toEqual(false);
+  });
+});

--- a/src/get-next-connection-state.test.ts
+++ b/src/get-next-connection-state.test.ts
@@ -24,24 +24,34 @@ type Input = Pick<
 const testGetNextConnectionState = ({
   input,
   initialHasAttemptedReconnect,
+  initialOnFirstConnectAttempt,
   expectedNextConnectionState,
   expectedHasAttemptedReconnect,
+  expectedOnFirstConnectAttempt,
 }: {
   input: Input;
   initialHasAttemptedReconnect: boolean;
   expectedNextConnectionState: NextConnectionState;
   expectedHasAttemptedReconnect: boolean;
+  initialOnFirstConnectAttempt: boolean;
+  expectedOnFirstConnectAttempt: boolean;
 }) => {
   let hasAttempedReconnect = initialHasAttemptedReconnect;
+  let onFirstConnectAttempt = initialOnFirstConnectAttempt;
   const result = getNextConnectionState({
     ...input,
     hasAttempedReconnect,
+    onFirstConnectAttempt,
+    setOnFirstConnectAttempt: (val: boolean) => {
+      onFirstConnectAttempt = val;
+    },
     setHasAttemptedReconnect: (val: boolean) => {
       hasAttempedReconnect = val;
     },
   });
   expect(result).toEqual(expectedNextConnectionState);
   expect(hasAttempedReconnect).toEqual(expectedHasAttemptedReconnect);
+  expect(onFirstConnectAttempt).toEqual(expectedOnFirstConnectAttempt);
 };
 
 describe("getNextConnectionState for radio connection", () => {
@@ -54,6 +64,8 @@ describe("getNextConnectionState for radio connection", () => {
         prevDeviceStatus: DeviceConnectionStatus.NO_AUTHORIZED_DEVICE,
         type: "usb",
       },
+      initialOnFirstConnectAttempt: true,
+      expectedOnFirstConnectAttempt: true,
       initialHasAttemptedReconnect: false,
       expectedHasAttemptedReconnect: false,
       expectedNextConnectionState: undefined,
@@ -68,6 +80,8 @@ describe("getNextConnectionState for radio connection", () => {
         prevDeviceStatus: DeviceConnectionStatus.NO_AUTHORIZED_DEVICE,
         type: "radioRemote",
       },
+      initialOnFirstConnectAttempt: false,
+      expectedOnFirstConnectAttempt: true,
       initialHasAttemptedReconnect: false,
       expectedHasAttemptedReconnect: false,
       expectedNextConnectionState: {
@@ -85,6 +99,8 @@ describe("getNextConnectionState for radio connection", () => {
         prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
         type: "radioRemote",
       },
+      initialOnFirstConnectAttempt: true,
+      expectedOnFirstConnectAttempt: false,
       initialHasAttemptedReconnect: false,
       expectedHasAttemptedReconnect: false,
       expectedNextConnectionState: {
@@ -102,6 +118,8 @@ describe("getNextConnectionState for radio connection", () => {
         prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
         type: "radioRemote",
       },
+      initialOnFirstConnectAttempt: false,
+      expectedOnFirstConnectAttempt: false,
       initialHasAttemptedReconnect: true,
       expectedHasAttemptedReconnect: false,
       expectedNextConnectionState: {
@@ -119,6 +137,8 @@ describe("getNextConnectionState for radio connection", () => {
         prevDeviceStatus: DeviceConnectionStatus.CONNECTED,
         type: "radioRemote",
       },
+      initialOnFirstConnectAttempt: false,
+      expectedOnFirstConnectAttempt: false,
       initialHasAttemptedReconnect: false,
       expectedHasAttemptedReconnect: false,
       expectedNextConnectionState: {
@@ -136,6 +156,8 @@ describe("getNextConnectionState for radio connection", () => {
         prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
         type: "radioRemote",
       },
+      initialOnFirstConnectAttempt: true,
+      expectedOnFirstConnectAttempt: true,
       initialHasAttemptedReconnect: false,
       expectedHasAttemptedReconnect: false,
       expectedNextConnectionState: {
@@ -153,6 +175,8 @@ describe("getNextConnectionState for radio connection", () => {
         prevDeviceStatus: DeviceConnectionStatus.DISCONNECTED,
         type: "radioRemote",
       },
+      initialOnFirstConnectAttempt: false,
+      expectedOnFirstConnectAttempt: false,
       initialHasAttemptedReconnect: false,
       expectedHasAttemptedReconnect: false,
       expectedNextConnectionState: {
@@ -170,6 +194,8 @@ describe("getNextConnectionState for radio connection", () => {
         prevDeviceStatus: DeviceConnectionStatus.CONNECTED,
         type: "radioRemote",
       },
+      initialOnFirstConnectAttempt: false,
+      expectedOnFirstConnectAttempt: false,
       initialHasAttemptedReconnect: false,
       expectedHasAttemptedReconnect: false,
       expectedNextConnectionState: {
@@ -187,6 +213,8 @@ describe("getNextConnectionState for radio connection", () => {
         prevDeviceStatus: DeviceConnectionStatus.NO_AUTHORIZED_DEVICE,
         type: "usb",
       },
+      initialOnFirstConnectAttempt: false,
+      expectedOnFirstConnectAttempt: false,
       initialHasAttemptedReconnect: false,
       expectedHasAttemptedReconnect: true,
       expectedNextConnectionState: {
@@ -204,6 +232,8 @@ describe("getNextConnectionState for radio connection", () => {
         prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
         type: "usb",
       },
+      initialOnFirstConnectAttempt: false,
+      expectedOnFirstConnectAttempt: false,
       initialHasAttemptedReconnect: false,
       expectedHasAttemptedReconnect: true,
       expectedNextConnectionState: {
@@ -221,6 +251,8 @@ describe("getNextConnectionState for radio connection", () => {
         prevDeviceStatus: DeviceConnectionStatus.DISCONNECTED,
         type: "usb",
       },
+      initialOnFirstConnectAttempt: false,
+      expectedOnFirstConnectAttempt: false,
       initialHasAttemptedReconnect: true,
       expectedHasAttemptedReconnect: true,
       expectedNextConnectionState: {
@@ -238,6 +270,8 @@ describe("getNextConnectionState for radio connection", () => {
         prevDeviceStatus: DeviceConnectionStatus.RECONNECTING,
         type: "radioRemote",
       },
+      initialOnFirstConnectAttempt: false,
+      expectedOnFirstConnectAttempt: false,
       initialHasAttemptedReconnect: false,
       expectedHasAttemptedReconnect: true,
       expectedNextConnectionState: {
@@ -255,6 +289,8 @@ describe("getNextConnectionState for radio connection", () => {
         prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
         type: "radioRemote",
       },
+      initialOnFirstConnectAttempt: false,
+      expectedOnFirstConnectAttempt: false,
       initialHasAttemptedReconnect: false,
       expectedHasAttemptedReconnect: true,
       expectedNextConnectionState: {
@@ -272,6 +308,8 @@ describe("getNextConnectionState for radio connection", () => {
         prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
         type: "radioRemote",
       },
+      initialOnFirstConnectAttempt: false,
+      expectedOnFirstConnectAttempt: false,
       initialHasAttemptedReconnect: true,
       expectedHasAttemptedReconnect: true,
       expectedNextConnectionState: {
@@ -292,6 +330,8 @@ describe("getNextConnectionState for bluetooth connection", () => {
         prevDeviceStatus: DeviceConnectionStatus.NO_AUTHORIZED_DEVICE,
         type: "bluetooth",
       },
+      initialOnFirstConnectAttempt: false,
+      expectedOnFirstConnectAttempt: true,
       initialHasAttemptedReconnect: false,
       expectedHasAttemptedReconnect: false,
       expectedNextConnectionState: {
@@ -309,6 +349,8 @@ describe("getNextConnectionState for bluetooth connection", () => {
         prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
         type: "bluetooth",
       },
+      initialOnFirstConnectAttempt: true,
+      expectedOnFirstConnectAttempt: false,
       initialHasAttemptedReconnect: false,
       expectedHasAttemptedReconnect: false,
       expectedNextConnectionState: {
@@ -326,6 +368,8 @@ describe("getNextConnectionState for bluetooth connection", () => {
         prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
         type: "bluetooth",
       },
+      initialOnFirstConnectAttempt: false,
+      expectedOnFirstConnectAttempt: false,
       initialHasAttemptedReconnect: false,
       expectedHasAttemptedReconnect: false,
       expectedNextConnectionState: {
@@ -343,10 +387,31 @@ describe("getNextConnectionState for bluetooth connection", () => {
         prevDeviceStatus: DeviceConnectionStatus.CONNECTED,
         type: "bluetooth",
       },
+      initialOnFirstConnectAttempt: false,
+      expectedOnFirstConnectAttempt: false,
       initialHasAttemptedReconnect: false,
       expectedHasAttemptedReconnect: false,
       expectedNextConnectionState: {
         status: ConnectionStatus.Disconnected,
+        flowType: ConnectionFlowType.Bluetooth,
+      },
+    });
+  });
+  test("bluetooth did not select device", () => {
+    testGetNextConnectionState({
+      input: {
+        currConnType: "bluetooth",
+        currStatus: ConnectionStatus.NotConnected,
+        deviceStatus: DeviceConnectionStatus.NO_AUTHORIZED_DEVICE,
+        prevDeviceStatus: DeviceConnectionStatus.NO_AUTHORIZED_DEVICE,
+        type: "bluetooth",
+      },
+      initialOnFirstConnectAttempt: false,
+      expectedOnFirstConnectAttempt: false,
+      initialHasAttemptedReconnect: false,
+      expectedHasAttemptedReconnect: false,
+      expectedNextConnectionState: {
+        status: ConnectionStatus.FailedToSelectBluetoothDevice,
         flowType: ConnectionFlowType.Bluetooth,
       },
     });
@@ -360,6 +425,8 @@ describe("getNextConnectionState for bluetooth connection", () => {
         prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
         type: "bluetooth",
       },
+      initialOnFirstConnectAttempt: true,
+      expectedOnFirstConnectAttempt: true,
       initialHasAttemptedReconnect: false,
       expectedHasAttemptedReconnect: false,
       expectedNextConnectionState: {
@@ -377,6 +444,8 @@ describe("getNextConnectionState for bluetooth connection", () => {
         prevDeviceStatus: DeviceConnectionStatus.DISCONNECTED,
         type: "bluetooth",
       },
+      initialOnFirstConnectAttempt: false,
+      expectedOnFirstConnectAttempt: false,
       initialHasAttemptedReconnect: false,
       expectedHasAttemptedReconnect: false,
       expectedNextConnectionState: {
@@ -394,6 +463,8 @@ describe("getNextConnectionState for bluetooth connection", () => {
         prevDeviceStatus: DeviceConnectionStatus.CONNECTED,
         type: "bluetooth",
       },
+      initialOnFirstConnectAttempt: false,
+      expectedOnFirstConnectAttempt: false,
       initialHasAttemptedReconnect: false,
       expectedHasAttemptedReconnect: false,
       expectedNextConnectionState: {
@@ -411,6 +482,8 @@ describe("getNextConnectionState for bluetooth connection", () => {
         prevDeviceStatus: DeviceConnectionStatus.RECONNECTING,
         type: "bluetooth",
       },
+      initialOnFirstConnectAttempt: false,
+      expectedOnFirstConnectAttempt: false,
       initialHasAttemptedReconnect: false,
       expectedHasAttemptedReconnect: true,
       expectedNextConnectionState: {
@@ -428,6 +501,8 @@ describe("getNextConnectionState for bluetooth connection", () => {
         prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
         type: "bluetooth",
       },
+      initialOnFirstConnectAttempt: false,
+      expectedOnFirstConnectAttempt: false,
       initialHasAttemptedReconnect: false,
       expectedHasAttemptedReconnect: true,
       expectedNextConnectionState: {
@@ -445,6 +520,8 @@ describe("getNextConnectionState for bluetooth connection", () => {
         prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
         type: "bluetooth",
       },
+      initialOnFirstConnectAttempt: false,
+      expectedOnFirstConnectAttempt: false,
       initialHasAttemptedReconnect: true,
       expectedHasAttemptedReconnect: true,
       expectedNextConnectionState: {

--- a/src/get-next-connection-state.ts
+++ b/src/get-next-connection-state.ts
@@ -69,7 +69,7 @@ export const getNextConnectionState = ({
   }
   if (
     // Disconnection happens for newly started / restarted
-    // connection flows when clearing device
+    // bluetooth connection flows when clearing device
     deviceStatus === DeviceConnectionStatus.DISCONNECTED &&
     currStatus === ConnectionStatus.NotConnected
   ) {

--- a/src/get-next-connection-state.ts
+++ b/src/get-next-connection-state.ts
@@ -39,30 +39,24 @@ export const getNextConnectionState = ({
 
   // We are using usb status to infer the radio bridge device status.
   if (type === "usb") {
-    // Ignore USB status updates when radio connection is not established.
-    if (currConnType !== "radio" || onFirstConnectAttempt) {
+    // Ignore USB status updates when radio connection is not established or is disconnected.
+    if (
+      currConnType !== "radio" ||
+      onFirstConnectAttempt ||
+      deviceStatus !== DeviceConnectionStatus.DISCONNECTED ||
+      currStatus === ConnectionStatus.Disconnected
+    ) {
       return undefined;
     }
-    if (
-      !hasAttempedReconnect &&
-      currStatus === ConnectionStatus.Connected &&
-      deviceStatus === DeviceConnectionStatus.DISCONNECTED
-    ) {
+    if (!hasAttempedReconnect && currStatus === ConnectionStatus.Connected) {
       setHasAttemptedReconnect(true);
       return { status: ConnectionStatus.ConnectionLost, flowType };
     }
-    if (
-      !hasAttempedReconnect &&
-      currStatus !== ConnectionStatus.Connected &&
-      deviceStatus === DeviceConnectionStatus.DISCONNECTED
-    ) {
+    if (!hasAttempedReconnect && currStatus !== ConnectionStatus.Connected) {
       setHasAttemptedReconnect(true);
       return { status: ConnectionStatus.FailedToReconnect, flowType };
     }
-    if (
-      hasAttempedReconnect &&
-      deviceStatus === DeviceConnectionStatus.DISCONNECTED
-    ) {
+    if (hasAttempedReconnect) {
       return {
         status: ConnectionStatus.FailedToReconnectTwice,
         flowType: ConnectionFlowType.RadioRemote,

--- a/src/get-next-connection-state.ts
+++ b/src/get-next-connection-state.ts
@@ -37,38 +37,43 @@ export const getNextConnectionState = ({
       ? ConnectionFlowType.RadioRemote
       : ConnectionFlowType.Bluetooth;
 
-  // We are using usb status to infer the radio bridge device status.
+  // We use usb status to infer the radio bridge device status for handling error.
   if (type === "usb") {
-    // Ignore USB status updates when radio connection is not established or is disconnected.
     if (
+      // Ignore USB status updates when radio connection is not established,
+      // is disconnected, or is reconnecting. The connection gets intentionally
+      // disconnected before reconnecting.
       currConnType !== "radio" ||
       onFirstConnectAttempt ||
       deviceStatus !== DeviceConnectionStatus.DISCONNECTED ||
       currStatus === ConnectionStatus.Disconnected ||
-      // Serial connection gets intentionally disconnected before doing
-      // reconnect attempt.
+      // Ignore usb status when reconnecting.
+      // Serial connection gets intentionally disconnected before reconnect.
       currStatus === ConnectionStatus.ReconnectingAutomatically ||
       currStatus === ConnectionStatus.ReconnectingExplicitly
     ) {
       return undefined;
     }
-    if (!hasAttempedReconnect && currStatus === ConnectionStatus.Connected) {
-      setHasAttemptedReconnect(true);
-      return { status: ConnectionStatus.ConnectionLost, flowType };
-    }
-    if (!hasAttempedReconnect && currStatus !== ConnectionStatus.Connected) {
-      setHasAttemptedReconnect(true);
-      return { status: ConnectionStatus.FailedToReconnect, flowType };
-    }
-    if (hasAttempedReconnect) {
+    if (
+      // If bridge micro:bit causes radio bridge reconnect to fail twice
+      hasAttempedReconnect
+    ) {
       return {
         status: ConnectionStatus.FailedToReconnectTwice,
         flowType: ConnectionFlowType.RadioRemote,
       };
     }
-    return undefined;
+    // If bridge micro:bit causes radio bridge reconnect to fail
+    setHasAttemptedReconnect(true);
+    const status =
+      currStatus === ConnectionStatus.Connected
+        ? ConnectionStatus.ConnectionLost
+        : ConnectionStatus.FailedToReconnect;
+    return { status, flowType };
   }
+
   if (
+    // If user starts or restarts connection flow.
     // Disconnection happens for newly started / restarted
     // bluetooth connection flows when clearing device
     deviceStatus === DeviceConnectionStatus.DISCONNECTED &&
@@ -76,12 +81,16 @@ export const getNextConnectionState = ({
   ) {
     return { status: ConnectionStatus.NotConnected, flowType };
   }
-  if (deviceStatus === DeviceConnectionStatus.CONNECTED) {
+  if (
+    // If connected.
+    deviceStatus === DeviceConnectionStatus.CONNECTED
+  ) {
     setOnFirstConnectAttempt(false);
     setHasAttemptedReconnect(false);
     return { status: ConnectionStatus.Connected, flowType };
   }
   if (
+    // If user fail to connect.
     onFirstConnectAttempt &&
     currStatus === ConnectionStatus.Connecting &&
     deviceStatus === DeviceConnectionStatus.DISCONNECTED
@@ -89,7 +98,7 @@ export const getNextConnectionState = ({
     return { status: ConnectionStatus.FailedToConnect, flowType };
   }
   if (
-    // If user does not select a device for bluetooth connection
+    // If user does not select a device for bluetooth connection.
     type === "bluetooth" &&
     deviceStatus === DeviceConnectionStatus.NO_AUTHORIZED_DEVICE &&
     prevDeviceStatus === DeviceConnectionStatus.NO_AUTHORIZED_DEVICE
@@ -97,6 +106,7 @@ export const getNextConnectionState = ({
     return { status: ConnectionStatus.FailedToSelectBluetoothDevice, flowType };
   }
   if (
+    // If fails to reconnect twice.
     hasAttempedReconnect &&
     deviceStatus === DeviceConnectionStatus.DISCONNECTED &&
     prevDeviceStatus === DeviceConnectionStatus.CONNECTING
@@ -104,6 +114,7 @@ export const getNextConnectionState = ({
     return { status: ConnectionStatus.FailedToReconnectTwice, flowType };
   }
   if (
+    // If fails to reconnect by user.
     deviceStatus === DeviceConnectionStatus.DISCONNECTED &&
     (prevDeviceStatus === DeviceConnectionStatus.CONNECTING ||
       prevDeviceStatus === DeviceConnectionStatus.NO_AUTHORIZED_DEVICE)
@@ -112,28 +123,40 @@ export const getNextConnectionState = ({
     return { status: ConnectionStatus.FailedToReconnect, flowType };
   }
   if (
+    // If fails to reconnect automatically.
     deviceStatus === DeviceConnectionStatus.DISCONNECTED &&
     currStatus === ConnectionStatus.ReconnectingAutomatically
   ) {
     setHasAttemptedReconnect(true);
     return { status: ConnectionStatus.ConnectionLost, flowType };
   }
-  if (deviceStatus === DeviceConnectionStatus.DISCONNECTED) {
+  if (
+    // If disconnected by user.
+    deviceStatus === DeviceConnectionStatus.DISCONNECTED
+  ) {
     return { status: ConnectionStatus.Disconnected, flowType };
   }
-  if (deviceStatus === DeviceConnectionStatus.CONNECTING) {
-    const hasStartedOver =
-      currStatus === ConnectionStatus.NotConnected ||
-      currStatus === ConnectionStatus.FailedToConnect;
-    if (hasStartedOver) {
-      setOnFirstConnectAttempt(true);
-    }
-    const newStatus = hasStartedOver
-      ? ConnectionStatus.Connecting
-      : ConnectionStatus.ReconnectingExplicitly;
-    return { status: newStatus, flowType };
+  const hasStartedOver =
+    currStatus === ConnectionStatus.NotConnected ||
+    currStatus === ConnectionStatus.FailedToConnect;
+  if (
+    // If connecting.
+    deviceStatus === DeviceConnectionStatus.CONNECTING &&
+    hasStartedOver
+  ) {
+    setOnFirstConnectAttempt(true);
+    return { status: ConnectionStatus.Connecting, flowType };
   }
-  if (deviceStatus === DeviceConnectionStatus.RECONNECTING) {
+  if (
+    // If reconnecting explicitly by user.
+    deviceStatus === DeviceConnectionStatus.CONNECTING
+  ) {
+    return { status: ConnectionStatus.ReconnectingExplicitly, flowType };
+  }
+  if (
+    // If reconnecting automatically.
+    deviceStatus === DeviceConnectionStatus.RECONNECTING
+  ) {
     return { status: ConnectionStatus.ReconnectingAutomatically, flowType };
   }
   return undefined;

--- a/src/get-next-connection-state.ts
+++ b/src/get-next-connection-state.ts
@@ -44,7 +44,11 @@ export const getNextConnectionState = ({
       currConnType !== "radio" ||
       onFirstConnectAttempt ||
       deviceStatus !== DeviceConnectionStatus.DISCONNECTED ||
-      currStatus === ConnectionStatus.Disconnected
+      currStatus === ConnectionStatus.Disconnected ||
+      // Serial connection gets intentionally disconnected before doing
+      // reconnect attempt.
+      currStatus === ConnectionStatus.ReconnectingAutomatically ||
+      currStatus === ConnectionStatus.ReconnectingExplicitly
     ) {
       return undefined;
     }
@@ -101,14 +105,15 @@ export const getNextConnectionState = ({
   }
   if (
     deviceStatus === DeviceConnectionStatus.DISCONNECTED &&
-    prevDeviceStatus === DeviceConnectionStatus.CONNECTING
+    (prevDeviceStatus === DeviceConnectionStatus.CONNECTING ||
+      prevDeviceStatus === DeviceConnectionStatus.NO_AUTHORIZED_DEVICE)
   ) {
     setHasAttemptedReconnect(true);
     return { status: ConnectionStatus.FailedToReconnect, flowType };
   }
   if (
     deviceStatus === DeviceConnectionStatus.DISCONNECTED &&
-    prevDeviceStatus === DeviceConnectionStatus.RECONNECTING
+    currStatus === ConnectionStatus.ReconnectingAutomatically
   ) {
     setHasAttemptedReconnect(true);
     return { status: ConnectionStatus.ConnectionLost, flowType };

--- a/src/get-next-connection-state.ts
+++ b/src/get-next-connection-state.ts
@@ -39,7 +39,6 @@ export const getNextConnectionState = ({
     if (currConnType !== "radio") {
       return undefined;
     }
-    console.log(type, deviceStatus, prevDeviceStatus, currStatus);
 
     if (
       !hasAttempedReconnect &&
@@ -115,10 +114,7 @@ export const getNextConnectionState = ({
     setHasAttemptedReconnect(true);
     return { status: ConnectionStatus.ConnectionLost, flowType };
   }
-  if (
-    deviceStatus === DeviceConnectionStatus.DISCONNECTED &&
-    prevDeviceStatus !== DeviceConnectionStatus.DISCONNECTED
-  ) {
+  if (deviceStatus === DeviceConnectionStatus.DISCONNECTED) {
     return { status: ConnectionStatus.Disconnected, flowType };
   }
   if (

--- a/src/get-next-connection-state.ts
+++ b/src/get-next-connection-state.ts
@@ -1,0 +1,144 @@
+import { MutableRefObject } from "react";
+import { StatusListenerType } from "./connect-actions";
+import { ConnectionStatus } from "./connect-status-hooks";
+import { ConnectionFlowType, ConnectionType } from "./connection-stage-hooks";
+import { ConnectionStatus as DeviceConnectionStatus } from "@microbit/microbit-connection";
+
+export interface ConnectionState {
+  currConnType: ConnectionType;
+  currStatus: ConnectionStatus;
+  deviceStatus: DeviceConnectionStatus;
+  prevDeviceStatus: DeviceConnectionStatus | null;
+  type: StatusListenerType;
+  hasAttempedReconnect: boolean;
+  setHasAttemptedReconnect: (val: boolean) => void;
+  hasRadioConnected: boolean;
+  setHasRadioConnected: (val: boolean) => void;
+}
+
+export const getNextConnectionState = ({
+  currConnType,
+  currStatus,
+  deviceStatus,
+  prevDeviceStatus,
+  type,
+  hasAttempedReconnect,
+  setHasAttemptedReconnect,
+  hasRadioConnected,
+  setHasRadioConnected,
+}: ConnectionState):
+  | { status: ConnectionStatus; flowType: ConnectionFlowType }
+  | undefined => {
+  console.log(type, deviceStatus, hasRadioConnected);
+  const flowType =
+    type === "usb"
+      ? ConnectionFlowType.RadioBridge
+      : type === "radioRemote"
+      ? ConnectionFlowType.RadioRemote
+      : ConnectionFlowType.Bluetooth;
+
+  // We are using usb status to infer the radio bridge device status.
+  if (type === "usb") {
+    // Ignore USB status updates when radio connection is not established.
+    if (currConnType !== "radio") {
+      return undefined;
+    }
+    if (
+      !hasAttempedReconnect &&
+      deviceStatus === DeviceConnectionStatus.DISCONNECTED &&
+      prevDeviceStatus === DeviceConnectionStatus.CONNECTED
+    ) {
+      setHasAttemptedReconnect(true);
+      return { status: ConnectionStatus.ConnectionLost, flowType };
+    }
+    if (
+      !hasAttempedReconnect &&
+      deviceStatus === DeviceConnectionStatus.DISCONNECTED
+    ) {
+      setHasAttemptedReconnect(true);
+      return { status: ConnectionStatus.FailedToReconnect, flowType };
+    }
+    if (
+      hasAttempedReconnect &&
+      deviceStatus === DeviceConnectionStatus.DISCONNECTED
+    ) {
+      return { status: ConnectionStatus.FailedToReconnectTwice, flowType };
+    }
+    return undefined;
+  }
+
+  if (
+    type === "radioRemote" &&
+    deviceStatus === DeviceConnectionStatus.DISCONNECTED
+  ) {
+    setHasRadioConnected(false);
+  }
+  if (
+    // Disconnection happens for newly started / restarted
+    // connection flows when clearing device
+    deviceStatus === DeviceConnectionStatus.DISCONNECTED &&
+    currStatus === ConnectionStatus.NotConnected
+  ) {
+    return { status: ConnectionStatus.NotConnected, flowType };
+  }
+  if (deviceStatus === DeviceConnectionStatus.CONNECTED) {
+    setHasAttemptedReconnect(false);
+    if (type === "radioRemote") {
+      setHasRadioConnected(true);
+    }
+    return { status: ConnectionStatus.Connected, flowType };
+  }
+  if (
+    currStatus === ConnectionStatus.Connecting &&
+    deviceStatus === DeviceConnectionStatus.DISCONNECTED
+  ) {
+    return { status: ConnectionStatus.FailedToConnect, flowType };
+  }
+  if (
+    // If user does not select a device for bluetooth connection
+    type === "bluetooth" &&
+    deviceStatus === DeviceConnectionStatus.NO_AUTHORIZED_DEVICE &&
+    prevDeviceStatus === DeviceConnectionStatus.NO_AUTHORIZED_DEVICE
+  ) {
+    return { status: ConnectionStatus.FailedToConnect, flowType };
+  }
+  if (
+    hasAttempedReconnect &&
+    deviceStatus === DeviceConnectionStatus.DISCONNECTED &&
+    prevDeviceStatus === DeviceConnectionStatus.CONNECTING
+  ) {
+    return { status: ConnectionStatus.FailedToReconnectTwice, flowType };
+  }
+  if (
+    deviceStatus === DeviceConnectionStatus.DISCONNECTED &&
+    prevDeviceStatus === DeviceConnectionStatus.CONNECTING
+  ) {
+    setHasAttemptedReconnect(true);
+    return { status: ConnectionStatus.FailedToReconnect, flowType };
+  }
+  if (
+    deviceStatus === DeviceConnectionStatus.DISCONNECTED &&
+    prevDeviceStatus === DeviceConnectionStatus.RECONNECTING
+  ) {
+    setHasAttemptedReconnect(true);
+    return { status: ConnectionStatus.ConnectionLost, flowType };
+  }
+  if (
+    deviceStatus === DeviceConnectionStatus.DISCONNECTED &&
+    prevDeviceStatus !== DeviceConnectionStatus.DISCONNECTED
+  ) {
+    return { status: ConnectionStatus.Disconnected, flowType };
+  }
+  if (
+    deviceStatus === DeviceConnectionStatus.RECONNECTING ||
+    deviceStatus === DeviceConnectionStatus.CONNECTING
+  ) {
+    const newStatus =
+      currStatus === ConnectionStatus.NotConnected ||
+      currStatus === ConnectionStatus.FailedToConnect
+        ? ConnectionStatus.Connecting
+        : ConnectionStatus.Reconnecting;
+    return { status: newStatus, flowType };
+  }
+  return undefined;
+};

--- a/src/get-next-connection-state.ts
+++ b/src/get-next-connection-state.ts
@@ -30,7 +30,6 @@ export const getNextConnectionState = ({
   onFirstConnectAttempt,
   setOnFirstConnectAttempt,
 }: GetNextConnectionStateInput): NextConnectionState => {
-  console.log(type, currStatus, deviceStatus, prevDeviceStatus);
   const flowType =
     type === "usb"
       ? ConnectionFlowType.RadioBridge

--- a/src/get-next-connection-state.ts
+++ b/src/get-next-connection-state.ts
@@ -117,16 +117,17 @@ export const getNextConnectionState = ({
   if (deviceStatus === DeviceConnectionStatus.DISCONNECTED) {
     return { status: ConnectionStatus.Disconnected, flowType };
   }
-  if (
-    deviceStatus === DeviceConnectionStatus.RECONNECTING ||
-    deviceStatus === DeviceConnectionStatus.CONNECTING
-  ) {
-    const newStatus =
+  if (deviceStatus === DeviceConnectionStatus.CONNECTING) {
+    const hasStartedOver =
       currStatus === ConnectionStatus.NotConnected ||
-      currStatus === ConnectionStatus.FailedToConnect
-        ? ConnectionStatus.Connecting
-        : ConnectionStatus.Reconnecting;
+      currStatus === ConnectionStatus.FailedToConnect;
+    const newStatus = hasStartedOver
+      ? ConnectionStatus.Connecting
+      : ConnectionStatus.ReconnectingExplicitly;
     return { status: newStatus, flowType };
+  }
+  if (deviceStatus === DeviceConnectionStatus.RECONNECTING) {
+    return { status: ConnectionStatus.ReconnectingAutomatically, flowType };
   }
   return undefined;
 };

--- a/src/ml-hooks.tsx
+++ b/src/ml-hooks.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useMemo, useState } from "react";
 import { useBufferedData } from "./buffered-data-hooks";
 import { useConnectActions } from "./connect-actions-hooks";
-import { ConnectionStatus, useConnectStatus } from "./connect-status-hooks";
+import {
+  ConnectionStatus,
+  useConnectStatusUpdater,
+} from "./connect-status-hooks";
 import { useGestureData } from "./gestures-hooks";
 import { useLogging } from "./logging/logging-hooks";
 import { Confidences, mlSettings, predict } from "./ml";
@@ -24,7 +27,7 @@ export const usePrediction = () => {
   const buffer = useBufferedData();
   const logging = useLogging();
   const [status] = useMlStatus();
-  const connectStatus = useConnectStatus();
+  const connectStatus = useConnectStatusUpdater();
   const connection = useConnectActions();
   const [confidences, setConfidences] = useState<Confidences | undefined>();
   const [gestureData] = useGestureData();

--- a/src/ml-hooks.tsx
+++ b/src/ml-hooks.tsx
@@ -1,10 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useBufferedData } from "./buffered-data-hooks";
 import { useConnectActions } from "./connect-actions-hooks";
-import {
-  ConnectionStatus,
-  useConnectStatusUpdater,
-} from "./connect-status-hooks";
+import { ConnectionStatus, useConnectStatus } from "./connect-status-hooks";
 import { useGestureData } from "./gestures-hooks";
 import { useLogging } from "./logging/logging-hooks";
 import { Confidences, mlSettings, predict } from "./ml";
@@ -27,7 +24,7 @@ export const usePrediction = () => {
   const buffer = useBufferedData();
   const logging = useLogging();
   const [status] = useMlStatus();
-  const connectStatus = useConnectStatusUpdater();
+  const [connectStatus] = useConnectStatus();
   const connection = useConnectActions();
   const [confidences, setConfidences] = useState<Confidences | undefined>();
   const [gestureData] = useGestureData();

--- a/src/pages/AddDataPage.tsx
+++ b/src/pages/AddDataPage.tsx
@@ -44,7 +44,7 @@ const AddDataPage = () => {
 
   const noStoredData = useMemo<boolean>(() => {
     const gestureData = gestures.data;
-    return (
+    return !(
       gestureData.length !== 0 &&
       gestureData.some((g) => g.recordings.length > 0)
     );

--- a/src/pages/AddDataPage.tsx
+++ b/src/pages/AddDataPage.tsx
@@ -29,13 +29,14 @@ import {
 import { addDataConfig } from "../pages-config";
 import { createStepPageUrl } from "../urls";
 import { useConnectionStage } from "../connection-stage-hooks";
+import { ConnectionStatus } from "../connect-status-hooks";
 
 const AddDataPage = () => {
   const intl = useIntl();
   const navigate = useNavigate();
   const [gestures] = useGestureData();
   const actions = useGestureActions();
-  const { isConnected } = useConnectionStage();
+  const { isConnected, status } = useConnectionStage();
 
   const hasSufficientData = useMemo(
     () => hasSufficientDataForTraining(gestures.data),
@@ -65,7 +66,9 @@ const AddDataPage = () => {
   return (
     <DefaultPageLayout titleId={`${addDataConfig.id}-title`}>
       <TabView activeStep={addDataConfig.id} />
-      {noStoredData && !isConnected ? (
+      {noStoredData &&
+      !isConnected &&
+      status !== ConnectionStatus.ReconnectingAutomatically ? (
         <ConnectFirstView />
       ) : (
         <AddDataGridView />


### PR DESCRIPTION
Task: https://microbit-global.monday.com/boards/1125389526/pulses/1575488964

Expected behaviour: Error connection cases logic https://paper.dropbox.com/doc/Reconnect-scenarios-copy--CTKwX5AyHNMod6Uq0Qosp8ZtAg-RWeX90ac5YQ9erncFZmWN can be used as reference

**EDITED**
Also implemented bluetooth connection fail dialog since there were conflicting changes
https://microbit-global.monday.com/boards/1125389526/pulses/1576736316

**Other minor changes**
- Includes a small fix in logic in Add Data page so that data can be visible without connecting
- For radio connection dev purposes, when locally developing, a skip button is visible for micro:bit 1 and the device Id is stored in the local storage.
- Close start over session warning dialog when new session is selected