### PR TITLE
Replace state on navigating from import page

### DIFF
--- a/src/pages/ImportPage.tsx
+++ b/src/pages/ImportPage.tsx
@@ -26,7 +26,7 @@ const ImportPage = () => {
         intl
       );
       loadProject(code);
-      navigate(createDataSamplesPageUrl());
+      navigate(createDataSamplesPageUrl(), { replace: true });
     };
     void updateAsync();
   }, [activitiesBaseUrl, intl, loadProject, navigate, resource]);


### PR DESCRIPTION
Chrome has some optimisations that make get you back to the page you want, otherwise you'll end up stuck in a loop or land on a broken import page where the URL has been encoded (& -> &amp).

It's worth pointing out that while this is an improvement, it's still three back presses to get back to microbit.org after using the "Open in micro:bit CreateAI" link.