### PR TITLE
Tweak recorded data graph color

### DIFF
--- a/src/recording-graph.ts
+++ b/src/recording-graph.ts
@@ -62,7 +62,7 @@ export const getConfig = ({
         },
         {
           label: "y",
-          borderColor: "brand2",
+          borderColor: "green",
           borderWidth: 1,
           pointRadius: 0,
           pointHoverRadius: 0,


### PR DESCRIPTION
Revert color of y-line to be green as it is in the prototype version

Before

<img width="837" alt="Screenshot 2024-10-07 at 10 46 28" src="https://github.com/user-attachments/assets/24ebee24-b42f-450a-80a3-bc4b1f484aac">

After

<img width="728" alt="Screenshot 2024-10-07 at 10 47 32" src="https://github.com/user-attachments/assets/9d4c8234-4f42-4f76-ad3b-4dcd5332ecf1">
