### PR TITLE
Handle connection status when user hides browser tab 

### DIFF
--- a/src/connect-actions-hooks.tsx
+++ b/src/connect-actions-hooks.tsx
@@ -28,8 +28,11 @@ interface ConnectProviderProps {
 
 export const ConnectProvider = ({ children }: ConnectProviderProps) => {
   const usb = useMemo(() => new MicrobitWebUSBConnection(), []);
-  const bluetooth = useMemo(() => new MicrobitWebBluetoothConnection(), []);
   const logging = useLogging();
+  const bluetooth = useMemo(
+    () => new MicrobitWebBluetoothConnection({ logging }),
+    [logging]
+  );
   const radioBridge = useMemo(
     () =>
       new MicrobitRadioBridgeConnection(usb, {

--- a/src/connect-status-hooks.tsx
+++ b/src/connect-status-hooks.tsx
@@ -136,7 +136,8 @@ export const useConnectStatusUpdater = (
         setConnectionStatus(nextState.status);
       }
     };
-    connectActions.addStatusListener(listener);
+    connectActions.removeStatusListener();
+    connectActions.addStatusListener(listener, currConnType);
     return () => {
       connectActions.removeStatusListener();
     };

--- a/src/connect-status-hooks.tsx
+++ b/src/connect-status-hooks.tsx
@@ -113,8 +113,8 @@ export const useConnectStatusUpdater = (
     useState<boolean>(true);
 
   useEffect(() => {
-    if (!isBrowserTabVisible) {
-      // Handles scenario where user hides browser tab
+    if (!isBrowserTabVisible && currConnType === "radio") {
+      // Show reconnecting when user hides browser tab for radio bridge connection
       setConnectionStatus(ConnectionStatus.ReconnectingAutomatically);
       return;
     }

--- a/src/connect-status-hooks.tsx
+++ b/src/connect-status-hooks.tsx
@@ -136,6 +136,7 @@ export const useConnectStatusUpdater = (
         setConnectionStatus(nextState.status);
       }
     };
+    // Only add relevant connection type status listener
     connectActions.removeStatusListener();
     connectActions.addStatusListener(listener, currConnType);
     return () => {

--- a/src/connection-stage-actions.ts
+++ b/src/connection-stage-actions.ts
@@ -218,6 +218,10 @@ export class ConnectionStageActions {
           flowType,
         });
       }
+      case ConnectionStatus.ReconnectingAutomatically: {
+        // Don't show dialogs when reconnecting automatically
+        return this.setFlowStep(ConnectionFlowStep.None);
+      }
     }
     return;
   };

--- a/src/connection-stage-actions.ts
+++ b/src/connection-stage-actions.ts
@@ -228,6 +228,7 @@ export class ConnectionStageActions {
   };
 
   reconnect = async () => {
+    this.setStatus(ConnectionStatus.ReconnectingExplicitly);
     if (this.stage.connType === "bluetooth") {
       await this.connectBluetooth(false);
     } else {

--- a/src/connection-stage-actions.ts
+++ b/src/connection-stage-actions.ts
@@ -179,6 +179,7 @@ export class ConnectionStageActions {
   };
 
   disconnect = async () => {
+    this.setStatus(ConnectionStatus.Disconnected);
     await this.actions.disconnect();
   };
 

--- a/src/get-next-connection-state.test.ts
+++ b/src/get-next-connection-state.test.ts
@@ -141,10 +141,7 @@ describe("getNextConnectionState for radio connection", () => {
       expectedOnFirstConnectAttempt: false,
       initialHasAttemptedReconnect: false,
       expectedHasAttemptedReconnect: false,
-      expectedNextConnectionState: {
-        status: ConnectionStatus.Disconnected,
-        flowType: ConnectionFlowType.RadioRemote,
-      },
+      expectedNextConnectionState: undefined,
     });
   });
   test("radio connect fail", () => {
@@ -391,10 +388,7 @@ describe("getNextConnectionState for bluetooth connection", () => {
       expectedOnFirstConnectAttempt: false,
       initialHasAttemptedReconnect: false,
       expectedHasAttemptedReconnect: false,
-      expectedNextConnectionState: {
-        status: ConnectionStatus.Disconnected,
-        flowType: ConnectionFlowType.Bluetooth,
-      },
+      expectedNextConnectionState: undefined,
     });
   });
   test("bluetooth did not select device", () => {

--- a/src/get-next-connection-state.test.ts
+++ b/src/get-next-connection-state.test.ts
@@ -113,7 +113,7 @@ describe("getNextConnectionState for radio connection", () => {
     testGetNextConnectionState({
       input: {
         currConnType: "radio",
-        currStatus: ConnectionStatus.Disconnected,
+        currStatus: ConnectionStatus.Connecting,
         deviceStatus: DeviceConnectionStatus.CONNECTED,
         prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
         type: "radioRemote",
@@ -176,10 +176,7 @@ describe("getNextConnectionState for radio connection", () => {
       expectedOnFirstConnectAttempt: false,
       initialHasAttemptedReconnect: false,
       expectedHasAttemptedReconnect: false,
-      expectedNextConnectionState: {
-        status: ConnectionStatus.ReconnectingExplicitly,
-        flowType: ConnectionFlowType.RadioRemote,
-      },
+      expectedNextConnectionState: undefined,
     });
   });
   test("radio reconnecting automatically", () => {
@@ -360,7 +357,7 @@ describe("getNextConnectionState for bluetooth connection", () => {
     testGetNextConnectionState({
       input: {
         currConnType: "bluetooth",
-        currStatus: ConnectionStatus.Disconnected,
+        currStatus: ConnectionStatus.Connecting,
         deviceStatus: DeviceConnectionStatus.CONNECTED,
         prevDeviceStatus: DeviceConnectionStatus.CONNECTING,
         type: "bluetooth",
@@ -442,10 +439,7 @@ describe("getNextConnectionState for bluetooth connection", () => {
       expectedOnFirstConnectAttempt: false,
       initialHasAttemptedReconnect: false,
       expectedHasAttemptedReconnect: false,
-      expectedNextConnectionState: {
-        status: ConnectionStatus.ReconnectingExplicitly,
-        flowType: ConnectionFlowType.Bluetooth,
-      },
+      expectedNextConnectionState: undefined,
     });
   });
   test("bluetooth reconnecting automatically", () => {

--- a/src/get-next-connection-state.test.ts
+++ b/src/get-next-connection-state.test.ts
@@ -254,7 +254,7 @@ describe("getNextConnectionState for radio connection", () => {
       initialOnFirstConnectAttempt: false,
       expectedOnFirstConnectAttempt: false,
       initialHasAttemptedReconnect: true,
-      expectedHasAttemptedReconnect: true,
+      expectedHasAttemptedReconnect: false,
       expectedNextConnectionState: {
         status: ConnectionStatus.FailedToReconnectTwice,
         flowType: ConnectionFlowType.RadioRemote,
@@ -311,7 +311,7 @@ describe("getNextConnectionState for radio connection", () => {
       initialOnFirstConnectAttempt: false,
       expectedOnFirstConnectAttempt: false,
       initialHasAttemptedReconnect: true,
-      expectedHasAttemptedReconnect: true,
+      expectedHasAttemptedReconnect: false,
       expectedNextConnectionState: {
         status: ConnectionStatus.FailedToReconnectTwice,
         flowType: ConnectionFlowType.RadioRemote,
@@ -523,7 +523,7 @@ describe("getNextConnectionState for bluetooth connection", () => {
       initialOnFirstConnectAttempt: false,
       expectedOnFirstConnectAttempt: false,
       initialHasAttemptedReconnect: true,
-      expectedHasAttemptedReconnect: true,
+      expectedHasAttemptedReconnect: false,
       expectedNextConnectionState: {
         status: ConnectionStatus.FailedToReconnectTwice,
         flowType: ConnectionFlowType.Bluetooth,

--- a/src/get-next-connection-state.ts
+++ b/src/get-next-connection-state.ts
@@ -30,7 +30,7 @@ export const getNextConnectionState = ({
   onFirstConnectAttempt,
   setOnFirstConnectAttempt,
 }: GetNextConnectionStateInput): NextConnectionState => {
-if (currStatus === ConnectionStatus.Disconnected) {
+  if (currStatus === ConnectionStatus.Disconnected) {
     // Do not update connection status when user explicitly disconnected connection
     // until user reconnects explicitly
     return undefined;
@@ -146,12 +146,6 @@ if (currStatus === ConnectionStatus.Disconnected) {
   ) {
     setOnFirstConnectAttempt(true);
     return { status: ConnectionStatus.Connecting, flowType };
-  }
-  if (
-    // If reconnecting explicitly by user.
-    deviceStatus === DeviceConnectionStatus.CONNECTING
-  ) {
-    return { status: ConnectionStatus.ReconnectingExplicitly, flowType };
   }
   if (
     // If reconnecting automatically.

--- a/src/get-next-connection-state.ts
+++ b/src/get-next-connection-state.ts
@@ -35,7 +35,6 @@ export const getNextConnectionState = ({
     // until user reconnects explicitly
     return undefined;
   }
-  console.log(type, deviceStatus, prevDeviceStatus);
   const flowType =
     type === "usb"
       ? ConnectionFlowType.RadioBridge

--- a/src/get-next-connection-state.ts
+++ b/src/get-next-connection-state.ts
@@ -58,6 +58,7 @@ export const getNextConnectionState = ({
       // If bridge micro:bit causes radio bridge reconnect to fail twice
       hasAttempedReconnect
     ) {
+      setHasAttemptedReconnect(false);
       return {
         status: ConnectionStatus.FailedToReconnectTwice,
         flowType: ConnectionFlowType.RadioRemote,
@@ -111,6 +112,7 @@ export const getNextConnectionState = ({
     deviceStatus === DeviceConnectionStatus.DISCONNECTED &&
     prevDeviceStatus === DeviceConnectionStatus.CONNECTING
   ) {
+    setHasAttemptedReconnect(false);
     return { status: ConnectionStatus.FailedToReconnectTwice, flowType };
   }
   if (

--- a/src/get-next-connection-state.ts
+++ b/src/get-next-connection-state.ts
@@ -30,6 +30,12 @@ export const getNextConnectionState = ({
   onFirstConnectAttempt,
   setOnFirstConnectAttempt,
 }: GetNextConnectionStateInput): NextConnectionState => {
+if (currStatus === ConnectionStatus.Disconnected) {
+    // Do not update connection status when user explicitly disconnected connection
+    // until user reconnects explicitly
+    return undefined;
+  }
+  console.log(type, deviceStatus, prevDeviceStatus);
   const flowType =
     type === "usb"
       ? ConnectionFlowType.RadioBridge
@@ -46,7 +52,6 @@ export const getNextConnectionState = ({
       currConnType !== "radio" ||
       onFirstConnectAttempt ||
       deviceStatus !== DeviceConnectionStatus.DISCONNECTED ||
-      currStatus === ConnectionStatus.Disconnected ||
       // Ignore usb status when reconnecting.
       // Serial connection gets intentionally disconnected before reconnect.
       currStatus === ConnectionStatus.ReconnectingAutomatically ||
@@ -109,8 +114,7 @@ export const getNextConnectionState = ({
   if (
     // If fails to reconnect twice.
     hasAttempedReconnect &&
-    deviceStatus === DeviceConnectionStatus.DISCONNECTED &&
-    prevDeviceStatus === DeviceConnectionStatus.CONNECTING
+    deviceStatus === DeviceConnectionStatus.DISCONNECTED
   ) {
     setHasAttemptedReconnect(false);
     return { status: ConnectionStatus.FailedToReconnectTwice, flowType };
@@ -131,12 +135,6 @@ export const getNextConnectionState = ({
   ) {
     setHasAttemptedReconnect(true);
     return { status: ConnectionStatus.ConnectionLost, flowType };
-  }
-  if (
-    // If disconnected by user.
-    deviceStatus === DeviceConnectionStatus.DISCONNECTED
-  ) {
-    return { status: ConnectionStatus.Disconnected, flowType };
   }
   const hasStartedOver =
     currStatus === ConnectionStatus.NotConnected ||


### PR DESCRIPTION
**Tab switch issue**

For radio connection, currently, switching tabs causes connection loss dialog to sometimes appear. The changes here sets the connection status to reconnecting when the tab is inactive. 

For bluetooth connection, currently, if you flash and connect with bluetooth, then switch tabs, the connection becomes disconnected. The issue does not occur if you skip flashing. Turns out this is due to the usb connection status affecting the connection status. To fix this, usb is disconnected when connecting to bluetooth.

**Changes**
Add and remove connection status listener depending on whether connection is bluetooth or radio. 
If user switches tab in radio, set connection status as reconnecting automatically.

**Other changes**
- Reset connection states when user failed twice (so that an error after the twice fail dialog is reset to the initial fail dialogs)
- Add logging to bluetooth connection instance