### PR TITLE
Remove not needed mlStatus update in RecordingDialog

### DIFF
--- a/src/components/RecordingDialog.tsx
+++ b/src/components/RecordingDialog.tsx
@@ -69,11 +69,10 @@ const RecordingDialog = ({
 
   const handleCleanup = useCallback(() => {
     setRecordingStatus(RecordingStatus.None);
-    setStatus({ stage: MlStage.NotTrained });
     setCountdownStageIndex(0);
     setProgress(0);
     onClose();
-  }, [onClose, setStatus]);
+  }, [onClose]);
 
   const handleOnClose = useCallback(() => {
     recordingDataSource.cancelRecording();


### PR DESCRIPTION
Fixing the following issue

**Issue**
1. Go to https://review-ml.microbit.org/react.
2. Start new session.
3. Go through connect micro:bit flow.
4. Record a sample. 

**Current behaviour:** Training button is activated and the ml status is NotTrained. 
**Expected behaviour:** ml status should be insufficient data