### PR TITLE
Show data even if micro:bit not connected

### DIFF
--- a/src/pages/DataSamplesPage.tsx
+++ b/src/pages/DataSamplesPage.tsx
@@ -46,8 +46,16 @@ const DataSamplesPage = () => {
   const hasSufficientData = useHasSufficientDataForTraining();
   const isAddNewGestureDisabled =
     !isConnected || gestures.some((g) => g.name.length === 0);
+
+  const hasNoData =
+    gestures.length === 1 &&
+    gestures[0].name.length === 0 &&
+    gestures[0].recordings.length === 0;
+
   const showConnectFirstView =
-    !isConnected && status !== ConnectionStatus.ReconnectingAutomatically;
+    hasNoData &&
+    !isConnected &&
+    status !== ConnectionStatus.ReconnectingAutomatically;
 
   const handleNavigateToModel = useCallback(() => {
     navigate(createSessionPageUrl(SessionPageId.TestingModel));


### PR DESCRIPTION
Regression in previous bug fix: https://github.com/microbit-foundation/ml-trainer/pull/322

Imported data is no longer shown when a micro:bit is not connected.