### PR TITLE
Handle importing of different files

### DIFF
--- a/lang/ui.en.json
+++ b/lang/ui.en.json
@@ -876,7 +876,7 @@
     "description": "Empty data samples page status text"
   },
   "not-create-ai-hex-import-dialog-content": {
-    "defaultMessage": "Train a model to view your imported MakeCode project.",
+    "defaultMessage": "Train a model to view your imported project.",
     "description": "Content of import non-CreateAI hex dialog"
   },
   "not-create-ai-hex-import-dialog-title": {

--- a/lang/ui.en.json
+++ b/lang/ui.en.json
@@ -727,6 +727,14 @@
     "defaultMessage": "Import data samples",
     "description": "Data samples action"
   },
+  "import-error-dialog-content": {
+    "defaultMessage": "Only a MakeCode hex file can be imported.",
+    "description": "Content of import error dialog"
+  },
+  "import-error-dialog-title": {
+    "defaultMessage": "File cannot be imported",
+    "description": "Title of import error dialog"
+  },
   "incompatible-device-body-alt": {
     "defaultMessage": "Go back to select a different micro:bit, or <link>save the project hex</link> which can be downloaded onto a micro:bit V2 later.",
     "description": "Incompatible device dialog body text"
@@ -882,14 +890,6 @@
   "not-found-title": {
     "defaultMessage": "Page not found",
     "description": "Page not found page title"
-  },
-  "not-makecode-hex-import-error-dialog-content": {
-    "defaultMessage": "Only a MakeCode hex file can be imported.",
-    "description": "Content of import MakeCode hex error dialog"
-  },
-  "not-makecode-hex-import-error-dialog-title": {
-    "defaultMessage": "Not a MakeCode hex file",
-    "description": "Title of import MakeCode hex error dialog"
   },
   "open-file-action": {
     "defaultMessage": "Open…",

--- a/lang/ui.en.json
+++ b/lang/ui.en.json
@@ -875,6 +875,14 @@
     "defaultMessage": "Page not found",
     "description": "Page not found page title"
   },
+  "not-makecode-hex-import-error-dialog-content": {
+    "defaultMessage": "Only a MakeCode hex file can be imported.",
+    "description": "Title of import MakeCode hex error dialog"
+  },
+  "not-makecode-hex-import-error-dialog-title": {
+    "defaultMessage": "Not a MakeCode hex file",
+    "description": "Title of import MakeCode hex error dialog"
+  },
   "open-file-action": {
     "defaultMessage": "Open…",
     "description": "Open file button text"

--- a/lang/ui.en.json
+++ b/lang/ui.en.json
@@ -728,11 +728,11 @@
     "description": "Data samples action"
   },
   "import-error-dialog-content": {
-    "defaultMessage": "Only a MakeCode hex file or a data samples json file can be opened for {appNameFull}.",
+    "defaultMessage": "Only MakeCode hex files or data samples files (.json) can be opened by {appNameFull}.",
     "description": "Content of import error dialog"
   },
   "import-error-dialog-title": {
-    "defaultMessage": "Cannot open file",
+    "defaultMessage": "Unsupported file type",
     "description": "Title of import error dialog"
   },
   "incompatible-device-body-alt": {
@@ -876,7 +876,7 @@
     "description": "Empty data samples page status text"
   },
   "not-create-ai-hex-import-dialog-content": {
-    "defaultMessage": "Train a model to view your code.",
+    "defaultMessage": "This project did not contain any data samples, so only the code has been opened. You need to train a model before you can use the code.",
     "description": "Content of import non-CreateAI hex dialog"
   },
   "not-create-ai-hex-import-dialog-title": {

--- a/lang/ui.en.json
+++ b/lang/ui.en.json
@@ -867,6 +867,14 @@
     "defaultMessage": "No data samples",
     "description": "Empty data samples page status text"
   },
+  "not-create-ai-hex-import-dialog-content": {
+    "defaultMessage": "Train a model to view your imported MakeCode project.",
+    "description": "Content of import non-CreateAI hex dialog"
+  },
+  "not-create-ai-hex-import-dialog-title": {
+    "defaultMessage": "Your MakeCode project has been imported",
+    "description": "Title of import non-CreateAI hex dialog"
+  },
   "not-found": {
     "defaultMessage": "{appNameFull} home page",
     "description": "Page not found link text"
@@ -877,7 +885,7 @@
   },
   "not-makecode-hex-import-error-dialog-content": {
     "defaultMessage": "Only a MakeCode hex file can be imported.",
-    "description": "Title of import MakeCode hex error dialog"
+    "description": "Content of import MakeCode hex error dialog"
   },
   "not-makecode-hex-import-error-dialog-title": {
     "defaultMessage": "Not a MakeCode hex file",

--- a/lang/ui.en.json
+++ b/lang/ui.en.json
@@ -728,7 +728,7 @@
     "description": "Data samples action"
   },
   "import-error-dialog-content": {
-    "defaultMessage": "Only a MakeCode hex file can be imported.",
+    "defaultMessage": "Only a MakeCode hex file or a data samples json file can be imported.",
     "description": "Content of import error dialog"
   },
   "import-error-dialog-title": {

--- a/lang/ui.en.json
+++ b/lang/ui.en.json
@@ -728,11 +728,11 @@
     "description": "Data samples action"
   },
   "import-error-dialog-content": {
-    "defaultMessage": "Only a MakeCode hex file or a data samples json file can be imported.",
+    "defaultMessage": "Only a MakeCode hex file or a data samples json file can be opened for {appNameFull}.",
     "description": "Content of import error dialog"
   },
   "import-error-dialog-title": {
-    "defaultMessage": "File cannot be imported",
+    "defaultMessage": "Cannot open file",
     "description": "Title of import error dialog"
   },
   "incompatible-device-body-alt": {
@@ -876,7 +876,7 @@
     "description": "Empty data samples page status text"
   },
   "not-create-ai-hex-import-dialog-content": {
-    "defaultMessage": "Train a model to view your imported project.",
+    "defaultMessage": "Train a model to view your code.",
     "description": "Content of import non-CreateAI hex dialog"
   },
   "not-create-ai-hex-import-dialog-title": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,7 +83,7 @@ const Layout = () => {
     return useStore.subscribe(
       (
         { projectLoadTimestamp },
-        { projectLoadTimestamp: prevProjectLoadTimestamp, project }
+        { projectLoadTimestamp: prevProjectLoadTimestamp, getCurrentProject }
       ) => {
         if (projectLoadTimestamp > prevProjectLoadTimestamp) {
           // Side effects of loading a project, which MakeCode notifies us of.
@@ -94,6 +94,7 @@ const Layout = () => {
             title: intl.formatMessage({ id: "project-loaded" }),
             status: "info",
           });
+          const project = getCurrentProject();
           if (!hasMakeCodeMlExtension(project)) {
             setPostImportDialogState(PostImportDialogState.NonCreateAiHex);
           }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import {
   createNewPageUrl,
   createTestingModelPageUrl,
 } from "./urls";
+import { hasMakeCodeMlExtension } from "./makecode/utils";
 
 export interface ProviderLayoutProps {
   children: ReactNode;
@@ -75,12 +76,15 @@ const Layout = () => {
   const navigate = useNavigate();
   const toast = useToast();
   const intl = useIntl();
+  const setIsNotCreateAiDialogOpen = useStore(
+    (s) => s.setIsNotCreateAHexiDialogOpen
+  );
 
   useEffect(() => {
     return useStore.subscribe(
       (
         { projectLoadTimestamp },
-        { projectLoadTimestamp: prevProjectLoadTimestamp }
+        { projectLoadTimestamp: prevProjectLoadTimestamp, project }
       ) => {
         if (projectLoadTimestamp > prevProjectLoadTimestamp) {
           // Side effects of loading a project, which MakeCode notifies us of.
@@ -91,10 +95,13 @@ const Layout = () => {
             title: intl.formatMessage({ id: "project-loaded" }),
             status: "info",
           });
+          if (!hasMakeCodeMlExtension(project)) {
+            setIsNotCreateAiDialogOpen(true);
+          }
         }
       }
     );
-  }, [intl, navigate, toast]);
+  }, [intl, navigate, setIsNotCreateAiDialogOpen, toast]);
 
   return (
     // We use this even though we have errorElement as this does logging.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,7 @@ import {
   createTestingModelPageUrl,
 } from "./urls";
 import { hasMakeCodeMlExtension } from "./makecode/utils";
+import { PostImportDialogState } from "./model";
 
 export interface ProviderLayoutProps {
   children: ReactNode;
@@ -73,12 +74,10 @@ const Providers = ({ children }: ProviderLayoutProps) => {
 
 const Layout = () => {
   const driverRef = useRef<MakeCodeFrameDriver>(null);
+  const setPostImportDialogState = useStore((s) => s.setPostImportDialogState);
   const navigate = useNavigate();
   const toast = useToast();
   const intl = useIntl();
-  const setIsNotCreateAiDialogOpen = useStore(
-    (s) => s.setIsNotCreateAHexiDialogOpen
-  );
 
   useEffect(() => {
     return useStore.subscribe(
@@ -96,12 +95,12 @@ const Layout = () => {
             status: "info",
           });
           if (!hasMakeCodeMlExtension(project)) {
-            setIsNotCreateAiDialogOpen(true);
+            setPostImportDialogState(PostImportDialogState.NonCreateAiHex);
           }
         }
       }
     );
-  }, [intl, navigate, setIsNotCreateAiDialogOpen, toast]);
+  }, [intl, navigate, setPostImportDialogState, toast]);
 
   return (
     // We use this even though we have errorElement as this does logging.

--- a/src/components/DefaultPageLayout.tsx
+++ b/src/components/DefaultPageLayout.tsx
@@ -36,6 +36,7 @@ import SettingsMenu from "./SettingsMenu";
 import ToolbarMenu from "./ToolbarMenu";
 import HelpMenuItems from "./HelpMenuItems";
 import NotMakeCodeHexImportErrorDialog from "./NotMakeCodeHexImportErrorDialog";
+import NotCreateAiHexImportDialog from "./NotCreateAiHexImportDialog";
 
 interface DefaultPageLayoutProps {
   titleId?: string;
@@ -59,6 +60,7 @@ const DefaultPageLayout = ({
   const isNotMakeCodeHexDialogOpen = useStore(
     (s) => s.isNotMakeCodeHexDialogOpen
   );
+  const isNotCreateAiDialogOpen = useStore((s) => s.isNotCreateAiHexDialogOpen);
 
   const isTourClosed = useStore((s) => s.tourState === undefined);
   const isTrainDialogClosed = useStore(
@@ -82,9 +84,11 @@ const DefaultPageLayout = ({
         isTrainDialogClosed &&
         isTourClosed &&
         isSaveDialogClosed &&
-        !isNotMakeCodeHexDialogOpen && <ConnectionDialogs />}
+        !isNotMakeCodeHexDialogOpen &&
+        !isNotCreateAiDialogOpen && <ConnectionDialogs />}
       <Tour />
       <SaveDialogs />
+      {isNotCreateAiDialogOpen && <NotCreateAiHexImportDialog />}
       {isNotMakeCodeHexDialogOpen && <NotMakeCodeHexImportErrorDialog />}
       <ProjectDropTarget
         isEnabled={

--- a/src/components/DefaultPageLayout.tsx
+++ b/src/components/DefaultPageLayout.tsx
@@ -20,7 +20,11 @@ import {
 import { useDeployment } from "../deployment";
 import { flags } from "../flags";
 import { useProject } from "../hooks/project-hooks";
-import { SaveStep, TrainModelDialogStage } from "../model";
+import {
+  PostImportDialogState,
+  SaveStep,
+  TrainModelDialogStage,
+} from "../model";
 import Tour from "../pages/Tour";
 import { useStore } from "../store";
 import { createHomePageUrl } from "../urls";
@@ -57,11 +61,6 @@ const DefaultPageLayout = ({
 }: DefaultPageLayoutProps) => {
   const intl = useIntl();
   const isEditorOpen = useStore((s) => s.isEditorOpen);
-  const isNotMakeCodeHexDialogOpen = useStore(
-    (s) => s.isNotMakeCodeHexDialogOpen
-  );
-  const isNotCreateAiDialogOpen = useStore((s) => s.isNotCreateAiHexDialogOpen);
-
   const isTourClosed = useStore((s) => s.tourState === undefined);
   const isTrainDialogClosed = useStore(
     (s) => s.trainModelDialogStage === TrainModelDialogStage.Closed
@@ -77,6 +76,12 @@ const DefaultPageLayout = ({
       : appNameFull;
   }, [appNameFull, intl, titleId]);
 
+  const postImportDialogState = useStore((s) => s.postImportDialogState);
+  const setPostImportDialogState = useStore((s) => s.setPostImportDialogState);
+  const closePostImportDialog = useCallback(() => {
+    setPostImportDialogState(PostImportDialogState.None);
+  }, [setPostImportDialogState]);
+
   return (
     <>
       {/* Suppress dialogs to prevent overlapping dialogs */}
@@ -84,12 +89,19 @@ const DefaultPageLayout = ({
         isTrainDialogClosed &&
         isTourClosed &&
         isSaveDialogClosed &&
-        !isNotMakeCodeHexDialogOpen &&
-        !isNotCreateAiDialogOpen && <ConnectionDialogs />}
+        postImportDialogState === PostImportDialogState.None && (
+          <ConnectionDialogs />
+        )}
       <Tour />
       <SaveDialogs />
-      {isNotCreateAiDialogOpen && <NotCreateAiHexImportDialog />}
-      {isNotMakeCodeHexDialogOpen && <NotMakeCodeHexImportErrorDialog />}
+      <NotCreateAiHexImportDialog
+        onClose={closePostImportDialog}
+        isOpen={postImportDialogState === PostImportDialogState.NonCreateAiHex}
+      />
+      <NotMakeCodeHexImportErrorDialog
+        onClose={closePostImportDialog}
+        isOpen={postImportDialogState === PostImportDialogState.NonMakeCodeHex}
+      />
       <ProjectDropTarget
         isEnabled={
           isTrainDialogClosed &&

--- a/src/components/DefaultPageLayout.tsx
+++ b/src/components/DefaultPageLayout.tsx
@@ -35,6 +35,7 @@ import SaveDialogs from "./SaveDialogs";
 import SettingsMenu from "./SettingsMenu";
 import ToolbarMenu from "./ToolbarMenu";
 import HelpMenuItems from "./HelpMenuItems";
+import NotMakeCodeHexImportErrorDialog from "./NotMakeCodeHexImportErrorDialog";
 
 interface DefaultPageLayoutProps {
   titleId?: string;
@@ -55,6 +56,10 @@ const DefaultPageLayout = ({
 }: DefaultPageLayoutProps) => {
   const intl = useIntl();
   const isEditorOpen = useStore((s) => s.isEditorOpen);
+  const isNotMakeCodeHexDialogOpen = useStore(
+    (s) => s.isNotMakeCodeHexDialogOpen
+  );
+
   const isTourClosed = useStore((s) => s.tourState === undefined);
   const isTrainDialogClosed = useStore(
     (s) => s.trainModelDialogStage === TrainModelDialogStage.Closed
@@ -76,9 +81,11 @@ const DefaultPageLayout = ({
       {!isEditorOpen &&
         isTrainDialogClosed &&
         isTourClosed &&
-        isSaveDialogClosed && <ConnectionDialogs />}
+        isSaveDialogClosed &&
+        !isNotMakeCodeHexDialogOpen && <ConnectionDialogs />}
       <Tour />
       <SaveDialogs />
+      {isNotMakeCodeHexDialogOpen && <NotMakeCodeHexImportErrorDialog />}
       <ProjectDropTarget
         isEnabled={
           isTrainDialogClosed &&

--- a/src/components/DefaultPageLayout.tsx
+++ b/src/components/DefaultPageLayout.tsx
@@ -39,7 +39,7 @@ import SaveDialogs from "./SaveDialogs";
 import SettingsMenu from "./SettingsMenu";
 import ToolbarMenu from "./ToolbarMenu";
 import HelpMenuItems from "./HelpMenuItems";
-import NotMakeCodeHexImportErrorDialog from "./NotMakeCodeHexImportErrorDialog";
+import ImportErrorDialog from "./ImportErrorDialog";
 import NotCreateAiHexImportDialog from "./NotCreateAiHexImportDialog";
 
 interface DefaultPageLayoutProps {
@@ -98,9 +98,9 @@ const DefaultPageLayout = ({
         onClose={closePostImportDialog}
         isOpen={postImportDialogState === PostImportDialogState.NonCreateAiHex}
       />
-      <NotMakeCodeHexImportErrorDialog
+      <ImportErrorDialog
         onClose={closePostImportDialog}
-        isOpen={postImportDialogState === PostImportDialogState.NonMakeCodeHex}
+        isOpen={postImportDialogState === PostImportDialogState.Error}
       />
       <ProjectDropTarget
         isEnabled={

--- a/src/components/ImportErrorDialog.tsx
+++ b/src/components/ImportErrorDialog.tsx
@@ -11,11 +11,13 @@ import {
   Text,
 } from "@chakra-ui/react";
 import { FormattedMessage } from "react-intl";
+import { useDeployment } from "../deployment";
 
 const ImportErrorDialog = ({
   onClose,
   ...props
 }: Omit<ModalProps, "children">) => {
+  const { appNameFull } = useDeployment();
   return (
     <Modal
       closeOnOverlayClick={false}
@@ -33,7 +35,10 @@ const ImportErrorDialog = ({
           <ModalBody>
             <ModalCloseButton />
             <Text>
-              <FormattedMessage id="import-error-dialog-content" />
+              <FormattedMessage
+                id="import-error-dialog-content"
+                values={{ appNameFull }}
+              />
             </Text>
           </ModalBody>
           <ModalFooter justifyContent="flex-end">

--- a/src/components/ImportErrorDialog.tsx
+++ b/src/components/ImportErrorDialog.tsx
@@ -12,7 +12,7 @@ import {
 } from "@chakra-ui/react";
 import { FormattedMessage } from "react-intl";
 
-const NotMakeCodeHexImportErrorDialog = ({
+const ImportErrorDialog = ({
   onClose,
   ...props
 }: Omit<ModalProps, "children">) => {
@@ -28,12 +28,12 @@ const NotMakeCodeHexImportErrorDialog = ({
       <ModalOverlay>
         <ModalContent>
           <ModalHeader>
-            <FormattedMessage id="not-makecode-hex-import-error-dialog-title" />
+            <FormattedMessage id="import-error-dialog-title" />
           </ModalHeader>
           <ModalBody>
             <ModalCloseButton />
             <Text>
-              <FormattedMessage id="not-makecode-hex-import-error-dialog-content" />
+              <FormattedMessage id="import-error-dialog-content" />
             </Text>
           </ModalBody>
           <ModalFooter justifyContent="flex-end">
@@ -47,4 +47,4 @@ const NotMakeCodeHexImportErrorDialog = ({
   );
 };
 
-export default NotMakeCodeHexImportErrorDialog;
+export default ImportErrorDialog;

--- a/src/components/NotCreateAiHexImportDialog.tsx
+++ b/src/components/NotCreateAiHexImportDialog.tsx
@@ -1,0 +1,54 @@
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+} from "@chakra-ui/react";
+import { useCallback } from "react";
+import { FormattedMessage } from "react-intl";
+import { useStore } from "../store";
+
+const NotCreateAiHexImportDialog = () => {
+  const setIsNotCreateAiHexDialogOpen = useStore(
+    (s) => s.setIsNotCreateAHexiDialogOpen
+  );
+  const handleClose = useCallback(() => {
+    setIsNotCreateAiHexDialogOpen(false);
+  }, [setIsNotCreateAiHexDialogOpen]);
+  return (
+    <Modal
+      isOpen
+      closeOnOverlayClick={false}
+      motionPreset="none"
+      size="md"
+      isCentered
+      onClose={handleClose}
+    >
+      <ModalOverlay>
+        <ModalContent>
+          <ModalHeader>
+            <FormattedMessage id="not-create-ai-hex-import-dialog-title" />
+          </ModalHeader>
+          <ModalBody>
+            <ModalCloseButton />
+            <Text>
+              <FormattedMessage id="not-create-ai-hex-import-dialog-content" />
+            </Text>
+          </ModalBody>
+          <ModalFooter justifyContent="flex-end">
+            <Button variant="primary" onClick={handleClose}>
+              <FormattedMessage id="close-action" />
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </ModalOverlay>
+    </Modal>
+  );
+};
+
+export default NotCreateAiHexImportDialog;

--- a/src/components/NotCreateAiHexImportDialog.tsx
+++ b/src/components/NotCreateAiHexImportDialog.tsx
@@ -20,7 +20,7 @@ const NotCreateAiHexImportDialog = ({
     <Modal
       closeOnOverlayClick={false}
       motionPreset="none"
-      size="md"
+      size="lg"
       isCentered
       onClose={onClose}
       {...props}

--- a/src/components/NotCreateAiHexImportDialog.tsx
+++ b/src/components/NotCreateAiHexImportDialog.tsx
@@ -7,27 +7,23 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
+  ModalProps,
   Text,
 } from "@chakra-ui/react";
-import { useCallback } from "react";
 import { FormattedMessage } from "react-intl";
-import { useStore } from "../store";
 
-const NotCreateAiHexImportDialog = () => {
-  const setIsNotCreateAiHexDialogOpen = useStore(
-    (s) => s.setIsNotCreateAHexiDialogOpen
-  );
-  const handleClose = useCallback(() => {
-    setIsNotCreateAiHexDialogOpen(false);
-  }, [setIsNotCreateAiHexDialogOpen]);
+const NotCreateAiHexImportDialog = ({
+  onClose,
+  ...props
+}: Omit<ModalProps, "children">) => {
   return (
     <Modal
-      isOpen
       closeOnOverlayClick={false}
       motionPreset="none"
       size="md"
       isCentered
-      onClose={handleClose}
+      onClose={onClose}
+      {...props}
     >
       <ModalOverlay>
         <ModalContent>
@@ -41,7 +37,7 @@ const NotCreateAiHexImportDialog = () => {
             </Text>
           </ModalBody>
           <ModalFooter justifyContent="flex-end">
-            <Button variant="primary" onClick={handleClose}>
+            <Button variant="primary" onClick={onClose}>
               <FormattedMessage id="close-action" />
             </Button>
           </ModalFooter>

--- a/src/components/NotMakeCodeHexImportErrorDialog.tsx
+++ b/src/components/NotMakeCodeHexImportErrorDialog.tsx
@@ -1,0 +1,54 @@
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+} from "@chakra-ui/react";
+import { useCallback } from "react";
+import { FormattedMessage } from "react-intl";
+import { useStore } from "../store";
+
+const NotMakeCodeHexImportErrorDialog = () => {
+  const setIsNotMakeCodeHexDialogOpen = useStore(
+    (s) => s.setIsNotMakeCodeHexDialogOpen
+  );
+  const handleClose = useCallback(() => {
+    setIsNotMakeCodeHexDialogOpen(false);
+  }, [setIsNotMakeCodeHexDialogOpen]);
+  return (
+    <Modal
+      isOpen
+      closeOnOverlayClick={false}
+      motionPreset="none"
+      size="md"
+      isCentered
+      onClose={handleClose}
+    >
+      <ModalOverlay>
+        <ModalContent>
+          <ModalHeader>
+            <FormattedMessage id="not-makecode-hex-import-error-dialog-title" />
+          </ModalHeader>
+          <ModalBody>
+            <ModalCloseButton />
+            <Text>
+              <FormattedMessage id="not-makecode-hex-import-error-dialog-content" />
+            </Text>
+          </ModalBody>
+          <ModalFooter justifyContent="flex-end">
+            <Button variant="primary" onClick={handleClose}>
+              <FormattedMessage id="close-action" />
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </ModalOverlay>
+    </Modal>
+  );
+};
+
+export default NotMakeCodeHexImportErrorDialog;

--- a/src/components/NotMakeCodeHexImportErrorDialog.tsx
+++ b/src/components/NotMakeCodeHexImportErrorDialog.tsx
@@ -7,27 +7,23 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
+  ModalProps,
   Text,
 } from "@chakra-ui/react";
-import { useCallback } from "react";
 import { FormattedMessage } from "react-intl";
-import { useStore } from "../store";
 
-const NotMakeCodeHexImportErrorDialog = () => {
-  const setIsNotMakeCodeHexDialogOpen = useStore(
-    (s) => s.setIsNotMakeCodeHexDialogOpen
-  );
-  const handleClose = useCallback(() => {
-    setIsNotMakeCodeHexDialogOpen(false);
-  }, [setIsNotMakeCodeHexDialogOpen]);
+const NotMakeCodeHexImportErrorDialog = ({
+  onClose,
+  ...props
+}: Omit<ModalProps, "children">) => {
   return (
     <Modal
-      isOpen
       closeOnOverlayClick={false}
       motionPreset="none"
       size="md"
       isCentered
-      onClose={handleClose}
+      onClose={onClose}
+      {...props}
     >
       <ModalOverlay>
         <ModalContent>
@@ -41,7 +37,7 @@ const NotMakeCodeHexImportErrorDialog = () => {
             </Text>
           </ModalBody>
           <ModalFooter justifyContent="flex-end">
-            <Button variant="primary" onClick={handleClose}>
+            <Button variant="primary" onClick={onClose}>
               <FormattedMessage id="close-action" />
             </Button>
           </ModalFooter>

--- a/src/hooks/project-hooks.tsx
+++ b/src/hooks/project-hooks.tsx
@@ -181,10 +181,16 @@ export const ProjectProvider = ({
           // TODO: complain to the user!
         }
       } else if (fileExtension === "hex") {
-        driverRef.current!.importFile({
-          filename: file.name,
-          parts: [await readFileAsText(file)],
-        });
+        const hex = await readFileAsText(file);
+        const makeCodeMagicMark = "41140E2FB82FA2BB";
+        if (hex.includes(makeCodeMagicMark)) {
+          driverRef.current!.importFile({
+            filename: file.name,
+            parts: [await readFileAsText(file)],
+          });
+        } else {
+          console.log("not makecode");
+        }
       }
     },
     [driverRef, loadDataset, logging, navigate]

--- a/src/hooks/project-hooks.tsx
+++ b/src/hooks/project-hooks.tsx
@@ -17,7 +17,12 @@ import {
 import { useIntl } from "react-intl";
 import { useNavigate } from "react-router";
 import { useLogging } from "../logging/logging-hooks";
-import { HexData, isDatasetUserFileFormat, SaveStep } from "../model";
+import {
+  HexData,
+  isDatasetUserFileFormat,
+  PostImportDialogState,
+  SaveStep,
+} from "../model";
 import { defaultProjectName } from "../project-name";
 import { useStore } from "../store";
 import {
@@ -92,9 +97,7 @@ export const ProjectProvider = ({
   const projectFlushedToEditor = useStore((s) => s.projectFlushedToEditor);
   const checkIfProjectNeedsFlush = useStore((s) => s.checkIfProjectNeedsFlush);
   const getCurrentProject = useStore((s) => s.getCurrentProject);
-  const setIsNotMakeCodeHexDialogOpen = useStore(
-    (s) => s.setIsNotMakeCodeHexDialogOpen
-  );
+  const setPostImportDialogState = useStore((s) => s.setPostImportDialogState);
   const navigate = useNavigate();
   const doAfterEditorUpdatePromise = useRef<Promise<void>>();
   const doAfterEditorUpdate = useCallback(
@@ -193,11 +196,11 @@ export const ProjectProvider = ({
             parts: [hex],
           });
         } else {
-          setIsNotMakeCodeHexDialogOpen(true);
+          setPostImportDialogState(PostImportDialogState.NonMakeCodeHex);
         }
       }
     },
-    [driverRef, loadDataset, logging, navigate, setIsNotMakeCodeHexDialogOpen]
+    [driverRef, loadDataset, logging, navigate, setPostImportDialogState]
   );
 
   const setSave = useStore((s) => s.setSave);

--- a/src/hooks/project-hooks.tsx
+++ b/src/hooks/project-hooks.tsx
@@ -92,6 +92,9 @@ export const ProjectProvider = ({
   const projectFlushedToEditor = useStore((s) => s.projectFlushedToEditor);
   const checkIfProjectNeedsFlush = useStore((s) => s.checkIfProjectNeedsFlush);
   const getCurrentProject = useStore((s) => s.getCurrentProject);
+  const setIsNotMakeCodeHexDialogOpen = useStore(
+    (s) => s.setIsNotMakeCodeHexDialogOpen
+  );
   const navigate = useNavigate();
   const doAfterEditorUpdatePromise = useRef<Promise<void>>();
   const doAfterEditorUpdate = useCallback(
@@ -189,11 +192,11 @@ export const ProjectProvider = ({
             parts: [await readFileAsText(file)],
           });
         } else {
-          console.log("not makecode");
+          setIsNotMakeCodeHexDialogOpen(true);
         }
       }
     },
-    [driverRef, loadDataset, logging, navigate]
+    [driverRef, loadDataset, logging, navigate, setIsNotMakeCodeHexDialogOpen]
   );
 
   const setSave = useStore((s) => s.setSave);

--- a/src/hooks/project-hooks.tsx
+++ b/src/hooks/project-hooks.tsx
@@ -184,7 +184,7 @@ export const ProjectProvider = ({
           loadDataset(gestureData);
           navigate(createDataSamplesPageUrl());
         } else {
-          // TODO: complain to the user!
+          setPostImportDialogState(PostImportDialogState.Error);
         }
       } else if (fileExtension === "hex") {
         const hex = await readFileAsText(file);

--- a/src/hooks/project-hooks.tsx
+++ b/src/hooks/project-hooks.tsx
@@ -196,8 +196,10 @@ export const ProjectProvider = ({
             parts: [hex],
           });
         } else {
-          setPostImportDialogState(PostImportDialogState.NonMakeCodeHex);
+          setPostImportDialogState(PostImportDialogState.Error);
         }
+      } else {
+        setPostImportDialogState(PostImportDialogState.Error);
       }
     },
     [driverRef, loadDataset, logging, navigate, setPostImportDialogState]

--- a/src/hooks/project-hooks.tsx
+++ b/src/hooks/project-hooks.tsx
@@ -186,10 +186,11 @@ export const ProjectProvider = ({
       } else if (fileExtension === "hex") {
         const hex = await readFileAsText(file);
         const makeCodeMagicMark = "41140E2FB82FA2BB";
+        // Check if is a MakeCode hex, otherwise show error dialog.
         if (hex.includes(makeCodeMagicMark)) {
           driverRef.current!.importFile({
             filename: file.name,
-            parts: [await readFileAsText(file)],
+            parts: [hex],
           });
         } else {
           setIsNotMakeCodeHexDialogOpen(true);

--- a/src/makecode/utils.test.ts
+++ b/src/makecode/utils.test.ts
@@ -20,6 +20,7 @@ import {
   filenames,
   generateCustomFiles,
   generateProject,
+  hasMakeCodeMlExtension,
   pxt,
 } from "./utils";
 import { currentDataWindow } from "../store";
@@ -260,5 +261,37 @@ describe("test actionNamesFromLabels", () => {
     ];
     const userDefined = ["내 행동"];
     expect(actionNamesFromLabels(userDefined)).toEqual(expected);
+  });
+});
+
+describe("test hasMakeCodeMlExtension", () => {
+  it("has extension, returns true", () => {
+    const project: Project = {
+      text: {
+        [filenames.pxtJson]: JSON.stringify({
+          dependencies: {
+            [extensionName]: "extension url",
+          },
+        }),
+      },
+    };
+    expect(hasMakeCodeMlExtension(project)).toEqual(true);
+  });
+
+  it("does not have extension, returns false", () => {
+    const project: Project = {
+      text: {
+        [filenames.pxtJson]: JSON.stringify({
+          dependencies: {
+            "some other extension": "extension url",
+          },
+        }),
+      },
+    };
+    expect(hasMakeCodeMlExtension(project)).toEqual(false);
+  });
+
+  it("empty object, returns false", () => {
+    expect(hasMakeCodeMlExtension({})).toEqual(false);
   });
 });

--- a/src/makecode/utils.ts
+++ b/src/makecode/utils.ts
@@ -137,3 +137,14 @@ export const actionNamesFromLabels = (actionLabels: string[]): ActionName[] => {
   });
   return actionNames;
 };
+
+export const hasMakeCodeMlExtension = (project: Project) => {
+  if (!project.text || !project.text[filenames.pxtJson]) {
+    return false;
+  }
+  const pxtJson = JSON.parse(project.text[filenames.pxtJson]) as object;
+  if (!("dependencies" in pxtJson)) {
+    return false;
+  }
+  return extensionName in (pxtJson["dependencies"] as object);
+};

--- a/src/messages/ui.en.json
+++ b/src/messages/ui.en.json
@@ -1315,6 +1315,18 @@
       "value": "Import data samples"
     }
   ],
+  "import-error-dialog-content": [
+    {
+      "type": 0,
+      "value": "Only a MakeCode hex file can be imported."
+    }
+  ],
+  "import-error-dialog-title": [
+    {
+      "type": 0,
+      "value": "File cannot be imported"
+    }
+  ],
   "incompatible-device-body-alt": [
     {
       "type": 0,
@@ -1631,18 +1643,6 @@
     {
       "type": 0,
       "value": "Page not found"
-    }
-  ],
-  "not-makecode-hex-import-error-dialog-content": [
-    {
-      "type": 0,
-      "value": "Only a MakeCode hex file can be imported."
-    }
-  ],
-  "not-makecode-hex-import-error-dialog-title": [
-    {
-      "type": 0,
-      "value": "Not a MakeCode hex file"
     }
   ],
   "open-file-action": [

--- a/src/messages/ui.en.json
+++ b/src/messages/ui.en.json
@@ -1318,7 +1318,7 @@
   "import-error-dialog-content": [
     {
       "type": 0,
-      "value": "Only a MakeCode hex file can be imported."
+      "value": "Only a MakeCode hex file or a data samples json file can be imported."
     }
   ],
   "import-error-dialog-title": [

--- a/src/messages/ui.en.json
+++ b/src/messages/ui.en.json
@@ -1621,6 +1621,18 @@
       "value": "Page not found"
     }
   ],
+  "not-makecode-hex-import-error-dialog-content": [
+    {
+      "type": 0,
+      "value": "Only a MakeCode hex file can be imported."
+    }
+  ],
+  "not-makecode-hex-import-error-dialog-title": [
+    {
+      "type": 0,
+      "value": "Not a MakeCode hex file"
+    }
+  ],
   "open-file-action": [
     {
       "type": 0,

--- a/src/messages/ui.en.json
+++ b/src/messages/ui.en.json
@@ -1605,6 +1605,18 @@
       "value": "No data samples"
     }
   ],
+  "not-create-ai-hex-import-dialog-content": [
+    {
+      "type": 0,
+      "value": "Train a model to view your imported MakeCode project."
+    }
+  ],
+  "not-create-ai-hex-import-dialog-title": [
+    {
+      "type": 0,
+      "value": "Your MakeCode project has been imported"
+    }
+  ],
   "not-found": [
     {
       "type": 1,

--- a/src/messages/ui.en.json
+++ b/src/messages/ui.en.json
@@ -1318,7 +1318,7 @@
   "import-error-dialog-content": [
     {
       "type": 0,
-      "value": "Only a MakeCode hex file or a data samples json file can be opened for "
+      "value": "Only MakeCode hex files or a data samples files (.json) can be opened by "
     },
     {
       "type": 1,
@@ -1332,7 +1332,7 @@
   "import-error-dialog-title": [
     {
       "type": 0,
-      "value": "Cannot open file"
+      "value": "Unsupported file type"
     }
   ],
   "incompatible-device-body-alt": [
@@ -1628,7 +1628,7 @@
   "not-create-ai-hex-import-dialog-content": [
     {
       "type": 0,
-      "value": "Train a model to view your code."
+      "value": "This project did not contain any data samples, so only the code has been opened. You need to train a model before you can use the code."
     }
   ],
   "not-create-ai-hex-import-dialog-title": [

--- a/src/messages/ui.en.json
+++ b/src/messages/ui.en.json
@@ -1620,7 +1620,7 @@
   "not-create-ai-hex-import-dialog-content": [
     {
       "type": 0,
-      "value": "Train a model to view your imported MakeCode project."
+      "value": "Train a model to view your imported project."
     }
   ],
   "not-create-ai-hex-import-dialog-title": [

--- a/src/messages/ui.en.json
+++ b/src/messages/ui.en.json
@@ -1318,13 +1318,21 @@
   "import-error-dialog-content": [
     {
       "type": 0,
-      "value": "Only a MakeCode hex file or a data samples json file can be imported."
+      "value": "Only a MakeCode hex file or a data samples json file can be opened for "
+    },
+    {
+      "type": 1,
+      "value": "appNameFull"
+    },
+    {
+      "type": 0,
+      "value": "."
     }
   ],
   "import-error-dialog-title": [
     {
       "type": 0,
-      "value": "File cannot be imported"
+      "value": "Cannot open file"
     }
   ],
   "incompatible-device-body-alt": [
@@ -1620,7 +1628,7 @@
   "not-create-ai-hex-import-dialog-content": [
     {
       "type": 0,
-      "value": "Train a model to view your imported project."
+      "value": "Train a model to view your code."
     }
   ],
   "not-create-ai-hex-import-dialog-title": [

--- a/src/model.ts
+++ b/src/model.ts
@@ -202,3 +202,9 @@ export enum DataSamplesView {
   DataFeatures = "data features",
   GraphAndDataFeatures = "graph and data features",
 }
+
+export enum PostImportDialogState {
+  None = "graph",
+  NonMakeCodeHex = "non makecode hex dialog",
+  NonCreateAiHex = "non create ai hex dialog",
+}

--- a/src/model.ts
+++ b/src/model.ts
@@ -205,6 +205,6 @@ export enum DataSamplesView {
 
 export enum PostImportDialogState {
   None = "graph",
-  NonMakeCodeHex = "non makecode hex dialog",
+  Error = "error",
   NonCreateAiHex = "non create ai hex dialog",
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -204,7 +204,7 @@ export enum DataSamplesView {
 }
 
 export enum PostImportDialogState {
-  None = "graph",
+  None = "none",
   Error = "error",
   NonCreateAiHex = "non create ai hex dialog",
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -19,6 +19,7 @@ import {
   Gesture,
   GestureData,
   MicrobitToFlash,
+  PostImportDialogState,
   RecordingData,
   SaveState,
   SaveStep,
@@ -148,8 +149,7 @@ export interface State {
   trainModelDialogStage: TrainModelDialogStage;
 
   tourState?: TourState;
-  isNotMakeCodeHexDialogOpen: boolean;
-  isNotCreateAiHexDialogOpen: boolean;
+  postImportDialogState: PostImportDialogState;
 }
 
 export interface Actions {
@@ -208,8 +208,7 @@ export interface Actions {
 
   setDataSamplesView(view: DataSamplesView): void;
 
-  setIsNotMakeCodeHexDialogOpen(isOpen: boolean): void;
-  setIsNotCreateAHexiDialogOpen(isOpen: boolean): void;
+  setPostImportDialogState(state: PostImportDialogState): void;
 }
 
 type Store = State & Actions;
@@ -243,8 +242,7 @@ const createMlStore = (logging: Logging) => {
           trainModelDialogStage: TrainModelDialogStage.Closed,
           trainModelProgress: 0,
           dataSamplesView: DataSamplesView.Graph,
-          isNotMakeCodeHexDialogOpen: false,
-          isNotCreateAiHexDialogOpen: false,
+          postImportDialogState: PostImportDialogState.None,
 
           setSettings(update: Partial<Settings>) {
             set(
@@ -820,12 +818,8 @@ const createMlStore = (logging: Logging) => {
             }));
           },
 
-          setIsNotMakeCodeHexDialogOpen(isOpen: boolean) {
-            set({ isNotMakeCodeHexDialogOpen: isOpen });
-          },
-
-          setIsNotCreateAHexiDialogOpen(isOpen: boolean) {
-            set({ isNotCreateAiHexDialogOpen: isOpen });
+          setPostImportDialogState(state: PostImportDialogState) {
+            set({ postImportDialogState: state });
           },
         }),
         {

--- a/src/store.ts
+++ b/src/store.ts
@@ -148,6 +148,7 @@ export interface State {
   trainModelDialogStage: TrainModelDialogStage;
 
   tourState?: TourState;
+  isNotMakeCodeHexDialogOpen: boolean;
 }
 
 export interface Actions {
@@ -205,6 +206,8 @@ export interface Actions {
   tourComplete(id: TourId): void;
 
   setDataSamplesView(view: DataSamplesView): void;
+
+  setIsNotMakeCodeHexDialogOpen(isOpen: boolean): void;
 }
 
 type Store = State & Actions;
@@ -238,6 +241,7 @@ const createMlStore = (logging: Logging) => {
           trainModelDialogStage: TrainModelDialogStage.Closed,
           trainModelProgress: 0,
           dataSamplesView: DataSamplesView.Graph,
+          isNotMakeCodeHexDialogOpen: false,
 
           setSettings(update: Partial<Settings>) {
             set(
@@ -811,6 +815,10 @@ const createMlStore = (logging: Logging) => {
                 dataSamplesView: view,
               },
             }));
+          },
+
+          setIsNotMakeCodeHexDialogOpen(isOpen: boolean) {
+            set({ isNotMakeCodeHexDialogOpen: isOpen });
           },
         }),
         {

--- a/src/store.ts
+++ b/src/store.ts
@@ -149,6 +149,7 @@ export interface State {
 
   tourState?: TourState;
   isNotMakeCodeHexDialogOpen: boolean;
+  isNotCreateAiHexDialogOpen: boolean;
 }
 
 export interface Actions {
@@ -208,6 +209,7 @@ export interface Actions {
   setDataSamplesView(view: DataSamplesView): void;
 
   setIsNotMakeCodeHexDialogOpen(isOpen: boolean): void;
+  setIsNotCreateAHexiDialogOpen(isOpen: boolean): void;
 }
 
 type Store = State & Actions;
@@ -242,6 +244,7 @@ const createMlStore = (logging: Logging) => {
           trainModelProgress: 0,
           dataSamplesView: DataSamplesView.Graph,
           isNotMakeCodeHexDialogOpen: false,
+          isNotCreateAiHexDialogOpen: false,
 
           setSettings(update: Partial<Settings>) {
             set(
@@ -819,6 +822,10 @@ const createMlStore = (logging: Logging) => {
 
           setIsNotMakeCodeHexDialogOpen(isOpen: boolean) {
             set({ isNotMakeCodeHexDialogOpen: isOpen });
+          },
+
+          setIsNotCreateAHexiDialogOpen(isOpen: boolean) {
+            set({ isNotCreateAiHexDialogOpen: isOpen });
           },
         }),
         {


### PR DESCRIPTION
When importing non-MakeCode hex, or invalid json files, or files with unexpected file extensions (e.g. .png), show import error dialog.
<img width="1326" alt="Screenshot 2024-10-30 at 10 11 47" src="https://github.com/user-attachments/assets/3da12e50-468d-49e4-acc1-e0834b19f946">

When importing non-CreateAI  (has no ML extension) MakeCode hex files, show dialog telling users how to view their project.
<img width="1325" alt="Screenshot 2024-10-30 at 10 13 18" src="https://github.com/user-attachments/assets/1a6a6a54-b43d-488f-a0f7-148dbbaae0d4">

