### PR TITLE
Show button loading animation when waiting for MakeCode to open

### DIFF
--- a/src/components/DownloadDialogs.tsx
+++ b/src/components/DownloadDialogs.tsx
@@ -10,7 +10,7 @@ import { useDownloadActions } from "../hooks/download-hooks";
 import { useStore } from "../store";
 import UnplugRadioLinkMicrobitDialog from "./UnplugRadioLinkMicrobitDialog";
 import ConnectRadioDataCollectionMicrobitDialog from "./ConnectRadioDataCollectionMicrobitDialog";
-import UnsupportedEditorDevice from "./IncompatibleEditorDevice";
+import IncompatibleEditorDevice from "./IncompatibleEditorDevice";
 
 const DownloadDialogs = () => {
   const actions = useDownloadActions();
@@ -101,7 +101,7 @@ const DownloadDialogs = () => {
       );
     case DownloadStep.IncompatibleDevice:
       return (
-        <UnsupportedEditorDevice
+        <IncompatibleEditorDevice
           isOpen
           onClose={actions.close}
           onBack={actions.getOnBack()}

--- a/src/components/IncompatibleEditorDevice.tsx
+++ b/src/components/IncompatibleEditorDevice.tsx
@@ -20,6 +20,7 @@ interface UnsupportedEditorDeviceProps {
   isOpen: boolean;
   onClose: () => void;
   onNext?: () => void;
+  onNextLoading?: boolean;
   onBack?: () => void;
   stage: "openEditor" | "flashDevice";
 }
@@ -28,6 +29,7 @@ const UnsupportedEditorDevice = ({
   isOpen,
   onClose,
   onNext,
+  onNextLoading,
   onBack,
   stage,
 }: UnsupportedEditorDeviceProps) => {
@@ -111,6 +113,7 @@ const UnsupportedEditorDevice = ({
                 onClick={onNext ?? onClose}
                 variant={onNext ? "primary" : "secondary"}
                 size="lg"
+                isLoading={onNextLoading}
               >
                 <FormattedMessage
                   id={onNext ? "continue-makecode-action" : "cancel-action"}

--- a/src/components/IncompatibleEditorDevice.tsx
+++ b/src/components/IncompatibleEditorDevice.tsx
@@ -16,7 +16,7 @@ import { ReactNode } from "react";
 import { FormattedMessage } from "react-intl";
 import { useProject } from "../hooks/project-hooks";
 
-interface UnsupportedEditorDeviceProps {
+interface IncompatibleEditorDeviceProps {
   isOpen: boolean;
   onClose: () => void;
   onNext?: () => void;
@@ -25,14 +25,14 @@ interface UnsupportedEditorDeviceProps {
   stage: "openEditor" | "flashDevice";
 }
 
-const UnsupportedEditorDevice = ({
+const IncompatibleEditorDevice = ({
   isOpen,
   onClose,
   onNext,
   onNextLoading,
   onBack,
   stage,
-}: UnsupportedEditorDeviceProps) => {
+}: IncompatibleEditorDeviceProps) => {
   const { saveHex } = useProject();
   return (
     <Modal
@@ -127,4 +127,4 @@ const UnsupportedEditorDevice = ({
   );
 };
 
-export default UnsupportedEditorDevice;
+export default IncompatibleEditorDevice;

--- a/src/components/TestingModelGridView.tsx
+++ b/src/components/TestingModelGridView.tsx
@@ -13,7 +13,7 @@ import {
   useDisclosure,
 } from "@chakra-ui/react";
 import { MakeCodeRenderBlocksProvider } from "@microbit/makecode-embed/react";
-import React, { useCallback } from "react";
+import React, { useCallback, useState } from "react";
 import { RiArrowRightLine, RiDeleteBin2Line } from "react-icons/ri";
 import { FormattedMessage, useIntl } from "react-intl";
 import { useConnectActions } from "../connect-actions-hooks";
@@ -69,17 +69,22 @@ const TestingModelGridView = () => {
 
   const { isOpen, onOpen, onClose } = useDisclosure();
 
+  const [editorLoading, setEditorLoading] = useState(false);
   const continueToEditor = useCallback(async () => {
+    setEditorLoading(true);
     await openEditor();
     onClose();
+    setEditorLoading(false);
   }, [onClose, openEditor]);
 
-  const maybeOpenEditor = useCallback(() => {
+  const maybeOpenEditor = useCallback(async () => {
     // Open editor if device is not a V1, otherwise show warning dialog.
     if (getDataCollectionBoardVersion() === "V1") {
       return onOpen();
     }
-    void openEditor();
+    setEditorLoading(true);
+    await openEditor();
+    setEditorLoading(false);
   }, [getDataCollectionBoardVersion, onOpen, openEditor]);
 
   return (
@@ -89,6 +94,7 @@ const TestingModelGridView = () => {
         onClose={onClose}
         onNext={continueToEditor}
         stage="openEditor"
+        onNextLoading={editorLoading}
       />
       <MakeCodeRenderBlocksProvider
         key={makeCodeLang}
@@ -181,6 +187,7 @@ const TestingModelGridView = () => {
                 variant="primary"
                 onClick={maybeOpenEditor}
                 className={tourElClassname.editInMakeCodeButton}
+                isLoading={editorLoading && !isOpen}
               >
                 <FormattedMessage id="edit-in-makecode-action" />
               </Button>

--- a/src/components/TestingModelGridView.tsx
+++ b/src/components/TestingModelGridView.tsx
@@ -28,7 +28,7 @@ import CodeViewCard from "./CodeViewCard";
 import CodeViewGridItem from "./CodeViewGridItem";
 import GestureNameGridItem from "./GestureNameGridItem";
 import HeadingGrid from "./HeadingGrid";
-import UnsupportedEditorDevice from "./IncompatibleEditorDevice";
+import IncompatibleEditorDevice from "./IncompatibleEditorDevice";
 import LiveGraphPanel from "./LiveGraphPanel";
 import MoreMenuButton from "./MoreMenuButton";
 
@@ -89,7 +89,7 @@ const TestingModelGridView = () => {
 
   return (
     <>
-      <UnsupportedEditorDevice
+      <IncompatibleEditorDevice
         isOpen={isOpen}
         onClose={onClose}
         onNext={continueToEditor}


### PR DESCRIPTION
Without this animation, it's not clear if the user's button click has registered.

A component rename to match its file name is also included in this PR.