### PR TITLE
Fix MakeCode download flow to download most recent hex

### DIFF
--- a/src/hooks/download-hooks.tsx
+++ b/src/hooks/download-hooks.tsx
@@ -52,10 +52,10 @@ export class DownloadProjectActions {
       this.state.usbDevice &&
       this.state.usbDevice.status === UsbConnectionStatus.CONNECTED
     ) {
-      const newState = {
+      const newState: DownloadState = {
         ...this.state,
         step: DownloadStep.FlashingInProgress,
-        project: download,
+        hex: download,
       };
       this.setState(newState);
       await this.flashMicrobit(newState, {


### PR DESCRIPTION
Most recent download hex data was not being passed through when usb was already connected.

https://microbit-global.monday.com/boards/1550536443/pulses/1676135382 (Private)