### PR TITLE
First cut in improving keyboard navigation and screen reading

### DIFF
--- a/lang/ui.en.json
+++ b/lang/ui.en.json
@@ -1,4 +1,8 @@
 {
+  "aarhus-university-alt": {
+    "defaultMessage": "Aarhus University",
+    "description": "Alt text for Aarhus University logo image in about dialog"
+  },
   "about": {
     "defaultMessage": "About",
     "description": "Menu item link to view information about app"
@@ -58,6 +62,10 @@
   "cancel-action": {
     "defaultMessage": "Cancel",
     "description": "Cancel button text"
+  },
+  "certainty-label": {
+    "defaultMessage": "certainty level for {action}: {currentConfidence} percent",
+    "description": "Label for certainty level of an action"
   },
   "close-action": {
     "defaultMessage": "Close",
@@ -719,6 +727,10 @@
     "defaultMessage": "Home",
     "description": "Home button text"
   },
+  "homepage-alt": {
+    "defaultMessage": "image of graph showing x, y, z graph lines representing micro:bit accelerometer data ",
+    "description": "Alt text for image in homepage"
+  },
   "homepage-description": {
     "defaultMessage": "Train a machine learning model on your own movement data and run it on your micro:bit.",
     "description": "Home page description"
@@ -832,7 +844,7 @@
     "description": "Open last session title"
   },
   "newpage-new-session-subtitle": {
-    "defaultMessage": "Connect your micro:bit and collect movement data to build a machine learning model",
+    "defaultMessage": "Connect your micro:bit and collect movement data to build a machine learning model.",
     "description": "Start new session subtitle"
   },
   "newpage-new-session-title": {
@@ -939,6 +951,10 @@
     "defaultMessage": "Follow these instructions to restart the connection process.",
     "description": ""
   },
+  "recording-graph-label": {
+    "defaultMessage": "image of graph showing x, y, z graph lines representing micro:bit accelerometer data in one recording",
+    "description": "Label for recording graph"
+  },
   "reload-action": {
     "defaultMessage": "Click to reload the page",
     "description": "Reload page button text"
@@ -990,6 +1006,10 @@
   "start-training-action": {
     "defaultMessage": "Start training",
     "description": "Start training button text"
+  },
+  "steps-alt": {
+    "defaultMessage": "diagram showing the iterative process of collecting data, training a model, testing the model, and improving the model by improving the data collected before finally coding using the model.",
+    "description": "Alt text for the step-by-step home page diagram"
   },
   "steps-code": {
     "defaultMessage": "Code",

--- a/lang/ui.en.json
+++ b/lang/ui.en.json
@@ -1,7 +1,7 @@
 {
   "aarhus-university-alt": {
     "defaultMessage": "Aarhus University",
-    "description": "Alt text for Aarhus University logo image in about dialog"
+    "description": "Alt text for Aarhus University logo in about dialog"
   },
   "about": {
     "defaultMessage": "About",
@@ -64,8 +64,8 @@
     "description": "Cancel button text"
   },
   "certainty-label": {
-    "defaultMessage": "certainty level for {action}: {currentConfidence} percent",
-    "description": "Label for certainty level of an action"
+    "defaultMessage": "certainty for {action}: {currentConfidence} percent",
+    "description": "Label for certainty of an action"
   },
   "close-action": {
     "defaultMessage": "Close",
@@ -728,7 +728,7 @@
     "description": "Home button text"
   },
   "homepage-alt": {
-    "defaultMessage": "image of graph showing x, y, z graph lines representing micro:bit accelerometer data ",
+    "defaultMessage": "graph showing x, y, z graph lines representing micro:bit accelerometer data",
     "description": "Alt text for image in homepage"
   },
   "homepage-description": {
@@ -952,7 +952,7 @@
     "description": ""
   },
   "recording-graph-label": {
-    "defaultMessage": "image of graph showing x, y, z graph lines representing micro:bit accelerometer data in one recording",
+    "defaultMessage": "graph showing micro:bit x, y, z accelerometer data for one recording",
     "description": "Label for recording graph"
   },
   "reload-action": {

--- a/src/components/AboutDialog.tsx
+++ b/src/components/AboutDialog.tsx
@@ -71,7 +71,11 @@ const AboutDialog = ({ isOpen, onClose, finalFocusRef }: AboutDialogProps) => {
             <VStack spacing={8} pl={5} pr={5} pt={5}>
               <HStack justifyContent="center" gap={8}>
                 {OrgLogo && <OrgLogo fill="#000" color="black" height={55} />}
-                <Image src={aarhusLogo} h="55px" />
+                <Image
+                  src={aarhusLogo}
+                  h="55px"
+                  alt={intl.formatMessage({ id: "aarhus-university-alt" })}
+                />
               </HStack>
               <Text textAlign="center">
                 <FormattedMessage

--- a/src/components/BrokenFirmwareDialog.tsx
+++ b/src/components/BrokenFirmwareDialog.tsx
@@ -1,12 +1,12 @@
 import {
   Button,
   HStack,
-  Heading,
   Icon,
   Modal,
   ModalBody,
   ModalContent,
   ModalFooter,
+  ModalHeader,
   ModalOverlay,
   Text,
   VStack,
@@ -39,56 +39,54 @@ const BrokenFirmwareDialog = ({
       isCentered
     >
       <ModalOverlay>
-        <ModalContent p={8}>
+        <ModalContent>
+          <ModalHeader>
+            <FormattedMessage id="connectMB.usb.firmwareBroken.heading" />
+          </ModalHeader>
           <ModalBody>
-            <VStack width="100%" alignItems="left" gap={5}>
-              <Heading as="h2" fontSize="xl" fontWeight="bold">
-                <FormattedMessage id="connectMB.usb.firmwareBroken.heading" />
-              </Heading>
-              <VStack gap={5} textAlign="left" w="100%">
-                <Text w="100%">
-                  <FormattedMessage id="connectMB.usb.firmwareBroken.content1" />
-                </Text>
-                <Text w="100%">
-                  <FormattedMessage
-                    id="connectMB.usb.firmwareBroken.content2"
-                    values={{
-                      link: (chunks: ReactNode) => (
-                        <Link
-                          color="brand.600"
-                          href="https://microbit.org/get-started/user-guide/firmware/"
-                          target="_blank"
-                          rel="noopener"
-                        >
-                          {chunks}
-                        </Link>
-                      ),
-                    }}
-                  />
-                </Text>
-                <Text w="100%">
-                  <Link
+            <VStack gap={5} textAlign="left" w="100%">
+              <Text w="100%">
+                <FormattedMessage id="connectMB.usb.firmwareBroken.content1" />
+              </Text>
+              <Text w="100%">
+                <FormattedMessage
+                  id="connectMB.usb.firmwareBroken.content2"
+                  values={{
+                    link: (chunks: ReactNode) => (
+                      <Link
+                        color="brand.600"
+                        href="https://microbit.org/get-started/user-guide/firmware/"
+                        target="_blank"
+                        rel="noopener"
+                      >
+                        {chunks}
+                      </Link>
+                    ),
+                  }}
+                />
+              </Text>
+              <Text w="100%">
+                <Link
+                  color="brand.600"
+                  href="https://microbit.org/get-started/user-guide/firmware/"
+                  target="_blank"
+                  rel="noopener"
+                  display="flex"
+                  flexDirection="row"
+                  gap={1}
+                >
+                  <FormattedMessage id="connectMB.usb.firmwareBroken.content3" />
+                  <Icon
+                    as={RiExternalLinkLine}
+                    boxSize={5}
                     color="brand.600"
-                    href="https://microbit.org/get-started/user-guide/firmware/"
-                    target="_blank"
-                    rel="noopener"
-                    display="flex"
-                    flexDirection="row"
-                    gap={1}
-                  >
-                    <FormattedMessage id="connectMB.usb.firmwareBroken.content3" />
-                    <Icon
-                      as={RiExternalLinkLine}
-                      boxSize={5}
-                      color="brand.600"
-                      position="relative"
-                    />
-                  </Link>
-                </Text>
-              </VStack>
+                    position="relative"
+                  />
+                </Link>
+              </Text>
             </VStack>
           </ModalBody>
-          <ModalFooter justifyContent="end" p={0}>
+          <ModalFooter justifyContent="end">
             <HStack gap={5}>
               <Button onClick={onClose} variant="secondary" size="lg">
                 <FormattedMessage id="cancel-action" />

--- a/src/components/CertaintyThresholdGridItem.tsx
+++ b/src/components/CertaintyThresholdGridItem.tsx
@@ -24,6 +24,7 @@ interface CertaintyThresholdGridItemProps {
   currentConfidence?: number;
   onThresholdChange: (val: number) => void;
   isTriggered: boolean;
+  actionName: string;
 }
 
 const CertaintyThresholdGridItem = ({
@@ -31,6 +32,7 @@ const CertaintyThresholdGridItem = ({
   currentConfidence = 0,
   onThresholdChange,
   isTriggered,
+  actionName,
 }: CertaintyThresholdGridItemProps) => {
   const intl = useIntl();
   const barWidth = 240;
@@ -71,6 +73,12 @@ const CertaintyThresholdGridItem = ({
               colorScheme={colorScheme}
             />
             <PercentageDisplay
+              ariaLabel={intl.formatMessage(
+                {
+                  id: "certainty-label",
+                },
+                { currentConfidence, action: actionName }
+              )}
               value={currentConfidence}
               colorScheme={colorScheme}
             />

--- a/src/components/ConnectContainerDialog.tsx
+++ b/src/components/ConnectContainerDialog.tsx
@@ -8,8 +8,8 @@ import {
 import {
   Button,
   HStack,
-  Heading,
   ModalCloseButton,
+  ModalHeader,
   VStack,
 } from "@chakra-ui/react";
 import { ReactNode } from "react";
@@ -46,20 +46,17 @@ const ConnectContainerDialog = ({
       isCentered
     >
       <ModalOverlay>
-        <ModalContent p={8}>
+        <ModalContent>
+          <ModalHeader as="h2">
+            <FormattedMessage id={headingId} />
+          </ModalHeader>
+          <ModalCloseButton />
           <ModalBody>
-            <ModalCloseButton />
-            <VStack width="100%" alignItems="left" gap={5}>
-              <Heading as="h2" fontSize="xl" fontWeight="bold">
-                <FormattedMessage id={headingId} />
-              </Heading>
+            <VStack width="100%" alignItems="left">
               {children}
             </VStack>
           </ModalBody>
-          <ModalFooter
-            justifyContent={footerLeft ? "space-between" : "end"}
-            p={0}
-          >
+          <ModalFooter justifyContent={footerLeft ? "space-between" : "end"}>
             {footerLeft && footerLeft}
             <HStack gap={5}>
               {onBackClick && (

--- a/src/components/ConnectErrorDialog.tsx
+++ b/src/components/ConnectErrorDialog.tsx
@@ -1,13 +1,13 @@
 import {
   Button,
   HStack,
-  Heading,
   ListItem,
   Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
+  ModalHeader,
   ModalOverlay,
   Text,
   UnorderedList,
@@ -85,15 +85,15 @@ const ReconnectErrorDialog = ({
       isCentered
     >
       <ModalOverlay>
-        <ModalContent p={8}>
-          <ModalBody px={0}>
-            <ModalCloseButton />
+        <ModalContent>
+          <ModalHeader>
+            <FormattedMessage
+              id={`${errorTextIdPrefix}.${flowTypeText}Heading`}
+            />
+          </ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
             <VStack width="100%" alignItems="left" gap={5}>
-              <Heading as="h2" fontSize="xl" fontWeight="bold">
-                <FormattedMessage
-                  id={`${errorTextIdPrefix}.${flowTypeText}Heading`}
-                />
-              </Heading>
               <VStack gap={3} textAlign="left" w="100%">
                 <Text w="100%">
                   <FormattedMessage
@@ -115,7 +115,7 @@ const ReconnectErrorDialog = ({
               </VStack>
             </VStack>
           </ModalBody>
-          <ModalFooter justifyContent="space-between" px={0} pb={0}>
+          <ModalFooter justifyContent="space-between">
             <ExternalLink
               textId="connectMB.troubleshooting"
               href={supportLinks.troubleshooting}

--- a/src/components/DataRecordingGridItem.tsx
+++ b/src/components/DataRecordingGridItem.tsx
@@ -94,7 +94,13 @@ const DataRecordingGridItem = ({
                     handleDeleteRecording(idx);
                   }}
                 />
-                <RecordingGraph data={recording.data} />
+                <RecordingGraph
+                  data={recording.data}
+                  role="image"
+                  aria-label={intl.formatMessage({
+                    id: "recording-graph-label",
+                  })}
+                />
               </HStack>
             ))}
           </CardBody>

--- a/src/components/DefaultPageLayout.tsx
+++ b/src/components/DefaultPageLayout.tsx
@@ -32,7 +32,6 @@ import PreReleaseNotice from "./PreReleaseNotice";
 import SaveDialogs from "./SaveDialogs";
 import SettingsMenu from "./SettingsMenu";
 import ToolbarMenu from "./ToolbarMenu";
-import TrainModelDialogs from "./TrainModelFlowDialogs";
 import ProjectDropTarget from "./ProjectDropTarget";
 import React from "react";
 import {
@@ -112,7 +111,6 @@ const DefaultPageLayout = ({
         isTrainDialogClosed &&
         isTourClosed &&
         isSaveDialogClosed && <ConnectionDialogs />}
-      {!isEditorOpen && <TrainModelDialogs />}
       {!isEditorOpen && <Tour />}
       <DownloadDialogs />
       <SaveDialogs />

--- a/src/components/DownloadHelpDialog.tsx
+++ b/src/components/DownloadHelpDialog.tsx
@@ -1,7 +1,6 @@
 import {
   Button,
   Checkbox,
-  Heading,
   HStack,
   Image,
   Modal,
@@ -9,14 +8,15 @@ import {
   ModalCloseButton,
   ModalContent,
   ModalFooter,
+  ModalHeader,
   ModalOverlay,
   Text,
   VStack,
 } from "@chakra-ui/react";
 import { ComponentProps, useCallback, useState } from "react";
 import { FormattedMessage } from "react-intl";
-import testModelImage from "../images/test_model_black.svg";
 import { useDeployment } from "../deployment";
+import testModelImage from "../images/test_model_black.svg";
 
 export interface DownloadHelpDialogProps
   extends Omit<ComponentProps<typeof Modal>, "children"> {
@@ -43,27 +43,25 @@ const DownloadHelpDialog = ({
       {...rest}
     >
       <ModalOverlay>
-        <ModalContent p={8}>
+        <ModalContent>
+          <ModalHeader>
+            <FormattedMessage id="download-project-intro-title" />
+          </ModalHeader>
+          <ModalCloseButton />
           <ModalBody>
-            <ModalCloseButton />
-            <VStack width="100%" alignItems="left" gap={5}>
-              <Heading as="h1" fontWeight="bold" fontSize="2xl">
-                <FormattedMessage id="download-project-intro-title" />
-              </Heading>
-              <HStack gap={5}>
-                <Image src={testModelImage} opacity={0.4} w="180px" alt="" />
-                <VStack gap={5}>
-                  <Text textAlign="left">
-                    <FormattedMessage
-                      id="download-project-intro-description"
-                      values={{ appNameFull }}
-                    />
-                  </Text>
-                </VStack>
-              </HStack>
-            </VStack>
+            <HStack gap={5} width="100%">
+              <Image src={testModelImage} opacity={0.4} w="180px" alt="" />
+              <VStack gap={5}>
+                <Text textAlign="left">
+                  <FormattedMessage
+                    id="download-project-intro-description"
+                    values={{ appNameFull }}
+                  />
+                </Text>
+              </VStack>
+            </HStack>
           </ModalBody>
-          <ModalFooter justifyContent="space-between" px={0} pb={0}>
+          <ModalFooter justifyContent="space-between">
             <Checkbox
               isChecked={isSkipNextTime}
               onChange={(e) => setSkipNextTime(e.target.checked)}

--- a/src/components/DownloadProgressDialog.tsx
+++ b/src/components/DownloadProgressDialog.tsx
@@ -1,8 +1,9 @@
 import {
-  Heading,
   Modal,
   ModalBody,
   ModalContent,
+  ModalFooter,
+  ModalHeader,
   ModalOverlay,
   Progress,
   Text,
@@ -43,12 +44,12 @@ const DownloadProgressDialog = ({
       isCentered
     >
       <ModalOverlay>
-        <ModalContent p={8}>
+        <ModalContent>
+          <ModalHeader>
+            <FormattedMessage id={headingId} />
+          </ModalHeader>
           <ModalBody>
             <VStack width="100%" alignItems="left" gap={5}>
-              <Heading as="h1" fontWeight="bold" fontSize="2xl">
-                <FormattedMessage id={headingId} />
-              </Heading>
               <Text>
                 <FormattedMessage id="connectMB.usbDownloading.subtitle" />
               </Text>
@@ -60,6 +61,7 @@ const DownloadProgressDialog = ({
               />
             </VStack>
           </ModalBody>
+          <ModalFooter />
         </ModalContent>
       </ModalOverlay>
     </Modal>

--- a/src/components/EnterBluetoothPatternDialog.tsx
+++ b/src/components/EnterBluetoothPatternDialog.tsx
@@ -70,9 +70,15 @@ const EnterBluetoothPatternDialog = ({
             onChange={handlePatternChange}
             invalid={showInvalid}
           />
-          <Text textColor="red" opacity={showInvalid ? 1 : 0}>
-            <FormattedMessage id="connectMB.bluetooth.invalidPattern" />
-          </Text>
+          <VStack role="region" aria-live="polite">
+            <Text
+              textColor="red"
+              opacity={showInvalid ? 1 : 0}
+              aria-hidden={!showInvalid}
+            >
+              <FormattedMessage id="connectMB.bluetooth.invalidPattern" />
+            </Text>
+          </VStack>
         </VStack>
       </VStack>
     </ConnectContainerDialog>

--- a/src/components/EnterBluetoothPatternDialog.tsx
+++ b/src/components/EnterBluetoothPatternDialog.tsx
@@ -70,7 +70,7 @@ const EnterBluetoothPatternDialog = ({
             onChange={handlePatternChange}
             invalid={showInvalid}
           />
-          <VStack role="region" aria-live="polite">
+          <VStack>
             <Text
               textColor="red"
               opacity={showInvalid ? 1 : 0}

--- a/src/components/HelpMenu.tsx
+++ b/src/components/HelpMenu.tsx
@@ -45,6 +45,7 @@ const HelpMenu = ({ isMobile, ...rest }: HelpMenuProps) => {
       <FeedbackForm
         isOpen={feedbackDisclosure.isOpen}
         onClose={feedbackDisclosure.onClose}
+        finalFocusRef={MenuButtonRef}
       />
       <Menu {...rest}>
         <MenuButton

--- a/src/components/LedIcon.tsx
+++ b/src/components/LedIcon.tsx
@@ -11,7 +11,14 @@ interface LedIconProps {
 const LedIcon = ({ icon, isTriggered, size = 20 }: LedIconProps) => {
   const iconData = icons[icon];
   return (
-    <AspectRatio width={size} height={size} ratio={1}>
+    <AspectRatio
+      width={size}
+      height={size}
+      ratio={1}
+      role="image"
+      // TODO: Will icon names need to be translated?
+      aria-label={icon}
+    >
       <VStack w="100%" h="100%" spacing={0.5}>
         {Array.from(Array(5)).map((_, idx) => {
           const start = idx * 5;

--- a/src/components/LiveGraphPanel.tsx
+++ b/src/components/LiveGraphPanel.tsx
@@ -1,6 +1,13 @@
-import { Button, HStack, Portal, Text, VStack } from "@chakra-ui/react";
+import {
+  Button,
+  HStack,
+  Portal,
+  Text,
+  VisuallyHidden,
+  VStack,
+} from "@chakra-ui/react";
 import { useMemo, useRef } from "react";
-import { FormattedMessage } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 import { ConnectionStatus } from "../connect-status-hooks";
 import { useConnectionStage } from "../connection-stage-hooks";
 import { Gesture } from "../model";
@@ -20,6 +27,7 @@ const LiveGraphPanel = ({
   showPredictedGesture,
   detected,
 }: LiveGraphPanelProps) => {
+  const intl = useIntl();
   const { actions, status } = useConnectionStage();
   const parentPortalRef = useRef(null);
   const isReconnecting =
@@ -112,6 +120,15 @@ const LiveGraphPanel = ({
             py={2.5}
             pt={3.5}
           >
+            <VisuallyHidden aria-live="polite">
+              <FormattedMessage
+                id="content.model.output.estimatedGesture.label"
+                values={{
+                  action:
+                    detected?.name ?? intl.formatMessage({ id: "unknown" }),
+                }}
+              />
+            </VisuallyHidden>
             <HStack justifyContent="flex-start" w="100%" gap={2} pr={2} mb={3}>
               <Text size="md" fontWeight="bold" alignSelf="start">
                 <FormattedMessage id="content.model.output.estimatedGesture.iconTitle" />

--- a/src/components/LoadingDialog.tsx
+++ b/src/components/LoadingDialog.tsx
@@ -1,8 +1,9 @@
 import {
-  Heading,
   Modal,
   ModalBody,
   ModalContent,
+  ModalFooter,
+  ModalHeader,
   ModalOverlay,
   Text,
   VStack,
@@ -26,20 +27,19 @@ const LoadingDialog = ({ headingId, isOpen }: LoadingDialogProps) => {
       isCentered
     >
       <ModalOverlay>
-        <ModalContent p={8}>
+        <ModalContent>
+          <ModalHeader>
+            <FormattedMessage id={headingId} />
+          </ModalHeader>
           <ModalBody>
-            <VStack width="100%" alignItems="left" gap={5}>
-              <Heading as="h1" fontWeight="bold" fontSize="2xl">
-                <FormattedMessage id={headingId} />
-              </Heading>
-              <VStack gap={5}>
-                <Text>
-                  <FormattedMessage id="connectMB.connecting" />
-                </Text>
-                <LoadingAnimation />
-              </VStack>
+            <VStack gap={5} width="100%" alignItems="left">
+              <Text>
+                <FormattedMessage id="connectMB.connecting" />
+              </Text>
+              <LoadingAnimation />
             </VStack>
           </ModalBody>
+          <ModalFooter />
         </ModalContent>
       </ModalOverlay>
     </Modal>

--- a/src/components/NameProjectDialog.tsx
+++ b/src/components/NameProjectDialog.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { Button } from "@chakra-ui/button";
-import { Box, Text, VStack } from "@chakra-ui/layout";
+import { Box, VStack } from "@chakra-ui/layout";
 import {
   Modal,
   ModalBody,

--- a/src/components/NameProjectDialog.tsx
+++ b/src/components/NameProjectDialog.tsx
@@ -19,6 +19,7 @@ import {
   FormHelperText,
   FormLabel,
   Input,
+  ModalCloseButton,
 } from "@chakra-ui/react";
 import { useCallback, useMemo, useState } from "react";
 import { FormattedMessage } from "react-intl";
@@ -57,10 +58,9 @@ export const NameProjectDialog = ({
       <ModalOverlay>
         <ModalContent>
           <ModalHeader>
-            <Text as="h2" fontSize="lg" fontWeight="bold">
-              <FormattedMessage id="name-project" />
-            </Text>
+            <FormattedMessage id="name-project" />
           </ModalHeader>
+          <ModalCloseButton />
           <ModalBody>
             <VStack>
               <Box as="form" onSubmit={handleSubmit} width="100%">

--- a/src/components/NewPageChoice.tsx
+++ b/src/components/NewPageChoice.tsx
@@ -40,6 +40,7 @@ const NewPageChoice = ({
       cursor="pointer"
       alignItems="stretch"
       opacity={disabled ? 0.5 : undefined}
+      userSelect={disabled ? "none" : undefined}
       _hover={{
         bgColor: disabled ? undefined : "brand.50",
       }}

--- a/src/components/PercentageDisplay.tsx
+++ b/src/components/PercentageDisplay.tsx
@@ -1,25 +1,33 @@
-import { BoxProps, Text } from "@chakra-ui/react";
+import { BoxProps, Text, VisuallyHidden } from "@chakra-ui/react";
 
 interface PercentageDisplayProps extends BoxProps {
   value: number;
   colorScheme?: string;
+  ariaLabel?: string;
 }
 
 const PercentageDisplay = ({
   value,
   colorScheme = "gray.600",
+  ariaLabel,
   ...rest
 }: PercentageDisplayProps) => {
   return (
-    <Text
-      bgColor={colorScheme}
-      color="white"
-      rounded="md"
-      textAlign="center"
-      fontSize="xl"
-      w="60px"
-      {...rest}
-    >{`${Math.round(value * 100)}%`}</Text>
+    <>
+      <VisuallyHidden>
+        <Text>{ariaLabel}</Text>
+      </VisuallyHidden>
+      <Text
+        bgColor={colorScheme}
+        color="white"
+        rounded="md"
+        textAlign="center"
+        fontSize="xl"
+        w="60px"
+        aria-hidden={!!ariaLabel}
+        {...rest}
+      >{`${Math.round(value * 100)}%`}</Text>
+    </>
   );
 };
 

--- a/src/components/RecordingDialog.tsx
+++ b/src/components/RecordingDialog.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  Heading,
   Modal,
   ModalBody,
   ModalCloseButton,
@@ -203,7 +202,7 @@ const RecordingDialog = ({
               </Button>
             </VStack>
           </ModalBody>
-          <ModalFooter></ModalFooter>
+          <ModalFooter />
         </ModalContent>
       </ModalOverlay>
     </Modal>

--- a/src/components/RecordingDialog.tsx
+++ b/src/components/RecordingDialog.tsx
@@ -5,6 +5,8 @@ import {
   ModalBody,
   ModalCloseButton,
   ModalContent,
+  ModalFooter,
+  ModalHeader,
   ModalOverlay,
   Progress,
   Text,
@@ -152,16 +154,16 @@ const RecordingDialog = ({
       isCentered
     >
       <ModalOverlay>
-        <ModalContent p={8}>
+        <ModalContent>
+          <ModalHeader>
+            <FormattedMessage
+              id="content.data.recordingDialog.title"
+              values={{ action: actionName }}
+            />
+          </ModalHeader>
+          <ModalCloseButton />
           <ModalBody>
-            <ModalCloseButton />
             <VStack width="100%" alignItems="left" gap={5}>
-              <Heading as="h1" fontWeight="bold" fontSize="2xl">
-                <FormattedMessage
-                  id="content.data.recordingDialog.title"
-                  values={{ action: actionName }}
-                />
-              </Heading>
               <VStack height="100px" justifyContent="center">
                 {recordingStatus === RecordingStatus.Recording ? (
                   <Text
@@ -201,6 +203,7 @@ const RecordingDialog = ({
               </Button>
             </VStack>
           </ModalBody>
+          <ModalFooter></ModalFooter>
         </ModalContent>
       </ModalOverlay>
     </Modal>

--- a/src/components/ResourceCard.tsx
+++ b/src/components/ResourceCard.tsx
@@ -28,7 +28,7 @@ const ResourceCard = ({ imgSrc, url, title }: ResourceCardProps) => {
       boxShadow="md"
     >
       <AspectRatio w="100%" ratio={4 / 3} position="relative">
-        <Image src={imgSrc} />
+        <Image src={imgSrc} alt="" />
       </AspectRatio>
       <VStack p={3} py={2} pb={3} flexGrow={1} spacing={3} alignItems="stretch">
         <HStack justifyContent="space-between" alignItems="flex-start">

--- a/src/components/ResourceCardPlaceholder.tsx
+++ b/src/components/ResourceCardPlaceholder.tsx
@@ -25,6 +25,7 @@ const ResourceCardPlaceholder = () => {
         transform="translateX(-50%)"
         mt={-2}
         color="gray.600"
+        as="h3"
       >
         <FormattedMessage id="coming-soon" />
       </Text>

--- a/src/components/SaveHelpDialog.tsx
+++ b/src/components/SaveHelpDialog.tsx
@@ -44,14 +44,14 @@ const SaveHelpDialog = ({ isOpen, onClose, onSave }: SaveHelpDialogProps) => {
       isCentered
     >
       <ModalOverlay>
-        <ModalContent p={5}>
+        <ModalContent>
           <ModalHeader>
             <Heading as="h2" fontSize="xl" fontWeight="bold">
               <FormattedMessage id="save-hex-dialog-heading" />
             </Heading>
           </ModalHeader>
+          <ModalCloseButton />
           <ModalBody>
-            <ModalCloseButton />
             <Stack gap={5}>
               <VStack gap={3}>
                 <Text>
@@ -66,7 +66,7 @@ const SaveHelpDialog = ({ isOpen, onClose, onSave }: SaveHelpDialogProps) => {
               </VStack>
             </Stack>
           </ModalBody>
-          <ModalFooter justifyContent="space-between" px={0} pb={0}>
+          <ModalFooter justifyContent="space-between">
             <Checkbox isChecked={skip} onChange={handleChangeSkip}>
               <FormattedMessage id="dont-show-again" />
             </Checkbox>

--- a/src/components/SaveProgressDialog.tsx
+++ b/src/components/SaveProgressDialog.tsx
@@ -1,8 +1,9 @@
 import {
-  Heading,
   Modal,
   ModalBody,
   ModalContent,
+  ModalFooter,
+  ModalHeader,
   ModalOverlay,
   Progress,
   Text,
@@ -25,18 +26,19 @@ const SaveProgressDialog = ({ isOpen }: SavingDialogProps) => {
       isCentered
     >
       <ModalOverlay>
-        <ModalContent p={8}>
+        <ModalContent>
+          <ModalHeader>
+            <FormattedMessage id="saving-title" />
+          </ModalHeader>
           <ModalBody>
             <VStack width="100%" alignItems="left" gap={5}>
-              <Heading as="h1" fontWeight="bold" fontSize="2xl">
-                <FormattedMessage id="saving-title" />
-              </Heading>
               <Text>
                 <FormattedMessage id="saving-description" />
               </Text>
               <Progress colorScheme="brand2" isIndeterminate rounded="md" />
             </VStack>
           </ModalBody>
+          <ModalFooter />
         </ModalContent>
       </ModalOverlay>
     </Modal>

--- a/src/components/TestingModelGridView.tsx
+++ b/src/components/TestingModelGridView.tsx
@@ -10,7 +10,6 @@ import {
   MenuList,
   Portal,
   VStack,
-  VisuallyHidden,
 } from "@chakra-ui/react";
 import { MakeCodeRenderBlocksProvider } from "@microbit/makecode-embed/react";
 import React from "react";
@@ -61,12 +60,6 @@ const TestingModelGridView = () => {
   const setRequiredConfidence = useStore((s) => s.setRequiredConfidence);
   const { openEditor, project, resetProject, projectEdited } = useProject();
 
-  const detectedLabel =
-    detected?.name ??
-    intl.formatMessage({
-      id: "unknown",
-    });
-
   const [{ languageId }] = useSettings();
   const makeCodeLang = getMakeCodeLang(languageId);
 
@@ -79,12 +72,6 @@ const TestingModelGridView = () => {
           lang: makeCodeLang,
         }}
       >
-        <VisuallyHidden aria-live="polite">
-          <FormattedMessage
-            id="content.model.output.estimatedGesture.label"
-            values={{ action: detectedLabel }}
-          />
-        </VisuallyHidden>
         <HeadingGrid {...gridCommonProps} px={5} headings={headings} />
         <VStack
           px={5}
@@ -123,6 +110,7 @@ const TestingModelGridView = () => {
                       isTriggered={isTriggered}
                     />
                     <CertaintyThresholdGridItem
+                      actionName={name}
                       onThresholdChange={(val) =>
                         setRequiredConfidence(ID, val)
                       }

--- a/src/components/TrainModelFlowDialogs.tsx
+++ b/src/components/TrainModelFlowDialogs.tsx
@@ -9,7 +9,11 @@ import TrainingModelProgressDialog from "./TrainingModelProgressDialog";
 import TrainModelIntroDialog from "./TrainModelHelpDialog";
 import TrainModelInsufficientDataDialog from "./TrainModelInsufficientDataDialog";
 
-const TrainModelDialogs = () => {
+interface TrainModelDialogsProps {
+  finalFocusRef?: React.RefObject<HTMLButtonElement>;
+}
+
+const TrainModelDialogs = ({ finalFocusRef }: TrainModelDialogsProps) => {
   const stage = useStore((s) => s.trainModelDialogStage);
   const closeTrainModelDialogs = useStore((s) => s.closeTrainModelDialogs);
   const tourStart = useStore((s) => s.tourStart);
@@ -34,19 +38,23 @@ const TrainModelDialogs = () => {
       <TrainModelInsufficientDataDialog
         isOpen={stage === TrainModelDialogStage.InsufficientData}
         onClose={closeTrainModelDialogs}
+        finalFocusRef={finalFocusRef}
       />
       <TrainModelIntroDialog
         isOpen={stage === TrainModelDialogStage.Help}
         onNext={handleHelpNext}
         onClose={closeTrainModelDialogs}
+        finalFocusRef={finalFocusRef}
       />
       <TrainingErrorDialog
         isOpen={stage === TrainModelDialogStage.TrainingError}
         onClose={closeTrainModelDialogs}
+        finalFocusRef={finalFocusRef}
       />
       <TrainingModelProgressDialog
         isOpen={stage === TrainModelDialogStage.TrainingInProgress}
         progress={trainModelProgress * 100}
+        finalFocusRef={finalFocusRef}
       />
     </>
   );

--- a/src/components/TrainModelHelpDialog.tsx
+++ b/src/components/TrainModelHelpDialog.tsx
@@ -1,7 +1,6 @@
 import {
   Button,
   Checkbox,
-  Heading,
   HStack,
   Image,
   Modal,
@@ -9,14 +8,15 @@ import {
   ModalCloseButton,
   ModalContent,
   ModalFooter,
+  ModalHeader,
   ModalOverlay,
   Text,
   VStack,
 } from "@chakra-ui/react";
 import { ComponentProps, useCallback, useState } from "react";
 import { FormattedMessage } from "react-intl";
-import trainModelImage from "../images/train_model_black.svg";
 import { useDeployment } from "../deployment";
+import trainModelImage from "../images/train_model_black.svg";
 
 interface TrainModelHelpDialogProps
   extends Omit<ComponentProps<typeof Modal>, "children"> {
@@ -40,34 +40,32 @@ const TrainModelIntroDialog = ({
       {...props}
     >
       <ModalOverlay>
-        <ModalContent p={8}>
+        <ModalContent>
+          <ModalHeader>
+            <FormattedMessage id="content.trainer.header" />
+          </ModalHeader>
+          <ModalCloseButton />
           <ModalBody>
-            <ModalCloseButton />
-            <VStack width="100%" alignItems="left" gap={5}>
-              <Heading as="h1" fontWeight="bold" fontSize="2xl">
-                <FormattedMessage id="content.trainer.header" />
-              </Heading>
-              <HStack gap={5}>
-                <Image
-                  src={trainModelImage}
-                  opacity={0.4}
-                  w="180px"
-                  h="107px"
-                  alt=""
-                  flexShrink={0}
-                />
-                <VStack gap={5}>
-                  <Text textAlign="left">
-                    <FormattedMessage
-                      id="content.trainer.description"
-                      values={{ appNameFull }}
-                    />
-                  </Text>
-                </VStack>
-              </HStack>
-            </VStack>
+            <HStack gap={5} width="100%" alignItems="left">
+              <Image
+                src={trainModelImage}
+                opacity={0.4}
+                w="180px"
+                h="107px"
+                alt=""
+                flexShrink={0}
+              />
+              <VStack gap={5}>
+                <Text textAlign="left">
+                  <FormattedMessage
+                    id="content.trainer.description"
+                    values={{ appNameFull }}
+                  />
+                </Text>
+              </VStack>
+            </HStack>
           </ModalBody>
-          <ModalFooter justifyContent="space-between" px={0} pb={0}>
+          <ModalFooter justifyContent="space-between">
             <Checkbox
               isChecked={skip}
               onChange={(e) => setSkip(e.target.checked)}

--- a/src/components/TrainModelInsufficientDataDialog.tsx
+++ b/src/components/TrainModelInsufficientDataDialog.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  Heading,
   HStack,
   Image,
   Modal,
@@ -8,6 +7,7 @@ import {
   ModalCloseButton,
   ModalContent,
   ModalFooter,
+  ModalHeader,
   ModalOverlay,
   Text,
   VStack,
@@ -24,19 +24,19 @@ const TrainModelInsufficientDataDialog = ({
     <Modal
       closeOnOverlayClick={false}
       motionPreset="none"
-      size="2xl"
+      size="lg"
       isCentered
       onClose={onClose}
       {...rest}
     >
       <ModalOverlay>
-        <ModalContent p={8}>
+        <ModalContent>
+          <ModalHeader>
+            <FormattedMessage id="insufficient-data-title" />
+          </ModalHeader>
+          <ModalCloseButton />
           <ModalBody>
-            <ModalCloseButton />
-            <VStack width="100%" alignItems="left" gap={5}>
-              <Heading as="h1" fontWeight="bold" fontSize="2xl">
-                <FormattedMessage id="insufficient-data-title" />
-              </Heading>
+            <VStack width="100%" alignItems="left">
               <HStack gap={5}>
                 <Image
                   src={trainModelImage}
@@ -54,7 +54,7 @@ const TrainModelInsufficientDataDialog = ({
               </HStack>
             </VStack>
           </ModalBody>
-          <ModalFooter justifyContent="flex-end" px={0} pb={0}>
+          <ModalFooter justifyContent="flex-end">
             <Button variant="primary" onClick={onClose}>
               <FormattedMessage id="close-action" />
             </Button>

--- a/src/components/TrainingErrorDialog.tsx
+++ b/src/components/TrainingErrorDialog.tsx
@@ -5,25 +5,15 @@ import {
   ModalCloseButton,
   ModalContent,
   ModalOverlay,
+  ModalProps,
   Text,
   VStack,
 } from "@chakra-ui/react";
 import { FormattedMessage } from "react-intl";
 
-interface TrainingErrorDialogProps {
-  isOpen: boolean;
-  onClose: () => void;
-}
-
-const TrainingErrorDialog = ({ isOpen, onClose }: TrainingErrorDialogProps) => {
+const TrainingErrorDialog = ({ ...rest }: Omit<ModalProps, "children">) => {
   return (
-    <Modal
-      motionPreset="none"
-      isOpen={isOpen}
-      onClose={onClose}
-      size="lg"
-      isCentered
-    >
+    <Modal motionPreset="none" size="lg" isCentered {...rest}>
       <ModalOverlay>
         <ModalContent p={8}>
           <ModalBody>

--- a/src/components/TrainingErrorDialog.tsx
+++ b/src/components/TrainingErrorDialog.tsx
@@ -1,9 +1,10 @@
 import {
-  Heading,
   Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
+  ModalFooter,
+  ModalHeader,
   ModalOverlay,
   ModalProps,
   Text,
@@ -15,23 +16,22 @@ const TrainingErrorDialog = ({ ...rest }: Omit<ModalProps, "children">) => {
   return (
     <Modal motionPreset="none" size="lg" isCentered {...rest}>
       <ModalOverlay>
-        <ModalContent p={8}>
+        <ModalContent>
+          <ModalHeader>
+            <FormattedMessage id="content.trainer.failure.header" />
+          </ModalHeader>
+          <ModalCloseButton />
           <ModalBody>
-            <ModalCloseButton />
-            <VStack width="100%" alignItems="left" gap={5}>
-              <Heading as="h2" fontSize="xl" fontWeight="bold">
-                <FormattedMessage id="content.trainer.failure.header" />
-              </Heading>
-              <VStack gap={3} textAlign="left" w="100%">
-                <Text w="100%">
-                  <FormattedMessage id="content.trainer.failure.body" />
-                </Text>
-                <Text w="100%" fontWeight="bold">
-                  <FormattedMessage id="content.trainer.failure.todo" />
-                </Text>
-              </VStack>
+            <VStack gap={3} textAlign="left" w="100%">
+              <Text w="100%">
+                <FormattedMessage id="content.trainer.failure.body" />
+              </Text>
+              <Text w="100%" fontWeight="bold">
+                <FormattedMessage id="content.trainer.failure.todo" />
+              </Text>
             </VStack>
           </ModalBody>
+          <ModalFooter />
         </ModalContent>
       </ModalOverlay>
     </Modal>

--- a/src/components/TrainingModelProgressDialog.tsx
+++ b/src/components/TrainingModelProgressDialog.tsx
@@ -12,11 +12,13 @@ import { FormattedMessage } from "react-intl";
 export interface DownloadingDialogProps {
   isOpen: boolean;
   progress: number;
+  finalFocusRef?: React.RefObject<HTMLButtonElement>;
 }
 
 const TrainingModelProgressDialog = ({
   isOpen,
   progress,
+  finalFocusRef,
 }: DownloadingDialogProps) => {
   return (
     <Modal
@@ -26,6 +28,7 @@ const TrainingModelProgressDialog = ({
       onClose={() => {}}
       size="2xl"
       isCentered
+      finalFocusRef={finalFocusRef}
     >
       <ModalOverlay>
         <ModalContent p={8}>

--- a/src/components/TrainingModelProgressDialog.tsx
+++ b/src/components/TrainingModelProgressDialog.tsx
@@ -1,8 +1,9 @@
 import {
-  Heading,
   Modal,
   ModalBody,
   ModalContent,
+  ModalFooter,
+  ModalHeader,
   ModalOverlay,
   Progress,
   VStack,
@@ -31,12 +32,12 @@ const TrainingModelProgressDialog = ({
       finalFocusRef={finalFocusRef}
     >
       <ModalOverlay>
-        <ModalContent p={8}>
+        <ModalContent>
+          <ModalHeader>
+            <FormattedMessage id="content.trainer.training.title" />
+          </ModalHeader>
           <ModalBody>
-            <VStack width="100%" alignItems="left" gap={5}>
-              <Heading as="h1" fontWeight="bold" fontSize="2xl">
-                <FormattedMessage id="content.trainer.training.title" />
-              </Heading>
+            <VStack width="100%" alignItems="left">
               <Progress
                 value={progress}
                 colorScheme="brand2"
@@ -45,6 +46,7 @@ const TrainingModelProgressDialog = ({
               />
             </VStack>
           </ModalBody>
+          <ModalFooter />
         </ModalContent>
       </ModalOverlay>
     </Modal>

--- a/src/components/TryAgainDialog.tsx
+++ b/src/components/TryAgainDialog.tsx
@@ -1,12 +1,12 @@
 import {
   Button,
   HStack,
-  Heading,
   ListItem,
   Modal,
   ModalBody,
   ModalContent,
   ModalFooter,
+  ModalHeader,
   ModalOverlay,
   Text,
   UnorderedList,
@@ -113,18 +113,18 @@ const TryAgainDialog = ({
       isCentered
     >
       <ModalOverlay>
-        <ModalContent p={8}>
+        <ModalContent>
+          <ModalHeader>
+            <FormattedMessage id={config.headingId} />
+          </ModalHeader>
           <ModalBody>
             <VStack width="100%" alignItems="left" gap={5}>
-              <Heading as="h2" fontSize="xl" fontWeight="bold">
-                <FormattedMessage id={config.headingId} />
-              </Heading>
               <VStack gap={5} textAlign="left" w="100%">
                 {config.children}
               </VStack>
             </VStack>
           </ModalBody>
-          <ModalFooter justifyContent="end" p={0}>
+          <ModalFooter justifyContent="end">
             <HStack gap={5}>
               <Button onClick={onClose} variant="secondary" size="lg">
                 <FormattedMessage id="cancel-action" />

--- a/src/components/UnsupportedMicrobitDialog.tsx
+++ b/src/components/UnsupportedMicrobitDialog.tsx
@@ -1,11 +1,11 @@
 import {
   Button,
   HStack,
-  Heading,
   Modal,
   ModalBody,
   ModalContent,
   ModalFooter,
+  ModalHeader,
   ModalOverlay,
   Text,
   VStack,
@@ -39,21 +39,40 @@ const UnsupportedMicrobitDialog = ({
       isCentered
     >
       <ModalOverlay>
-        <ModalContent p={8}>
+        <ModalContent>
+          <ModalHeader>
+            <FormattedMessage id="connectMB.unsupportedMicrobit.header" />
+          </ModalHeader>
           <ModalBody>
-            <VStack width="100%" alignItems="left" gap={5}>
-              <Heading as="h2" fontSize="xl" fontWeight="bold">
-                <FormattedMessage id="connectMB.unsupportedMicrobit.header" />
-              </Heading>
-              <VStack gap={5} textAlign="left" w="100%">
-                <Text w="100%">
+            <VStack gap={5} textAlign="left" w="100%">
+              <Text w="100%">
+                <FormattedMessage
+                  id="connectMB.unsupportedMicrobit.explain"
+                  values={{
+                    link: (chunks: ReactNode) => (
+                      <Link
+                        color="brand.600"
+                        href="https://support.microbit.org/support/solutions/articles/19000119162"
+                        target="_blank"
+                        rel="noopener"
+                      >
+                        {chunks}
+                      </Link>
+                    ),
+                  }}
+                />
+              </Text>
+              <Text w="100%">
+                {isBluetoothSupported ? (
+                  <FormattedMessage id="connectMB.unsupportedMicrobit.withBluetooth" />
+                ) : (
                   <FormattedMessage
-                    id="connectMB.unsupportedMicrobit.explain"
+                    id="connectMB.unsupportedMicrobit.withoutBluetooth"
                     values={{
                       link: (chunks: ReactNode) => (
                         <Link
                           color="brand.600"
-                          href="https://support.microbit.org/support/solutions/articles/19000119162"
+                          href={supportLinks.bluetooth}
                           target="_blank"
                           rel="noopener"
                         >
@@ -62,32 +81,11 @@ const UnsupportedMicrobitDialog = ({
                       ),
                     }}
                   />
-                </Text>
-                <Text w="100%">
-                  {isBluetoothSupported ? (
-                    <FormattedMessage id="connectMB.unsupportedMicrobit.withBluetooth" />
-                  ) : (
-                    <FormattedMessage
-                      id="connectMB.unsupportedMicrobit.withoutBluetooth"
-                      values={{
-                        link: (chunks: ReactNode) => (
-                          <Link
-                            color="brand.600"
-                            href={supportLinks.bluetooth}
-                            target="_blank"
-                            rel="noopener"
-                          >
-                            {chunks}
-                          </Link>
-                        ),
-                      }}
-                    />
-                  )}
-                </Text>
-              </VStack>
+                )}
+              </Text>
             </VStack>
           </ModalBody>
-          <ModalFooter justifyContent="end" p={0}>
+          <ModalFooter justifyContent="end">
             <HStack gap={5}>
               {isBluetoothSupported ? (
                 <Button

--- a/src/components/WebUsbBluetoothUnsupportedDialog.tsx
+++ b/src/components/WebUsbBluetoothUnsupportedDialog.tsx
@@ -1,11 +1,11 @@
 import {
   Button,
   HStack,
-  Heading,
   Modal,
   ModalBody,
   ModalContent,
   ModalFooter,
+  ModalHeader,
   ModalOverlay,
   Text,
   VStack,
@@ -31,23 +31,21 @@ const WebUsbBluetoothUnsupportedDialog = ({
       isCentered
     >
       <ModalOverlay>
-        <ModalContent p={8}>
+        <ModalContent>
+          <ModalHeader>
+            <FormattedMessage id="popup.compatibility.header" />
+          </ModalHeader>
           <ModalBody>
-            <VStack width="100%" alignItems="left" gap={5}>
-              <Heading as="h2" fontSize="xl" fontWeight="bold">
-                <FormattedMessage id="popup.compatibility.header" />
-              </Heading>
-              <VStack gap={5} textAlign="left" w="100%">
-                <Text w="100%">
-                  <FormattedMessage id="popup.compatibility.explain" />
-                </Text>
-                <Text w="100%">
-                  <FormattedMessage id="popup.compatibility.advice" />
-                </Text>
-              </VStack>
+            <VStack gap={5} textAlign="left" w="100%">
+              <Text w="100%">
+                <FormattedMessage id="popup.compatibility.explain" />
+              </Text>
+              <Text w="100%">
+                <FormattedMessage id="popup.compatibility.advice" />
+              </Text>
             </VStack>
           </ModalBody>
-          <ModalFooter justifyContent="end" p={0}>
+          <ModalFooter justifyContent="end">
             <HStack gap={5}>
               <Button onClick={onClose} variant="primary" size="lg">
                 <FormattedMessage id="close-action" />

--- a/src/components/WhatYouWillNeedDialog.tsx
+++ b/src/components/WhatYouWillNeedDialog.tsx
@@ -110,7 +110,7 @@ const WhatYouWillNeedDialog = ({
         width="100%"
         templateColumns={`repeat(${itemsConfig[type].length}, 1fr)`}
         gap={16}
-        py="30px"
+        p="30px"
       >
         {itemsConfig[type].map(({ imgSrc, titleId, subtitleId }) => {
           return (

--- a/src/messages/ui.en.json
+++ b/src/messages/ui.en.json
@@ -124,7 +124,7 @@
   "certainty-label": [
     {
       "type": 0,
-      "value": "certainty level for "
+      "value": "certainty for "
     },
     {
       "type": 1,
@@ -1306,7 +1306,7 @@
   "homepage-alt": [
     {
       "type": 0,
-      "value": "image of graph showing x, y, z graph lines representing micro:bit accelerometer data "
+      "value": "graph showing x, y, z graph lines representing micro:bit accelerometer data"
     }
   ],
   "homepage-description": [
@@ -1682,7 +1682,7 @@
   "recording-graph-label": [
     {
       "type": 0,
-      "value": "image of graph showing x, y, z graph lines representing micro:bit accelerometer data in one recording"
+      "value": "graph showing micro:bit x, y, z accelerometer data for one recording"
     }
   ],
   "reload-action": [

--- a/src/messages/ui.en.json
+++ b/src/messages/ui.en.json
@@ -1,4 +1,10 @@
 {
+  "aarhus-university-alt": [
+    {
+      "type": 0,
+      "value": "Aarhus University"
+    }
+  ],
   "about": [
     {
       "type": 0,
@@ -113,6 +119,28 @@
     {
       "type": 0,
       "value": "Cancel"
+    }
+  ],
+  "certainty-label": [
+    {
+      "type": 0,
+      "value": "certainty level for "
+    },
+    {
+      "type": 1,
+      "value": "action"
+    },
+    {
+      "type": 0,
+      "value": ": "
+    },
+    {
+      "type": 1,
+      "value": "currentConfidence"
+    },
+    {
+      "type": 0,
+      "value": " percent"
     }
   ],
   "close-action": [
@@ -1275,6 +1303,12 @@
       "value": "Home"
     }
   ],
+  "homepage-alt": [
+    {
+      "type": 0,
+      "value": "image of graph showing x, y, z graph lines representing micro:bit accelerometer data "
+    }
+  ],
   "homepage-description": [
     {
       "type": 0,
@@ -1403,30 +1437,6 @@
       "value": "The name is used when you save a file."
     }
   ],
-  "newpage-browse-lessons": [
-    {
-      "type": 0,
-      "value": "Browse lessons"
-    }
-  ],
-  "newpage-browse-projects": [
-    {
-      "type": 0,
-      "value": "Browse projects"
-    }
-  ],
-  "newpage-choose-subtitle": [
-    {
-      "type": 0,
-      "value": "Find a project or lesson from our teacher resources and open it in micro:bit classroom"
-    }
-  ],
-  "newpage-choose-title": [
-    {
-      "type": 0,
-      "value": "Choose a project or lesson"
-    }
-  ],
   "newpage-continue-session-instruction": [
     {
       "type": 0,
@@ -1449,12 +1459,6 @@
     {
       "type": 0,
       "value": "Run whole class sessions, easily share code with students and save progress"
-    }
-  ],
-  "newpage-heading-title": [
-    {
-      "type": 0,
-      "value": "Welcome to micro:bit classroom"
     }
   ],
   "newpage-last-session-date": [
@@ -1512,7 +1516,7 @@
   "newpage-new-session-subtitle": [
     {
       "type": 0,
-      "value": "Connect your micro:bit and collect movement data to build a machine learning model"
+      "value": "Connect your micro:bit and collect movement data to build a machine learning model."
     }
   ],
   "newpage-new-session-title": [
@@ -1675,6 +1679,12 @@
       "value": "Follow these instructions to restart the connection process."
     }
   ],
+  "recording-graph-label": [
+    {
+      "type": 0,
+      "value": "image of graph showing x, y, z graph lines representing micro:bit accelerometer data in one recording"
+    }
+  ],
   "reload-action": [
     {
       "type": 0,
@@ -1759,6 +1769,12 @@
     {
       "type": 0,
       "value": "Start training"
+    }
+  ],
+  "steps-alt": [
+    {
+      "type": 0,
+      "value": "diagram showing the iterative process of collecting data, training a model, testing the model, and improving the model by improving the data collected before finally coding using the model."
     }
   ],
   "steps-code": [
@@ -1970,7 +1986,7 @@
   "unplug-radio-link-microbit-description": [
     {
       "type": 0,
-      "value": "Unplug the radio link micro:bit from the computer. If you want to record more data samples, you will need to reconnect with the tool."
+      "value": "Unplug the radio link micro:bit from the computer. You will need to reconnect the micro:bit if you want to record more data samples."
     }
   ],
   "unplug-radio-link-microbit-label": [

--- a/src/pages/DataSamplesPage.tsx
+++ b/src/pages/DataSamplesPage.tsx
@@ -1,5 +1,5 @@
 import { Button, HStack, VStack } from "@chakra-ui/react";
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import { RiAddLine, RiArrowRightLine } from "react-icons/ri";
 import { FormattedMessage } from "react-intl";
 import { useNavigate } from "react-router";
@@ -13,6 +13,7 @@ import { SessionPageId } from "../pages-config";
 import { useHasSufficientDataForTraining, useStore } from "../store";
 import { tourElClassname } from "../tours";
 import { createSessionPageUrl } from "../urls";
+import TrainModelDialogs from "../components/TrainModelFlowDialogs";
 
 const DataSamplesPage = () => {
   const gestures = useStore((s) => s.gestures);
@@ -29,57 +30,62 @@ const DataSamplesPage = () => {
     navigate(createSessionPageUrl(SessionPageId.TestingModel));
   }, [navigate]);
 
+  const trainButtonRef = useRef(null);
   return (
-    <DefaultPageLayout
-      titleId={`${SessionPageId.DataSamples}-title`}
-      showPageTitle
-      menuItems={<ProjectMenuItems />}
-      toolbarItemsRight={<ProjectToolbarItems />}
-    >
-      <DataSampleGridView />
-      <VStack w="full" flexShrink={0} bottom={0} gap={0} bg="gray.25">
-        <HStack
-          justifyContent="space-between"
-          px={5}
-          py={2}
-          w="full"
-          borderBottomWidth={3}
-          borderTopWidth={3}
-          borderColor="gray.200"
-          alignItems="center"
-        >
-          <HStack gap={2} alignItems="center">
-            <Button
-              className={tourElClassname.addActionButton}
-              variant={hasSufficientData ? "secondary" : "primary"}
-              leftIcon={<RiAddLine />}
-              onClick={addNewGesture}
-              isDisabled={isAddNewGestureDisabled}
-            >
-              <FormattedMessage id="content.data.addAction" />
-            </Button>
+    <>
+      <TrainModelDialogs finalFocusRef={trainButtonRef} />
+      <DefaultPageLayout
+        titleId={`${SessionPageId.DataSamples}-title`}
+        showPageTitle
+        menuItems={<ProjectMenuItems />}
+        toolbarItemsRight={<ProjectToolbarItems />}
+      >
+        <DataSampleGridView />
+        <VStack w="full" flexShrink={0} bottom={0} gap={0} bg="gray.25">
+          <HStack
+            justifyContent="space-between"
+            px={5}
+            py={2}
+            w="full"
+            borderBottomWidth={3}
+            borderTopWidth={3}
+            borderColor="gray.200"
+            alignItems="center"
+          >
+            <HStack gap={2} alignItems="center">
+              <Button
+                className={tourElClassname.addActionButton}
+                variant={hasSufficientData ? "secondary" : "primary"}
+                leftIcon={<RiAddLine />}
+                onClick={addNewGesture}
+                isDisabled={isAddNewGestureDisabled}
+              >
+                <FormattedMessage id="content.data.addAction" />
+              </Button>
+            </HStack>
+            {model ? (
+              <Button
+                onClick={handleNavigateToModel}
+                variant="primary"
+                rightIcon={<RiArrowRightLine />}
+              >
+                <FormattedMessage id={`${SessionPageId.TestingModel}-title`} />
+              </Button>
+            ) : (
+              <Button
+                ref={trainButtonRef}
+                className={tourElClassname.trainModelButton}
+                onClick={trainModelFlowStart}
+                variant={hasSufficientData ? "primary" : "secondary-disabled"}
+              >
+                <FormattedMessage id={"menu.trainer.trainModelButton"} />
+              </Button>
+            )}
           </HStack>
-          {model ? (
-            <Button
-              onClick={handleNavigateToModel}
-              variant="primary"
-              rightIcon={<RiArrowRightLine />}
-            >
-              <FormattedMessage id={`${SessionPageId.TestingModel}-title`} />
-            </Button>
-          ) : (
-            <Button
-              className={tourElClassname.trainModelButton}
-              onClick={trainModelFlowStart}
-              variant={hasSufficientData ? "primary" : "secondary-disabled"}
-            >
-              <FormattedMessage id={"menu.trainer.trainModelButton"} />
-            </Button>
-          )}
-        </HStack>
-        <LiveGraphPanel />
-      </VStack>
-    </DefaultPageLayout>
+          <LiveGraphPanel />
+        </VStack>
+      </DefaultPageLayout>
+    </>
   );
 };
 

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -107,7 +107,13 @@ const HomePage = () => {
             </Button>
           </VStack>
           <Box flex="1" position="relative">
-            <Image src={xyzGraph} borderRadius="md" bgColor="white" pr={1} />
+            <Image
+              src={xyzGraph}
+              borderRadius="md"
+              bgColor="white"
+              pr={1}
+              alt={intl.formatMessage({ id: "homepage-alt" })}
+            />
           </Box>
         </HStack>
         <VStack spacing={8} w="100%" maxW="container.md">
@@ -146,7 +152,13 @@ const HomePage = () => {
           <Heading as="h2" textAlign="center">
             <FormattedMessage id="homepage-step-by-step" />
           </Heading>
-          <VStack gap={12} maxW="container.md" position="relative">
+          <VStack
+            gap={12}
+            maxW="container.md"
+            position="relative"
+            role="image"
+            aria-label={intl.formatMessage({ id: "steps-alt" })}
+          >
             <Step
               title={intl.formatMessage({ id: "steps-collect-data" })}
               image={<CollectDataIllustration />}


### PR DESCRIPTION
- Added alt text for Aarhus university
- Added aria label for certainty level
- Added alt text for homepage graphxyz and step-by-step process
- Added label for recordings in data samples page
- Aligned dialogs to use the same padding styling and to use ModalHeader & ModalFooter
- Aria hide the invalid bluetooth pattern text when it is valid
- Add finalFocusRef for Feedback form to return to help menu icon
- Add label for LED icon
- Make last session button user-select “none” when disabled
- Add final focus ref to train model dialogs so that it returns to train button

**Things still left to do soon or later:**
https://paper.dropbox.com/doc/Accessibility-Screen-reader-notes--CYVkn4VoOtC2okQbi_1gWAHgAQ-x6q77P8qUOW0KkkGmfO3N