### PR TITLE
Fix missing action name in the first recording dialog of a new session

### DIFF
--- a/src/components/AddDataGridView.tsx
+++ b/src/components/AddDataGridView.tsx
@@ -29,9 +29,8 @@ const headings = [
 
 const AddDataGridView = () => {
   const [gestures] = useGestureData();
-  const [selectedGesture, setSelectedGesture] = useState<GestureData>(
-    gestures.data[0]
-  );
+  const [selectedGestureIdx, setSelectedGestureIdx] = useState<number>(0);
+  const selectedGesture = gestures.data[selectedGestureIdx];
   const showWalkThrough = useMemo<boolean>(
     () =>
       gestures.data.length === 0 ||
@@ -82,15 +81,14 @@ const AddDataGridView = () => {
           <AddDataGridWalkThrough
             gesture={gestures.data[0]}
             startRecording={onOpen}
-            setSelectedGesture={setSelectedGesture}
           />
         ) : (
-          gestures.data.map((g) => (
+          gestures.data.map((g, idx) => (
             <AddDataGridRow
               key={g.ID}
               gesture={g}
               selected={selectedGesture.ID === g.ID}
-              onSelectRow={() => setSelectedGesture(g)}
+              onSelectRow={() => setSelectedGestureIdx(idx)}
               startRecording={onOpen}
             />
           ))

--- a/src/components/AddDataGridView.tsx
+++ b/src/components/AddDataGridView.tsx
@@ -30,7 +30,7 @@ const headings = [
 const AddDataGridView = () => {
   const [gestures] = useGestureData();
   const [selectedGestureIdx, setSelectedGestureIdx] = useState<number>(0);
-  const selectedGesture = gestures.data[selectedGestureIdx];
+  const selectedGesture = gestures.data[selectedGestureIdx] ?? gestures.data[0];
   const showWalkThrough = useMemo<boolean>(
     () =>
       gestures.data.length === 0 ||

--- a/src/components/AddDataGridView.tsx
+++ b/src/components/AddDataGridView.tsx
@@ -1,6 +1,6 @@
 import { Grid, GridProps, useDisclosure } from "@chakra-ui/react";
 import { useEffect, useMemo, useState } from "react";
-import { GestureData, useGestureData } from "../gestures-hooks";
+import { useGestureData } from "../gestures-hooks";
 import AddDataGridRow from "./AddDataGridRow";
 import AddDataGridWalkThrough from "./AddDataGridWalkThrough";
 import HeadingGrid from "./HeadingGrid";

--- a/src/components/AddDataGridView.tsx
+++ b/src/components/AddDataGridView.tsx
@@ -82,6 +82,7 @@ const AddDataGridView = () => {
           <AddDataGridWalkThrough
             gesture={gestures.data[0]}
             startRecording={onOpen}
+            setSelectedGesture={setSelectedGesture}
           />
         ) : (
           gestures.data.map((g) => (

--- a/src/components/AddDataGridWalkThrough.tsx
+++ b/src/components/AddDataGridWalkThrough.tsx
@@ -1,28 +1,20 @@
 import { GridItem, VStack, Image, Text, HStack } from "@chakra-ui/react";
-import { GestureData, useGestureData } from "../gestures-hooks";
+import { GestureData } from "../gestures-hooks";
 import greetingEmojiWithArrowImage from "../images/greeting-emoji-with-arrow.svg";
 import upCurveArrowImage from "../images/curve-arrow-up.svg";
 import GestureNameGridItem from "./GestureNameGridItem";
 import DataRecordingGridItem from "./DataRecordingGridItem";
 import { FormattedMessage } from "react-intl";
-import { useEffect } from "react";
 
 interface AddDataGridWalkThrough {
   gesture: GestureData;
   startRecording: () => void;
-  setSelectedGesture: (g: GestureData) => void;
 }
 
 const AddDataGridWalkThrough = ({
   gesture,
   startRecording,
-  setSelectedGesture,
 }: AddDataGridWalkThrough) => {
-  const [gestures] = useGestureData();
-  useEffect(() => {
-    // Keep selectedGesture up to date with gesture name changes
-    setSelectedGesture(gestures.data[0]);
-  }, [gestures, setSelectedGesture]);
   return (
     <>
       <GestureNameGridItem

--- a/src/components/AddDataGridWalkThrough.tsx
+++ b/src/components/AddDataGridWalkThrough.tsx
@@ -1,20 +1,28 @@
 import { GridItem, VStack, Image, Text, HStack } from "@chakra-ui/react";
-import { GestureData } from "../gestures-hooks";
+import { GestureData, useGestureData } from "../gestures-hooks";
 import greetingEmojiWithArrowImage from "../images/greeting-emoji-with-arrow.svg";
 import upCurveArrowImage from "../images/curve-arrow-up.svg";
 import GestureNameGridItem from "./GestureNameGridItem";
 import DataRecordingGridItem from "./DataRecordingGridItem";
 import { FormattedMessage } from "react-intl";
+import { useEffect } from "react";
 
 interface AddDataGridWalkThrough {
   gesture: GestureData;
   startRecording: () => void;
+  setSelectedGesture: (g: GestureData) => void;
 }
 
 const AddDataGridWalkThrough = ({
   gesture,
   startRecording,
+  setSelectedGesture,
 }: AddDataGridWalkThrough) => {
+  const [gestures] = useGestureData();
+  useEffect(() => {
+    // Keep selectedGesture up to date with gesture name changes
+    setSelectedGesture(gestures.data[0]);
+  }, [gestures, setSelectedGesture]);
   return (
     <>
       <GestureNameGridItem


### PR DESCRIPTION
Use idx of gestures to keep track of selected gesture instead of setting the selected gesture data as a state.
This is so that `selectedGesture` keeps up to date with changes in gesture data.

https://microbit-global.monday.com/boards/1125389526/pulses/1581415104