### PR TITLE
Ensure loading projects via files enables open last session option

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -551,9 +551,11 @@ export const useStore = create<Store>()(
                   ? (JSON.parse(datasetString) as DatasetEditorJsonFormat)
                   : { data: [] };
 
+                const timestamp = Date.now();
                 return {
                   project: newProject,
-                  projectLoadTimestamp: Date.now(),
+                  projectLoadTimestamp: timestamp,
+                  timestamp,
                   // New project loaded externally so we can't know whether its edited.
                   projectEdited: true,
                   gestures: dataset.data,

--- a/src/store.ts
+++ b/src/store.ts
@@ -404,6 +404,7 @@ export const useStore = create<Store>()(
                 return copy;
               })(),
               model: undefined,
+              timestamp: Date.now(),
               ...updateProject(project, projectEdited, newGestures, undefined),
             };
           });


### PR DESCRIPTION
The timestamp will be reset for new sessions when a .json file is loaded, but there doesn't seem an obvious downside to this.