### PR TITLE
Reset projectEdited state on starting new session

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -216,6 +216,7 @@ export const useStore = create<Store>()(
               gestures: [],
               model: undefined,
               project: createUntitledProject(),
+              projectEdited: false,
               appEditNeedsFlushToEditor: true,
               timestamp: Date.now(),
             },


### PR DESCRIPTION
This was previously leading to blank areas being shown where the default MakeCode blocks should have been rendered.