### PR TITLE
[DO NOT MERGE] Exploring Joyride

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "react-dom": "^18.3.1",
         "react-icons": "^4.12.0",
         "react-intl": "^6.6.8",
+        "react-joyride": "^2.9.2",
         "react-router": "^6.24.0",
         "react-router-dom": "^6.24.0",
         "smoothie": "^1.36.1",
@@ -4128,6 +4129,11 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@gilbarbara/deep-equal": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.3.1.tgz",
+      "integrity": "sha512-I7xWjLs2YSVMc5gGx1Z3ZG1lgFpITPndpi8Ku55GeEIKpACCPQNS/OTqQbxgTCfq0Ncvcc+CrFov96itVh6Qvw=="
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -7837,6 +7843,11 @@
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
       "dev": true
     },
+    "node_modules/deep-diff": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-1.0.2.tgz",
+      "integrity": "sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg=="
+    },
     "node_modules/deep-eql": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
@@ -7891,7 +7902,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9756,6 +9766,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-lite": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-lite/-/is-lite-1.2.1.tgz",
+      "integrity": "sha512-pgF+L5bxC+10hLBgf6R2P4ZZUBOQIIacbdo8YvuCP8/JvsWxG7aZ9p10DYuLtifFci4l3VITphhMlMV4Y+urPw=="
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -11589,6 +11604,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
@@ -11804,6 +11829,41 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
     },
+    "node_modules/react-floater": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/react-floater/-/react-floater-0.7.9.tgz",
+      "integrity": "sha512-NXqyp9o8FAXOATOEo0ZpyaQ2KPb4cmPMXGWkx377QtJkIXHlHRAGer7ai0r0C1kG5gf+KJ6Gy+gdNIiosvSicg==",
+      "dependencies": {
+        "deepmerge": "^4.3.1",
+        "is-lite": "^0.8.2",
+        "popper.js": "^1.16.0",
+        "prop-types": "^15.8.1",
+        "tree-changes": "^0.9.1"
+      },
+      "peerDependencies": {
+        "react": "15 - 18",
+        "react-dom": "15 - 18"
+      }
+    },
+    "node_modules/react-floater/node_modules/@gilbarbara/deep-equal": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.1.2.tgz",
+      "integrity": "sha512-jk+qzItoEb0D0xSSmrKDDzf9sheQj/BAPxlgNxgmOaA3mxpUa6ndJLYGZKsJnIVEQSD8zcTbyILz7I0HcnBCRA=="
+    },
+    "node_modules/react-floater/node_modules/is-lite": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/is-lite/-/is-lite-0.8.2.tgz",
+      "integrity": "sha512-JZfH47qTsslwaAsqbMI3Q6HNNjUuq6Cmzzww50TdP5Esb6e1y2sK2UAaZZuzfAzpoI2AkxoPQapZdlDuP6Vlsw=="
+    },
+    "node_modules/react-floater/node_modules/tree-changes": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/tree-changes/-/tree-changes-0.9.3.tgz",
+      "integrity": "sha512-vvvS+O6kEeGRzMglTKbc19ltLWNtmNt1cpBoSYLj/iEcPVvpJasemKOlxBrmZaCtDJoF+4bwv3m01UKYi8mukQ==",
+      "dependencies": {
+        "@gilbarbara/deep-equal": "^0.1.1",
+        "is-lite": "^0.8.2"
+      }
+    },
     "node_modules/react-focus-lock": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.12.1.tgz",
@@ -11832,6 +11892,15 @@
       "integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
       "peerDependencies": {
         "react": "*"
+      }
+    },
+    "node_modules/react-innertext": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/react-innertext/-/react-innertext-1.1.5.tgz",
+      "integrity": "sha512-PWAqdqhxhHIv80dT9znP2KvS+hfkbRovFp4zFYHFFlOoQLRiawIic81gKb3U1wEyJZgMwgs3JoLtwryASRWP3Q==",
+      "peerDependencies": {
+        "@types/react": ">=0.0.0 <=99",
+        "react": ">=0.0.0 <=99"
       }
     },
     "node_modules/react-intl": {
@@ -11864,6 +11933,39 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-joyride": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/react-joyride/-/react-joyride-2.9.2.tgz",
+      "integrity": "sha512-DQ3m3W/GeoASv4UE9ZaadFp3ACJusV0kjjBe7zTpPwWuHpvEoofc+2TCJkru0lbA+G9l39+vPVttcJA/p1XeSA==",
+      "dependencies": {
+        "@gilbarbara/deep-equal": "^0.3.1",
+        "deep-diff": "^1.0.2",
+        "deepmerge": "^4.3.1",
+        "is-lite": "^1.2.1",
+        "react-floater": "^0.7.9",
+        "react-innertext": "^1.1.5",
+        "react-is": "^16.13.1",
+        "scroll": "^3.0.1",
+        "scrollparent": "^2.1.0",
+        "tree-changes": "^0.11.2",
+        "type-fest": "^4.26.1"
+      },
+      "peerDependencies": {
+        "react": "15 - 18",
+        "react-dom": "15 - 18"
+      }
+    },
+    "node_modules/react-joyride/node_modules/type-fest": {
+      "version": "4.26.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
+      "integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",
@@ -12367,6 +12469,16 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "node_modules/scroll": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scroll/-/scroll-3.0.1.tgz",
+      "integrity": "sha512-pz7y517OVls1maEzlirKO5nPYle9AXsFzTMNJrRGmT951mzpIBy7sNHOg5o/0MQd/NqliCiWnAi0kZneMPFLcg=="
+    },
+    "node_modules/scrollparent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/scrollparent/-/scrollparent-2.1.0.tgz",
+      "integrity": "sha512-bnnvJL28/Rtz/kz2+4wpBjHzWoEzXhVg/TE8BeVGJHUqE8THNIRnDxDWMktwM+qahvlRdvlLdsQfYe+cuqfZeA=="
     },
     "node_modules/seedrandom": {
       "version": "3.0.5",
@@ -13007,6 +13119,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/tree-changes": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/tree-changes/-/tree-changes-0.11.2.tgz",
+      "integrity": "sha512-4gXlUthrl+RabZw6lLvcCDl6KfJOCmrC16BC5CRdut1EAH509Omgg0BfKLY+ViRlzrvYOTWR0FMS2SQTwzumrw==",
+      "dependencies": {
+        "@gilbarbara/deep-equal": "^0.3.1",
+        "is-lite": "^1.2.0"
       }
     },
     "node_modules/ts-api-utils": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "react-dom": "^18.3.1",
     "react-icons": "^4.12.0",
     "react-intl": "^6.6.8",
+    "react-joyride": "^2.9.2",
     "react-router": "^6.24.0",
     "react-router-dom": "^6.24.0",
     "smoothie": "^1.36.1",

--- a/src/components/CertaintyThresholdGridItem.tsx
+++ b/src/components/CertaintyThresholdGridItem.tsx
@@ -50,6 +50,8 @@ const CertaintyThresholdGridItem = ({
         width="fit-content"
         borderWidth={1}
         borderColor="transparent"
+        // Classname for spotlighting component in guided tour.
+        className="certainty-threshold"
       >
         <CardBody
           display="flex"

--- a/src/components/CodeViewCard.tsx
+++ b/src/components/CodeViewCard.tsx
@@ -22,7 +22,14 @@ const CodeViewCard = ({ project }: CodeViewCardProps) => {
       borderColor="brand.500"
       justifyContent="center"
     >
-      <Card w="full" h="full" p={5} objectFit="contain">
+      <Card
+        w="full"
+        h="full"
+        p={5}
+        objectFit="contain"
+        // Classname for spotlighting component in guided tour.
+        className="code-view"
+      >
         <MakeCodeBlocksRendering
           code={project}
           layout={BlockLayout.Flow}

--- a/src/components/CodeViewGridItem.tsx
+++ b/src/components/CodeViewGridItem.tsx
@@ -38,6 +38,8 @@ const CodeViewGridItem = ({
           minW="400px"
           width="fit-content"
           justifyContent="center"
+          // Classname for spotlighting component in guided tour.
+          className="code-view"
         >
           <Box width={width} py={2} px={2} overflow="hidden">
             <MakeCodeBlocksRendering

--- a/src/components/DataRecordingGridItem.tsx
+++ b/src/components/DataRecordingGridItem.tsx
@@ -20,6 +20,9 @@ interface DataRecordingGridItemProps {
   selected: boolean;
   onSelectRow?: () => void;
   startRecording: () => void;
+
+  // For guided tour.
+  cardId?: string;
 }
 
 const DataRecordingGridItem = ({
@@ -56,6 +59,8 @@ const DataRecordingGridItem = ({
           <CardBody display="flex" flexDirection="row" p={1} gap={3}>
             <HStack w="8.25rem" justifyContent="center">
               <IconButton
+                // Classname for spotlighting component in guided tour.
+                className="record-button"
                 ref={closeRecordingDialogFocusRef}
                 height="fit-content"
                 width="fit-content"

--- a/src/components/DefaultPageLayout.tsx
+++ b/src/components/DefaultPageLayout.tsx
@@ -17,7 +17,7 @@ import { useNavigate } from "react-router";
 import { TOOL_NAME } from "../constants";
 import { flags } from "../flags";
 import { useProject } from "../hooks/project-hooks";
-import { SaveStep } from "../model";
+import { GuidedTour, SaveStep } from "../model";
 import { SessionPageId } from "../pages-config";
 import { useSettings, useStore } from "../store";
 import { createHomePageUrl, createSessionPageUrl } from "../urls";
@@ -34,6 +34,10 @@ import SaveDialogs from "./SaveDialogs";
 import SettingsMenu from "./SettingsMenu";
 import ToolbarMenu from "./ToolbarMenu";
 import TrainModelDialogs from "./TrainModelFlowDialogs";
+import Joyride from "react-joyride";
+import GuidedTooltip from "./GuidedTooltip";
+import HiddenBeacon from "./HiddenBeacon";
+import { guidedTourSteps } from "../guided-tour-steps";
 
 interface DefaultPageLayoutProps {
   titleId: string;
@@ -57,6 +61,8 @@ const DefaultPageLayout = ({
   const intl = useIntl();
   const navigate = useNavigate();
   const isEditorOpen = useStore((s) => s.isEditorOpen);
+  const guidedTour = useStore((s) => s.guidedTour);
+
   const { saveHex } = useProject();
   const [settings] = useSettings();
   const toast = useToast();
@@ -109,6 +115,13 @@ const DefaultPageLayout = ({
       )}
       <DownloadDialogs />
       <SaveDialogs />
+      <Joyride
+        steps={guidedTourSteps[guidedTour]}
+        run={guidedTour !== GuidedTour.None}
+        continuous
+        tooltipComponent={GuidedTooltip}
+        beaconComponent={HiddenBeacon}
+      />
       <VStack
         minH="100dvh"
         w="100%"

--- a/src/components/DefaultPageLayout.tsx
+++ b/src/components/DefaultPageLayout.tsx
@@ -13,9 +13,11 @@ import {
 import { ReactNode, useCallback, useEffect } from "react";
 import { RiDownload2Line, RiFolderOpenLine, RiHome2Line } from "react-icons/ri";
 import { FormattedMessage, useIntl } from "react-intl";
+import Joyride from "react-joyride";
 import { useNavigate } from "react-router";
 import { TOOL_NAME } from "../constants";
 import { flags } from "../flags";
+import { guidedTourSteps } from "../guided-tour-steps";
 import { useProject } from "../hooks/project-hooks";
 import { GuidedTour, SaveStep } from "../model";
 import { SessionPageId } from "../pages-config";
@@ -25,6 +27,7 @@ import ActionBar from "./ActionBar";
 import AppLogo from "./AppLogo";
 import ConnectionDialogs from "./ConnectionFlowDialogs";
 import DownloadDialogs from "./DownloadDialogs";
+import GuidedTooltip from "./GuidedTooltip";
 import HelpMenu from "./HelpMenu";
 import LanguageMenuItem from "./LanguageMenuItem";
 import LoadProjectMenuItem from "./LoadProjectMenuItem";
@@ -34,10 +37,6 @@ import SaveDialogs from "./SaveDialogs";
 import SettingsMenu from "./SettingsMenu";
 import ToolbarMenu from "./ToolbarMenu";
 import TrainModelDialogs from "./TrainModelFlowDialogs";
-import Joyride from "react-joyride";
-import GuidedTooltip from "./GuidedTooltip";
-import HiddenBeacon from "./HiddenBeacon";
-import { guidedTourSteps } from "../guided-tour-steps";
 
 interface DefaultPageLayoutProps {
   titleId: string;
@@ -62,6 +61,7 @@ const DefaultPageLayout = ({
   const navigate = useNavigate();
   const isEditorOpen = useStore((s) => s.isEditorOpen);
   const guidedTour = useStore((s) => s.guidedTour);
+  const guidedTourCallback = useStore((s) => s.guidedTourCallback);
 
   const { saveHex } = useProject();
   const [settings] = useSettings();
@@ -118,9 +118,9 @@ const DefaultPageLayout = ({
       <Joyride
         steps={guidedTourSteps[guidedTour]}
         run={guidedTour !== GuidedTour.None}
+        callback={guidedTourCallback}
         continuous
         tooltipComponent={GuidedTooltip}
-        beaconComponent={HiddenBeacon}
       />
       <VStack
         minH="100dvh"

--- a/src/components/GestureNameGridItem.tsx
+++ b/src/components/GestureNameGridItem.tsx
@@ -83,6 +83,8 @@ const GestureNameGridItem = ({
         borderWidth={selected ? 1 : 0}
         onClick={onSelectRow}
         position="relative"
+        // Classname for spotlighting component in guided tour.
+        className="action-name-card"
       >
         {!readOnly && onDeleteAction && (
           <CloseButton

--- a/src/components/GuidedTooltip.tsx
+++ b/src/components/GuidedTooltip.tsx
@@ -1,0 +1,79 @@
+import {
+  Button,
+  CloseButton,
+  Heading,
+  HStack,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import { FormattedMessage } from "react-intl";
+import { TooltipRenderProps } from "react-joyride";
+
+const GuidedTooltip = (props: TooltipRenderProps) => {
+  const {
+    backProps,
+    closeProps,
+    continuous: hasNextButton,
+    index,
+    primaryProps,
+    step,
+    tooltipProps,
+    size: totalNumSteps,
+    isLastStep,
+  } = props;
+
+  const hasBackButton = index > 0;
+
+  return (
+    <VStack
+      backgroundColor="white"
+      borderRadius="md"
+      p={5}
+      gap={2}
+      {...tooltipProps}
+    >
+      <VStack width="100%" alignItems="left" gap={1}>
+        <HStack justifyContent="space-between">
+          {step.title && (
+            <Heading as="h2" fontSize="lg" fontWeight="bold">
+              <FormattedMessage id={step.title as string} />
+            </Heading>
+          )}
+          <CloseButton
+            mt={-5}
+            mr={-3}
+            size="sm"
+            borderRadius="sm"
+            {...closeProps}
+          />
+        </HStack>
+        <Text>
+          <FormattedMessage id={step.content as string} />
+        </Text>
+      </VStack>
+      <HStack justifyContent="space-between" p={0} w="full">
+        <Text>
+          Step {index + 1} of {totalNumSteps}
+        </Text>
+        <HStack gap={2}>
+          {hasBackButton && (
+            <Button {...backProps} variant="secondary" size="sm">
+              <FormattedMessage id="back-action" />
+            </Button>
+          )}
+          {hasNextButton && (
+            <Button {...primaryProps} variant="primary" size="sm">
+              {isLastStep ? (
+                <FormattedMessage id="close-action" />
+              ) : (
+                <FormattedMessage id="connectMB.nextButton" />
+              )}
+            </Button>
+          )}
+        </HStack>
+      </HStack>
+    </VStack>
+  );
+};
+
+export default GuidedTooltip;

--- a/src/components/HiddenBeacon.tsx
+++ b/src/components/HiddenBeacon.tsx
@@ -1,7 +1,0 @@
-import { Box } from "@chakra-ui/react";
-
-const HiddenBeacon = () => {
-  return <Box display="none" />;
-};
-
-export default HiddenBeacon;

--- a/src/components/HiddenBeacon.tsx
+++ b/src/components/HiddenBeacon.tsx
@@ -1,0 +1,7 @@
+import { Box } from "@chakra-ui/react";
+
+const HiddenBeacon = () => {
+  return <Box display="none" />;
+};
+
+export default HiddenBeacon;

--- a/src/components/LiveGraphPanel.tsx
+++ b/src/components/LiveGraphPanel.tsx
@@ -46,6 +46,8 @@ const LiveGraphPanel = ({
       width="100%"
       bgColor="white"
       ref={parentPortalRef}
+      // Used for guided tour
+      id="live-graph"
     >
       <Portal containerRef={parentPortalRef}>
         <HStack

--- a/src/components/TestingModelGridView.tsx
+++ b/src/components/TestingModelGridView.tsx
@@ -163,7 +163,12 @@ const TestingModelGridView = () => {
         >
           <Menu>
             <ButtonGroup isAttached>
-              <Button variant="primary" onClick={openEditor}>
+              <Button
+                variant="primary"
+                onClick={openEditor}
+                // ID for spotlighting component in guided tour.
+                id="edit-in-makecode"
+              >
                 <FormattedMessage id="edit-in-makecode-action" />
               </Button>
               <MoreMenuButton

--- a/src/components/TrainModelFlowDialogs.tsx
+++ b/src/components/TrainModelFlowDialogs.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { useNavigate } from "react-router";
-import { TrainModelDialogStage } from "../model";
+import { GuidedTour, TrainModelDialogStage } from "../model";
 import { SessionPageId } from "../pages-config";
 import { useStore, useSettings } from "../store";
 import { createSessionPageUrl } from "../urls";
@@ -12,6 +12,7 @@ import TrainModelInsufficientDataDialog from "./TrainModelInsufficientDataDialog
 const TrainModelDialogs = () => {
   const stage = useStore((s) => s.trainModelDialogStage);
   const closeTrainModelDialogs = useStore((s) => s.closeTrainModelDialogs);
+  const setGuidedTour = useStore((s) => s.setGuidedTour);
   const navigate = useNavigate();
   const trainModel = useStore((s) => s.trainModel);
   const trainModelProgress = useStore((s) => s.trainModelProgress);
@@ -23,9 +24,10 @@ const TrainModelDialogs = () => {
       const result = await trainModel();
       if (result) {
         navigate(createSessionPageUrl(SessionPageId.TestingModel));
+        setGuidedTour(GuidedTour.TestModelPage);
       }
     },
-    [navigate, setSettings, trainModel]
+    [navigate, setGuidedTour, setSettings, trainModel]
   );
   return (
     <>

--- a/src/connection-stage-actions.ts
+++ b/src/connection-stage-actions.ts
@@ -12,7 +12,7 @@ import {
   ConnectionType,
 } from "./connection-stage-hooks";
 import { getHexFileUrl, HexType } from "./device/get-hex-file";
-import { HexUrl } from "./model";
+import { GuidedTour, HexUrl } from "./model";
 import { downloadHex } from "./utils/fs-util";
 
 type FlowStage = Pick<ConnectionStage, "flowStep" | "flowType">;
@@ -27,7 +27,8 @@ export class ConnectionStageActions {
     private actions: ConnectActions,
     private stage: ConnectionStage,
     private setStage: (stage: ConnectionStage) => void,
-    private setStatus: (status: ConnectionStatus) => void
+    private setStatus: (status: ConnectionStatus) => void,
+    private setGuidedTourSteps: (state: GuidedTour) => void
   ) {}
 
   startConnect = () => {
@@ -193,6 +194,7 @@ export class ConnectionStageActions {
 
   private onConnected = () => {
     this.setFlowStep(ConnectionFlowStep.None);
+    this.setGuidedTourSteps(GuidedTour.DataSamplesPage);
   };
 
   disconnect = async () => {

--- a/src/connection-stage-hooks.tsx
+++ b/src/connection-stage-hooks.tsx
@@ -15,6 +15,7 @@ import {
   useConnectStatus,
   useConnectStatusUpdater,
 } from "./connect-status-hooks";
+import { useStore } from "./store";
 
 export enum ConnectionFlowType {
   ConnectBluetooth = "ConnectBluetooth",
@@ -166,15 +167,17 @@ export const useConnectionStage = (): {
   const [stage, setStage] = connectionStageContextValue;
   const connectActions = useConnectActions();
   const [, setStatus] = useConnectStatus();
+  const setGuidedTour = useStore((s) => s.setGuidedTour);
 
   const actions = useMemo(() => {
     return new ConnectionStageActions(
       connectActions,
       stage,
       setStage,
-      setStatus
+      setStatus,
+      setGuidedTour
     );
-  }, [connectActions, stage, setStage, setStatus]);
+  }, [connectActions, stage, setStage, setStatus, setGuidedTour]);
 
   const status = useConnectStatusUpdater(
     stage.connType,

--- a/src/guided-tour-steps.ts
+++ b/src/guided-tour-steps.ts
@@ -1,36 +1,64 @@
 import { Step } from "react-joyride";
 import { GuidedTour } from "./model";
 
-const commonStepConfig: Partial<Step> = {
-  spotlightPadding: 0,
-  disableBeacon: true,
-};
-
 const dataSamplesPageTourSteps: Step[] = [
   {
     target: "body",
     title: "Welcome!",
     content: "Here is a tour of this Data Samples page.",
     placement: "center" as const,
-    ...commonStepConfig,
+    disableBeacon: true,
   },
   {
     target: "#live-graph",
     title: "Live graph",
     content: "This shows live accelerometer data from the micro:bit.",
-    ...commonStepConfig,
+    spotlightPadding: 0,
+    disableBeacon: true,
   },
   {
     target: "#data-samples-table",
     title: "Data samples for actions",
     content: "This is where you can collect and view data samples.",
-    ...commonStepConfig,
+    spotlightPadding: 0,
+    disableBeacon: true,
+  },
+];
+
+const trainModelTourSteps: Step[] = [
+  {
+    target: "body",
+    title: "You collected your first recording!",
+    content: "Learn how to train a model.",
+    placement: "center" as const,
+    disableBeacon: true,
+  },
+  {
+    target: ".record-button",
+    title: "Collect more recordings",
+    content:
+      "You need at least 3 data samples for 2 actions to train the model.",
+    disableBeacon: true,
+  },
+  {
+    target: "#add-action",
+    title: "Add more actions",
+    content:
+      "You need at least 2 actions each with 3 data samples to train the model.",
+    disableBeacon: true,
+  },
+  {
+    target: "#train-model",
+    title: "Train model",
+    content:
+      "You need at least 2 actions each with 3 data samples to train the model.",
+    disableBeacon: true,
   },
 ];
 
 export const guidedTourSteps: Record<GuidedTour, Step[]> = {
   [GuidedTour.None]: [],
   [GuidedTour.DataSamplesPage]: dataSamplesPageTourSteps,
+  [GuidedTour.CollectDataToTrainModel]: trainModelTourSteps,
   [GuidedTour.HowToTestModel]: dataSamplesPageTourSteps,
-  [GuidedTour.HowToTrainModel]: dataSamplesPageTourSteps,
 };

--- a/src/guided-tour-steps.ts
+++ b/src/guided-tour-steps.ts
@@ -1,0 +1,36 @@
+import { Step } from "react-joyride";
+import { GuidedTour } from "./model";
+
+const commonStepConfig: Partial<Step> = {
+  spotlightPadding: 0,
+  disableBeacon: true,
+};
+
+const dataSamplesPageTourSteps: Step[] = [
+  {
+    target: "body",
+    title: "Welcome!",
+    content: "Here is a tour of this Data Samples page.",
+    placement: "center" as const,
+    ...commonStepConfig,
+  },
+  {
+    target: "#live-graph",
+    title: "Live graph",
+    content: "This shows live accelerometer data from the micro:bit.",
+    ...commonStepConfig,
+  },
+  {
+    target: "#data-samples-table",
+    title: "Data samples for actions",
+    content: "This is where you can collect and view data samples.",
+    ...commonStepConfig,
+  },
+];
+
+export const guidedTourSteps: Record<GuidedTour, Step[]> = {
+  [GuidedTour.None]: [],
+  [GuidedTour.DataSamplesPage]: dataSamplesPageTourSteps,
+  [GuidedTour.HowToTestModel]: dataSamplesPageTourSteps,
+  [GuidedTour.HowToTrainModel]: dataSamplesPageTourSteps,
+};

--- a/src/guided-tour-steps.ts
+++ b/src/guided-tour-steps.ts
@@ -56,9 +56,44 @@ const trainModelTourSteps: Step[] = [
   },
 ];
 
+const testModelPageTourSteps: Step[] = [
+  {
+    title: "You have a trained model!",
+    content: "Learn how to test your model with a connected micro:bit.",
+    target: "body",
+    placement: "center" as const,
+    disableBeacon: true,
+  },
+  {
+    title: "Look out for the estimated action",
+    content:
+      "The action with the green icon indicates that it is the estimated action.",
+    target: ".action-name-card",
+    disableBeacon: true,
+  },
+  {
+    title: "Adjust the recognition point",
+    content: "Move the slider to adjust the recognition point.",
+    target: ".certainty-threshold",
+    disableBeacon: true,
+  },
+  {
+    title: "View your MakeCode project",
+    content: "See what you can do.",
+    target: ".code-view",
+    disableBeacon: true,
+  },
+  {
+    title: "Edit your project in MakeCode",
+    content: "Click here to customise your machine learning micro:bit project.",
+    target: "#edit-in-makecode",
+    disableBeacon: true,
+  },
+];
+
 export const guidedTourSteps: Record<GuidedTour, Step[]> = {
   [GuidedTour.None]: [],
   [GuidedTour.DataSamplesPage]: dataSamplesPageTourSteps,
   [GuidedTour.CollectDataToTrainModel]: trainModelTourSteps,
-  [GuidedTour.HowToTestModel]: dataSamplesPageTourSteps,
+  [GuidedTour.TestModelPage]: testModelPageTourSteps,
 };

--- a/src/model.ts
+++ b/src/model.ts
@@ -149,6 +149,6 @@ export enum SaveStep {
 export enum GuidedTour {
   None = "none",
   DataSamplesPage = "data samples page",
-  HowToTrainModel = "HowToTrainModel",
+  CollectDataToTrainModel = "collect data to train model",
   HowToTestModel = "HowToTestModel",
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -150,5 +150,5 @@ export enum GuidedTour {
   None = "none",
   DataSamplesPage = "data samples page",
   CollectDataToTrainModel = "collect data to train model",
-  HowToTestModel = "HowToTestModel",
+  TestModelPage = "test model page",
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -145,3 +145,10 @@ export enum SaveStep {
    */
   SaveProgress = "progress",
 }
+
+export enum GuidedTour {
+  None = "none",
+  DataSamplesPage = "data samples page",
+  HowToTrainModel = "HowToTrainModel",
+  HowToTestModel = "HowToTestModel",
+}

--- a/src/pages/DataSamplesPage.tsx
+++ b/src/pages/DataSamplesPage.tsx
@@ -79,6 +79,8 @@ const DataSamplesPage = () => {
         >
           <HStack gap={2} alignItems="center">
             <Button
+              // ID for spotlighting component in guided tour.
+              id="add-action"
               variant={hasSufficientData ? "secondary" : "primary"}
               leftIcon={<RiAddLine />}
               onClick={addNewGesture}
@@ -122,6 +124,8 @@ const DataSamplesPage = () => {
             </Button>
           ) : (
             <Button
+              // ID for spotlighting component in guided tour.
+              id="train-model"
               onClick={trainModelFlowStart}
               variant={hasSufficientData ? "primary" : "secondary-disabled"}
             >

--- a/src/pages/DataSamplesPage.tsx
+++ b/src/pages/DataSamplesPage.tsx
@@ -30,6 +30,7 @@ import { useConnectionStage } from "../connection-stage-hooks";
 import { SessionPageId } from "../pages-config";
 import { useHasSufficientDataForTraining, useStore } from "../store";
 import { createSessionPageUrl } from "../urls";
+import { GuidedTour } from "../model";
 
 const DataSamplesPage = () => {
   const intl = useIntl();
@@ -52,9 +53,11 @@ const DataSamplesPage = () => {
     !isConnected &&
     status !== ConnectionStatus.ReconnectingAutomatically;
 
+  const setGuidedTour = useStore((s) => s.setGuidedTour);
   const handleNavigateToModel = useCallback(() => {
     navigate(createSessionPageUrl(SessionPageId.TestingModel));
-  }, [navigate]);
+    setGuidedTour(GuidedTour.TestModelPage);
+  }, [navigate, setGuidedTour]);
 
   return (
     <DefaultPageLayout

--- a/src/pages/DataSamplesPage.tsx
+++ b/src/pages/DataSamplesPage.tsx
@@ -19,13 +19,10 @@ import {
   RiUpload2Line,
 } from "react-icons/ri";
 import { FormattedMessage, useIntl } from "react-intl";
-import Joyride from "react-joyride";
 import { useNavigate } from "react-router";
 import ConnectFirstView from "../components/ConnectFirstView";
 import DataSampleGridView from "../components/DataSampleGridView";
 import DefaultPageLayout from "../components/DefaultPageLayout";
-import GuidedTooltip from "../components/GuidedTooltip";
-import HiddenBeacon from "../components/HiddenBeacon";
 import LiveGraphPanel from "../components/LiveGraphPanel";
 import LoadProjectMenuItem from "../components/LoadProjectMenuItem";
 import { ConnectionStatus } from "../connect-status-hooks";
@@ -59,27 +56,6 @@ const DataSamplesPage = () => {
     navigate(createSessionPageUrl(SessionPageId.TestingModel));
   }, [navigate]);
 
-  const steps = [
-    {
-      target: "body",
-      title: "Welcome!",
-      content: "How to collect data samples",
-      placement: "center" as const,
-    },
-    {
-      target: "#live-graph",
-      title: "Live graph",
-      content: "This shows live accelerometer data from the micro:bit.",
-      spotlightPadding: 0,
-    },
-    {
-      target: "#data-samples-table",
-      title: "Collect data samples for actions",
-      content: "Follow the prompts to collect data samples for an action.",
-      spotlightPadding: 0,
-    },
-  ];
-
   return (
     <DefaultPageLayout
       titleId={`${SessionPageId.DataSamples}-title`}
@@ -87,12 +63,6 @@ const DataSamplesPage = () => {
       showHomeButton
       showSaveButton
     >
-      <Joyride
-        steps={steps}
-        continuous
-        tooltipComponent={GuidedTooltip}
-        beaconComponent={HiddenBeacon}
-      />
       <VStack flexGrow={1} id="data-samples-table">
         {showConnectFirstView ? <ConnectFirstView /> : <DataSampleGridView />}
       </VStack>

--- a/src/pages/DataSamplesPage.tsx
+++ b/src/pages/DataSamplesPage.tsx
@@ -19,10 +19,13 @@ import {
   RiUpload2Line,
 } from "react-icons/ri";
 import { FormattedMessage, useIntl } from "react-intl";
+import Joyride from "react-joyride";
 import { useNavigate } from "react-router";
 import ConnectFirstView from "../components/ConnectFirstView";
 import DataSampleGridView from "../components/DataSampleGridView";
 import DefaultPageLayout from "../components/DefaultPageLayout";
+import GuidedTooltip from "../components/GuidedTooltip";
+import HiddenBeacon from "../components/HiddenBeacon";
 import LiveGraphPanel from "../components/LiveGraphPanel";
 import LoadProjectMenuItem from "../components/LoadProjectMenuItem";
 import { ConnectionStatus } from "../connect-status-hooks";
@@ -30,8 +33,6 @@ import { useConnectionStage } from "../connection-stage-hooks";
 import { SessionPageId } from "../pages-config";
 import { useHasSufficientDataForTraining, useStore } from "../store";
 import { createSessionPageUrl } from "../urls";
-import Joyride from "react-joyride";
-import GuidedTooltip from "../components/GuidedTooltip";
 
 const DataSamplesPage = () => {
   const intl = useIntl();
@@ -75,6 +76,7 @@ const DataSamplesPage = () => {
       target: "#data-samples-table",
       title: "Collect data samples for actions",
       content: "Follow the prompts to collect data samples for an action.",
+      spotlightPadding: 0,
     },
   ];
 
@@ -85,7 +87,12 @@ const DataSamplesPage = () => {
       showHomeButton
       showSaveButton
     >
-      <Joyride steps={steps} continuous tooltipComponent={GuidedTooltip} />
+      <Joyride
+        steps={steps}
+        continuous
+        tooltipComponent={GuidedTooltip}
+        beaconComponent={HiddenBeacon}
+      />
       <VStack flexGrow={1} id="data-samples-table">
         {showConnectFirstView ? <ConnectFirstView /> : <DataSampleGridView />}
       </VStack>

--- a/src/pages/DataSamplesPage.tsx
+++ b/src/pages/DataSamplesPage.tsx
@@ -30,6 +30,8 @@ import { useConnectionStage } from "../connection-stage-hooks";
 import { SessionPageId } from "../pages-config";
 import { useHasSufficientDataForTraining, useStore } from "../store";
 import { createSessionPageUrl } from "../urls";
+import Joyride from "react-joyride";
+import GuidedTooltip from "../components/GuidedTooltip";
 
 const DataSamplesPage = () => {
   const intl = useIntl();
@@ -56,6 +58,26 @@ const DataSamplesPage = () => {
     navigate(createSessionPageUrl(SessionPageId.TestingModel));
   }, [navigate]);
 
+  const steps = [
+    {
+      target: "body",
+      title: "Welcome!",
+      content: "How to collect data samples",
+      placement: "center" as const,
+    },
+    {
+      target: "#live-graph",
+      title: "Live graph",
+      content: "This shows live accelerometer data from the micro:bit.",
+      spotlightPadding: 0,
+    },
+    {
+      target: "#data-samples-table",
+      title: "Collect data samples for actions",
+      content: "Follow the prompts to collect data samples for an action.",
+    },
+  ];
+
   return (
     <DefaultPageLayout
       titleId={`${SessionPageId.DataSamples}-title`}
@@ -63,7 +85,10 @@ const DataSamplesPage = () => {
       showHomeButton
       showSaveButton
     >
-      {showConnectFirstView ? <ConnectFirstView /> : <DataSampleGridView />}
+      <Joyride steps={steps} continuous tooltipComponent={GuidedTooltip} />
+      <VStack flexGrow={1} id="data-samples-table">
+        {showConnectFirstView ? <ConnectFirstView /> : <DataSampleGridView />}
+      </VStack>
       <VStack w="full" flexShrink={0} bottom={0} gap={0} bg="gray.25">
         <HStack
           justifyContent="space-between"

--- a/src/store.ts
+++ b/src/store.ts
@@ -16,6 +16,7 @@ import {
   DownloadStep,
   Gesture,
   GestureData,
+  GuidedTour,
   MicrobitToFlash,
   RecordingData,
   SaveState,
@@ -82,6 +83,8 @@ export interface State {
 
   trainModelProgress: number;
   trainModelDialogStage: TrainModelDialogStage;
+
+  guidedTour: GuidedTour;
 }
 
 export interface Actions {
@@ -106,6 +109,7 @@ export interface Actions {
   closeTrainModelDialogs: () => void;
   trainModel(): Promise<boolean>;
   setSettings(update: Partial<Settings>): void;
+  setGuidedTour: (state: GuidedTour) => void;
   /**
    * Resets the project.
    */
@@ -173,6 +177,7 @@ export const useStore = create<Store>()(
         // This dialog flow spans two pages
         trainModelDialogStage: TrainModelDialogStage.Closed,
         trainModelProgress: 0,
+        guidedTour: GuidedTour.None,
 
         setSettings(update: Partial<Settings>) {
           set(
@@ -507,6 +512,10 @@ export const useStore = create<Store>()(
             false,
             "projectFlushedToEditor"
           );
+        },
+
+        setGuidedTour(guidedTour: GuidedTour) {
+          set({ guidedTour });
         },
       }),
       {


### PR DESCRIPTION
### To do
- [ ] Add placeholder strings to ui.en.json.
- [ ] Only show tour once. Store in local storage whether or not the tour has been completed/closed.
- [ ] Add "Tour" on help menu to re-trigger tour. **Which tour should be triggered on the data samples page?**

### Other uncertainties
**When do we want the tours to be triggered?**
At the moment, the tours are triggered as follows:
- Data samples page tour is triggered once micro:bit is connected.
- Collect data to train model tour is triggered once only one recording is collected. 
- Testing model page tour is triggered on navigating to test model page (including after training data).

**Do we want to add a skip button?** 
**Is the current behaviour of close button expected?**
**What happens if the user imports data in their first use of the tool? Which tour should we show in the data samples page?**

