### PR TITLE
Pull the prediction up to the test model page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@microbit-foundation/ml-header-generator": "^0.3.8",
         "@microbit-foundation/react-code-view": "^5.0.2",
         "@microbit-foundation/react-editor-embed": "^1.0.0-controller.mode.47",
-        "@microbit/microbit-connection": "^0.0.0-alpha.18",
+        "@microbit/microbit-connection": "^0.0.0-alpha.19",
         "@tensorflow/tfjs": "^4.20.0",
         "@types/w3c-web-serial": "^1.0.6",
         "@types/w3c-web-usb": "^1.0.6",
@@ -4434,9 +4434,9 @@
       }
     },
     "node_modules/@microbit/microbit-connection": {
-      "version": "0.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/@microbit/microbit-connection/-/microbit-connection-0.0.0-alpha.18.tgz",
-      "integrity": "sha512-/3eFGsdHXwXtQqfyhHfngpsqpX5vM5t9CgR+9qppGW/9eP5J2N+v4zRlGb1dLxmWSsxyRJXE4av4TQ0W9P0zww==",
+      "version": "0.0.0-alpha.19",
+      "resolved": "https://registry.npmjs.org/@microbit/microbit-connection/-/microbit-connection-0.0.0-alpha.19.tgz",
+      "integrity": "sha512-VLOLVKkkxGHA6yzla39/dcU9IOFlIjrYyfkvWvR7ypzCnhJ0moJSsDpPduR4m+WLHDv4SlwEhFHLNvyHfveKnQ==",
       "dependencies": {
         "@microbit/microbit-universal-hex": "^0.2.2",
         "@types/web-bluetooth": "^0.0.20",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@microbit-foundation/ml-header-generator": "^0.3.8",
     "@microbit-foundation/react-code-view": "^5.0.2",
     "@microbit-foundation/react-editor-embed": "^1.0.0-controller.mode.47",
-    "@microbit/microbit-connection": "^0.0.0-alpha.18",
+    "@microbit/microbit-connection": "^0.0.0-alpha.19",
     "@tensorflow/tfjs": "^4.20.0",
     "@types/w3c-web-serial": "^1.0.6",
     "@types/w3c-web-usb": "^1.0.6",

--- a/src/components/GestureNameGridItem.tsx
+++ b/src/components/GestureNameGridItem.tsx
@@ -35,7 +35,7 @@ const GestureNameGridItem = ({
   id,
   selected = false,
   readOnly = false,
-  isTriggered = false,
+  isTriggered = undefined,
 }: GestureNameGridItemProps) => {
   const intl = useIntl();
   const toast = useToast();
@@ -100,12 +100,7 @@ const GestureNameGridItem = ({
         <CardBody p={0} alignContent="center">
           <HStack>
             <HStack>
-              <LedIcon
-                icon={icon}
-                isTestModelPage={readOnly}
-                isTriggered={isTriggered}
-              />
-              ;
+              <LedIcon icon={icon} isTriggered={isTriggered} />;
               {!readOnly && (
                 <LedIconPicker onIconSelected={handleIconSelected} />
               )}

--- a/src/components/LedIcon.tsx
+++ b/src/components/LedIcon.tsx
@@ -4,17 +4,11 @@ import { icons, LedIconType } from "../utils/icons";
 
 interface LedIconProps {
   icon: LedIconType;
-  isTestModelPage?: boolean;
   isTriggered?: boolean;
   size?: string | number;
 }
 
-const LedIcon = ({
-  icon,
-  isTestModelPage,
-  isTriggered,
-  size = 20,
-}: LedIconProps) => {
+const LedIcon = ({ icon, isTriggered, size = 20 }: LedIconProps) => {
   const iconData = icons[icon];
   return (
     <AspectRatio width={size} height={size} ratio={1}>
@@ -25,8 +19,7 @@ const LedIcon = ({
             <LedIconRow
               key={idx}
               data={iconData.substring(start, start + 5)}
-              isTestModelPage={!!isTestModelPage}
-              isTriggered={!!isTriggered}
+              isTriggered={isTriggered}
             />
           );
         })}
@@ -61,15 +54,10 @@ const turnOff = keyframes`
 
 interface LedIconRowProps {
   data: string;
-  isTestModelPage: boolean;
-  isTriggered: boolean;
+  isTriggered?: boolean;
 }
 
-const LedIconRow = ({
-  data,
-  isTestModelPage,
-  isTriggered,
-}: LedIconRowProps) => {
+const LedIconRow = ({ data, isTriggered }: LedIconRowProps) => {
   const turnOnAnimation = `${turnOn} 200ms ease`;
   const turnOffAnimation = `${turnOff} 200ms ease`;
   const getBgColor = useCallback(
@@ -77,15 +65,15 @@ const LedIconRow = ({
       if (!isOn) {
         return "gray.200";
       }
-      if (isTestModelPage && isTriggered) {
+      if (typeof isTriggered === "boolean" && isTriggered) {
         return "green.500";
       }
-      if (isTestModelPage && !isTriggered) {
+      if (typeof isTriggered === "boolean" && !isTriggered) {
         return "gray.600";
       }
       return "brand.500";
     },
-    [isTriggered, isTestModelPage]
+    [isTriggered]
   );
   return (
     <HStack w="100%" h="100%" spacing={0.5}>

--- a/src/components/LiveGraphPanel.tsx
+++ b/src/components/LiveGraphPanel.tsx
@@ -4,17 +4,20 @@ import { MdBolt } from "react-icons/md";
 import { FormattedMessage } from "react-intl";
 import { ConnectionStatus } from "../connect-status-hooks";
 import { useConnectionStage } from "../connection-stage-hooks";
-import { getPredictedGesture, usePrediction } from "../ml-hooks";
 import InfoToolTip from "./InfoToolTip";
 import LedIcon from "./LedIcon";
 import LiveGraph from "./LiveGraph";
-import { useGestureData } from "../gestures-hooks";
+import { Gesture } from "../gestures-hooks";
 
 interface LiveGraphPanelProps {
-  isTestModelPage?: boolean;
+  predictedGesture?: Gesture | undefined;
+  showPredictedGesture?: boolean;
 }
 
-const LiveGraphPanel = ({ isTestModelPage = false }: LiveGraphPanelProps) => {
+const LiveGraphPanel = ({
+  showPredictedGesture,
+  predictedGesture,
+}: LiveGraphPanelProps) => {
   const { actions, status } = useConnectionStage();
   const parentPortalRef = useRef(null);
   const isReconnecting =
@@ -36,10 +39,6 @@ const LiveGraphPanel = ({ isTestModelPage = false }: LiveGraphPanelProps) => {
         };
   }, [actions.reconnect, actions.startConnect, status]);
 
-  const confidences = usePrediction();
-  const [gestures] = useGestureData();
-  const predictedGesture = getPredictedGesture(gestures, confidences);
-
   return (
     <HStack
       position="relative"
@@ -57,7 +56,7 @@ const LiveGraphPanel = ({ isTestModelPage = false }: LiveGraphPanelProps) => {
           right={0}
           px={7}
           py={4}
-          w={`calc(100% - ${isTestModelPage ? "160px" : "0"})`}
+          w={`calc(100% - ${showPredictedGesture ? "160px" : "0"})`}
         >
           <HStack gap={4}>
             <LiveIndicator />
@@ -91,13 +90,12 @@ const LiveGraphPanel = ({ isTestModelPage = false }: LiveGraphPanelProps) => {
       </Portal>
       <HStack position="absolute" width="100%" height="100%" spacing={0}>
         <LiveGraph />
-        {isTestModelPage && (
+        {showPredictedGesture && (
           <Box px={5}>
             <LedIcon
               icon={predictedGesture?.icon ?? "off"}
               size="120px"
-              isTestModelPage={true}
-              isTriggered={true}
+              isTriggered
             />
           </Box>
         )}

--- a/src/components/TestModelGridView.tsx
+++ b/src/components/TestModelGridView.tsx
@@ -17,9 +17,8 @@ import React, { useCallback } from "react";
 import { RiArrowRightLine } from "react-icons/ri";
 import { FormattedMessage, useIntl } from "react-intl";
 import { useConnectionStage } from "../connection-stage-hooks";
-import { useGestureActions, useGestureData } from "../gestures-hooks";
-import { mlSettings } from "../ml";
-import { getPredictedGesture, usePrediction } from "../ml-hooks";
+import { Gesture, useGestureActions, useGestureData } from "../gestures-hooks";
+import { Confidences, mlSettings } from "../ml";
 import { getMakeCodeLang, useSettings } from "../settings";
 import { useMakeCodeProject } from "../user-projects-hooks";
 import CertaintyThresholdGridItem from "./CertaintyThresholdGridItem";
@@ -53,7 +52,15 @@ const headings = [
   },
 ];
 
-const TestModelGridView = () => {
+interface TestModelGridViewProps {
+  predictedGesture: Gesture | undefined;
+  confidences: Confidences | undefined;
+}
+
+const TestModelGridView = ({
+  confidences,
+  predictedGesture,
+}: TestModelGridViewProps) => {
   const intl = useIntl();
   const editCodeDialogDisclosure = useDisclosure();
   const [gestures] = useGestureData();
@@ -63,8 +70,6 @@ const TestModelGridView = () => {
   const { hasStoredProject, userProject, setUserProject } =
     useMakeCodeProject();
 
-  const confidences = usePrediction();
-  const predictedGesture = getPredictedGesture(gestures, confidences);
   const predicationLabel =
     predictedGesture?.name ??
     intl.formatMessage({
@@ -164,6 +169,9 @@ const TestModelGridView = () => {
                   icon,
                   requiredConfidence: threshold,
                 } = gesture;
+                const isTriggered = predictedGesture
+                  ? predictedGesture.ID === ID
+                  : false;
                 return (
                   <React.Fragment key={idx}>
                     <GestureNameGridItem
@@ -171,7 +179,7 @@ const TestModelGridView = () => {
                       name={name}
                       icon={icon}
                       readOnly={true}
-                      isTriggered={predictedGesture?.ID === ID}
+                      isTriggered={isTriggered}
                     />
                     <CertaintyThresholdGridItem
                       onThresholdChange={(val) =>
@@ -181,7 +189,7 @@ const TestModelGridView = () => {
                       requiredConfidence={
                         threshold ?? mlSettings.defaultRequiredConfidence
                       }
-                      isTriggered={predictedGesture?.ID === ID}
+                      isTriggered={isTriggered}
                     />
                     <VStack justifyContent="center" h="full">
                       <Icon

--- a/src/pages/TestModelPage.tsx
+++ b/src/pages/TestModelPage.tsx
@@ -5,17 +5,27 @@ import TestModelGridView from "../components/TestModelGridView";
 import TrainModelFirstView from "../components/TrainModelFirstView";
 import { testModelConfig } from "../pages-config";
 import { MlStage, useMlStatus } from "../ml-status-hooks";
+import { getPredictedGesture, usePrediction } from "../ml-hooks";
+import { useGestureData } from "../gestures-hooks";
 
 const TestModelPage = () => {
   const [{ stage }] = useMlStatus();
-
+  const confidences = usePrediction();
+  const [gestureData] = useGestureData();
+  const predictedGesture = getPredictedGesture(gestureData, confidences);
   return (
     <DefaultPageLayout titleId={`${testModelConfig.id}-title`}>
       <TabView activeStep={testModelConfig.id} />
       {stage === MlStage.TrainingComplete ? (
         <>
-          <TestModelGridView />
-          <LiveGraphPanel isTestModelPage={true} />
+          <TestModelGridView
+            confidences={confidences}
+            predictedGesture={predictedGesture}
+          />
+          <LiveGraphPanel
+            predictedGesture={predictedGesture}
+            showPredictedGesture
+          />
         </>
       ) : (
         <TrainModelFirstView />


### PR DESCRIPTION
Then we can pass it via props to the live graph and grid. Previously we performed the prediction twice.

I've also tried to remove the knowledge of where components are rendered from them in favour of using more focussed props.

I've also updated the connection lib in preparation for setting the LED.