### PR TITLE
Fix beta warning notice to the top

### DIFF
--- a/src/components/DataSampleGridView.tsx
+++ b/src/components/DataSampleGridView.tsx
@@ -24,7 +24,7 @@ const gridCommonProps: Partial<GridProps> = {
   gridTemplateColumns: "290px 1fr",
   gap: 3,
   px: 10,
-  mb: 2,
+  py: 2,
   w: "100%",
 };
 

--- a/src/components/DefaultPageLayout.tsx
+++ b/src/components/DefaultPageLayout.tsx
@@ -102,39 +102,41 @@ const DefaultPageLayout = ({
         spacing={0}
         bgColor="whitesmoke"
       >
-        <ActionBar
-          zIndex={2}
-          position="sticky"
-          top={0}
-          itemsCenter={
-            <>
-              {showPageTitle && (
-                <Heading size="md" fontWeight="normal" color="white">
-                  <FormattedMessage id={titleId} />
-                </Heading>
-              )}
-            </>
-          }
-          itemsLeft={toolbarItemsLeft || <AppLogo />}
-          itemsRight={
-            <>
-              <HStack spacing={3} display={{ base: "none", lg: "flex" }}>
-                {toolbarItemsRight}
-                <SettingsMenu />
-              </HStack>
-              <HelpMenu />
-              <ToolbarMenu
-                isMobile
-                variant="plain"
-                label={intl.formatMessage({ id: "main-menu" })}
-              >
-                {menuItems}
-                <LanguageMenuItem />
-              </ToolbarMenu>
-            </>
-          }
-        />
-        {flags.preReleaseNotice && <PreReleaseNotice />}
+        <VStack zIndex={1} position="sticky" top={0} gap={0}>
+          <ActionBar
+            zIndex={2}
+            position="sticky"
+            top={0}
+            itemsCenter={
+              <>
+                {showPageTitle && (
+                  <Heading size="md" fontWeight="normal" color="white">
+                    <FormattedMessage id={titleId} />
+                  </Heading>
+                )}
+              </>
+            }
+            itemsLeft={toolbarItemsLeft || <AppLogo />}
+            itemsRight={
+              <>
+                <HStack spacing={3} display={{ base: "none", lg: "flex" }}>
+                  {toolbarItemsRight}
+                  <SettingsMenu />
+                </HStack>
+                <HelpMenu />
+                <ToolbarMenu
+                  isMobile
+                  variant="plain"
+                  label={intl.formatMessage({ id: "main-menu" })}
+                >
+                  {menuItems}
+                  <LanguageMenuItem />
+                </ToolbarMenu>
+              </>
+            }
+          />
+          {flags.preReleaseNotice && <PreReleaseNotice />}
+        </VStack>
         <Flex flexGrow={1} flexDir="column">
           {children}
         </Flex>

--- a/src/components/DefaultPageLayout.tsx
+++ b/src/components/DefaultPageLayout.tsx
@@ -104,9 +104,7 @@ const DefaultPageLayout = ({
       >
         <VStack zIndex={1} position="sticky" top={0} gap={0}>
           <ActionBar
-            zIndex={2}
-            position="sticky"
-            top={0}
+            w="100%"
             itemsCenter={
               <>
                 {showPageTitle && (

--- a/src/components/PreReleaseNotice.tsx
+++ b/src/components/PreReleaseNotice.tsx
@@ -19,6 +19,7 @@ const PreReleaseNotice = () => {
         onClose={feedbackDialogDisclosure.onClose}
       />
       <Flex
+        w="100%"
         bgColor="gray.800"
         color="white"
         p={1}


### PR DESCRIPTION
https://microbit-global.monday.com/boards/1550536443/pulses/1656908071

Additionally, small styling fix for data grid view to prevent unexpected gaps when there are many actions that vertical scrolling is enabled

<img width="565" alt="Screenshot 2024-10-07 at 16 27 02" src="https://github.com/user-attachments/assets/906e2485-b47f-4975-8cf3-6a5159076301">


