### PR TITLE
Improve UI state after loading a project

### DIFF
--- a/lang/ui.en.json
+++ b/lang/ui.en.json
@@ -935,6 +935,10 @@
     "defaultMessage": "Privacy policy",
     "description": "Link to view privacy policy"
   },
+  "project-loaded": {
+    "defaultMessage": "Project loaded",
+    "description": "Toast when a new project is loaded"
+  },
   "prototype.warning": {
     "defaultMessage": "This is a prototype version and is subject to change without notice",
     "description": ""

--- a/src/components/DefaultPageLayout.tsx
+++ b/src/components/DefaultPageLayout.tsx
@@ -1,11 +1,18 @@
-import { Flex, Heading, HStack, IconButton, VStack } from "@chakra-ui/react";
+import {
+  Flex,
+  Heading,
+  HStack,
+  IconButton,
+  useToast,
+  VStack,
+} from "@chakra-ui/react";
 import { ReactNode, useCallback, useEffect } from "react";
 import { RiHome2Line } from "react-icons/ri";
 import { FormattedMessage, useIntl } from "react-intl";
 import { useNavigate } from "react-router";
 import { TOOL_NAME } from "../constants";
 import { flags } from "../flags";
-import { createHomePageUrl } from "../urls";
+import { createHomePageUrl, createSessionPageUrl } from "../urls";
 import ActionBar from "./ActionBar";
 import AppLogo from "./AppLogo";
 import ConnectionDialogs from "./ConnectionFlowDialogs";
@@ -15,6 +22,7 @@ import SettingsMenu from "./SettingsMenu";
 import TrainModelDialogs from "./TrainModelFlowDialogs";
 import DownloadProjectDialogs from "./DownloadProjectDialogs";
 import { useStore } from "../store";
+import { SessionPageId } from "../pages-config";
 
 interface DefaultPageLayoutProps {
   titleId: string;
@@ -38,6 +46,27 @@ const DefaultPageLayout = ({
   useEffect(() => {
     document.title = intl.formatMessage({ id: titleId });
   }, [intl, titleId]);
+
+  const toast = useToast();
+  useEffect(() => {
+    return useStore.subscribe(
+      (
+        { projectLoadTimestamp },
+        { projectLoadTimestamp: prevProjectLoadTimestamp }
+      ) => {
+        if (projectLoadTimestamp > prevProjectLoadTimestamp) {
+          // Side effects of loading a project, which MakeCode notifies us of.
+          navigate(createSessionPageUrl(SessionPageId.DataSamples));
+          toast({
+            position: "top",
+            duration: 5_000,
+            title: intl.formatMessage({ id: "project-loaded" }),
+            status: "info",
+          });
+        }
+      }
+    );
+  }, [intl, navigate, toast]);
 
   const handleHomeClick = useCallback(() => {
     navigate(createHomePageUrl());

--- a/src/messages/ui.en.json
+++ b/src/messages/ui.en.json
@@ -1555,6 +1555,12 @@
       "value": "Privacy policy"
     }
   ],
+  "project-loaded": [
+    {
+      "type": 0,
+      "value": "Project loaded"
+    }
+  ],
   "prototype.warning": [
     {
       "type": 0,

--- a/src/store.ts
+++ b/src/store.ts
@@ -64,6 +64,11 @@ export interface State {
   isRecording: boolean;
 
   project: Project;
+  /**
+   * We use this for the UI to tell when we've switched new project,
+   * e.g. to show a toast.
+   */
+  projectLoadTimestamp: number;
   // false if we're sure the user hasn't changed the project, otherwise true
   projectEdited: boolean;
   changedHeaderExpected: boolean;
@@ -147,6 +152,7 @@ export const useStore = create<Store>()(
           } as any,
           ...generateProject({ data: [] }, undefined),
         },
+        projectLoadTimestamp: 0,
         downloadStage: {
           step: DownloadProjectStep.None,
           microbitToFlash: MicrobitToFlash.Default,
@@ -428,6 +434,7 @@ export const useStore = create<Store>()(
             "resetProject"
           );
         },
+
         editorChange(newProject: Project) {
           const actionName = "editorChange";
           set(
@@ -459,10 +466,12 @@ export const useStore = create<Store>()(
 
                 return {
                   project: newProject,
+                  projectLoadTimestamp: Date.now(),
                   // New project loaded externally so we can't know whether its edited.
                   projectEdited: true,
                   gestures: dataset.data,
                   model: undefined,
+                  isEditorOpen: false,
                 };
               } else if (isEditorOpen) {
                 return {


### PR DESCRIPTION
- Close editor if in MakeCode
- Pop a toast to acknowledge the load
- Ensure we're on the data samples page

Bit of a pain as we only find out about it via MakeCode so we add a timestamp to the state that we can watch change.