### PR TITLE
Stop creating default project code when blocks not displayed

### DIFF
--- a/src/components/CodeViewGridItem.tsx
+++ b/src/components/CodeViewGridItem.tsx
@@ -11,13 +11,9 @@ import { tourElClassname } from "../tours";
 
 interface CodeViewGridItemProps {
   gesture: GestureData;
-  projectEdited: boolean;
 }
 
-const CodeViewGridItem = ({
-  gesture,
-  projectEdited,
-}: CodeViewGridItemProps) => {
+const CodeViewGridItem = ({ gesture }: CodeViewGridItemProps) => {
   const model = useStore((s) => s.model);
   const gestures = useStore((s) => s.gestures);
   const project = useMemo(
@@ -31,33 +27,31 @@ const CodeViewGridItem = ({
   );
   return (
     <GridItem>
-      {!projectEdited && (
-        <Card
-          px={5}
-          h="120px"
-          display="flex"
-          borderColor="brand.500"
-          minW="400px"
-          width="fit-content"
-          justifyContent="center"
-          className={tourElClassname.makeCodeCodeView}
-        >
-          <Box width={width} py={2} px={2} overflow="hidden">
-            <MakeCodeBlocksRendering
-              code={project}
-              layout={BlockLayout.Clean}
-              loaderCmp={
-                <SkeletonText
-                  w="full"
-                  noOfLines={3}
-                  spacing="5"
-                  skeletonHeight="2"
-                />
-              }
-            />
-          </Box>
-        </Card>
-      )}
+      <Card
+        px={5}
+        h="120px"
+        display="flex"
+        borderColor="brand.500"
+        minW="400px"
+        width="fit-content"
+        justifyContent="center"
+        className={tourElClassname.makeCodeCodeView}
+      >
+        <Box width={width} py={2} px={2} overflow="hidden">
+          <MakeCodeBlocksRendering
+            code={project}
+            layout={BlockLayout.Clean}
+            loaderCmp={
+              <SkeletonText
+                w="full"
+                noOfLines={3}
+                spacing="5"
+                skeletonHeight="2"
+              />
+            }
+          />
+        </Box>
+      </Card>
     </GridItem>
   );
 };

--- a/src/components/TestingModelGridView.tsx
+++ b/src/components/TestingModelGridView.tsx
@@ -2,6 +2,7 @@ import {
   Button,
   ButtonGroup,
   Grid,
+  GridItem,
   GridProps,
   HStack,
   Icon,
@@ -19,6 +20,7 @@ import { FormattedMessage, useIntl } from "react-intl";
 import { useConnectActions } from "../connect-actions-hooks";
 import { usePrediction } from "../hooks/ml-hooks";
 import { useProject } from "../hooks/project-hooks";
+import { mlSettings } from "../mlConfig";
 import { getMakeCodeLang } from "../settings";
 import { useSettings, useStore } from "../store";
 import { tourElClassname } from "../tours";
@@ -30,7 +32,6 @@ import HeadingGrid from "./HeadingGrid";
 import IncompatibleEditorDevice from "./IncompatibleEditorDevice";
 import LiveGraphPanel from "./LiveGraphPanel";
 import MoreMenuButton from "./MoreMenuButton";
-import { mlSettings } from "../mlConfig";
 
 const gridCommonProps: Partial<GridProps> = {
   gridTemplateColumns: "290px 360px 40px auto",
@@ -158,10 +159,11 @@ const TestingModelGridView = () => {
                         color="gray.600"
                       />
                     </VStack>
-                    <CodeViewGridItem
-                      gesture={gesture}
-                      projectEdited={projectEdited}
-                    />
+                    {!projectEdited ? (
+                      <CodeViewGridItem gesture={gesture} />
+                    ) : (
+                      <GridItem />
+                    )}
                   </React.Fragment>
                 );
               })}


### PR DESCRIPTION
We previously re-created the project code for each default block, even when they were not shown because the user had edited the project.