### PR TITLE
Only ask to connect first in data samples page when not connected

### DIFF
--- a/src/pages/DataSamplesPage.tsx
+++ b/src/pages/DataSamplesPage.tsx
@@ -44,13 +44,10 @@ const DataSamplesPage = () => {
   const { isConnected, status } = useConnectionStage();
 
   const hasSufficientData = useHasSufficientDataForTraining();
-  const hasAnyRecordings = gestures.some((g) => g.recordings.length > 0);
   const isAddNewGestureDisabled =
     !isConnected || gestures.some((g) => g.name.length === 0);
   const showConnectFirstView =
-    !hasAnyRecordings &&
-    !isConnected &&
-    status !== ConnectionStatus.ReconnectingAutomatically;
+    !isConnected && status !== ConnectionStatus.ReconnectingAutomatically;
 
   const handleNavigateToModel = useCallback(() => {
     navigate(createSessionPageUrl(SessionPageId.TestingModel));


### PR DESCRIPTION
Small fix

**Repro steps**
1. Start new session.
2. Connect micro:bit
3. Add action name.
4. Add a recording.
5. Delete just the recording.

**Current behaviour:** Data samples page asks user to connect micro:bit. 
**Expected behaviour:** The user should not be asked to connect micro:bit since it is already connected.