### PR TITLE
Remove IconButton onClick for "Continue saved session" button

### DIFF
--- a/src/components/NewPageChoice.tsx
+++ b/src/components/NewPageChoice.tsx
@@ -63,7 +63,6 @@ const NewPageChoice = ({
           height="100%"
           variant="unstyled"
           icon={icon}
-          onClick={onClick}
           borderInlineEndRadius="md"
           _groupHover={{
             color: disabled ? undefined : "#efedf5",


### PR DESCRIPTION
Fixes issue of needing to select a file twice when clicking on the IconButton