### PR TITLE
Allow viewing data samples page on mobile

### DIFF
--- a/src/components/DataSamplesTable.tsx
+++ b/src/components/DataSamplesTable.tsx
@@ -119,7 +119,7 @@ const DataSamplesTable = ({
             <FormattedMessage id="no-data-samples" />
           </Text>
           {!isConnected && (
-            <Text fontSize="lg">
+            <Text fontSize="lg" textAlign="center">
               <FormattedMessage
                 id="connect-or-import"
                 values={{

--- a/src/components/DefaultPageLayout.tsx
+++ b/src/components/DefaultPageLayout.tsx
@@ -110,6 +110,11 @@ const DefaultPageLayout = ({
               itemsLeft={
                 toolbarItemsLeft || (
                   <AppLogo
+                    display={
+                      showPageTitle
+                        ? { base: "none", md: "inline-flex" }
+                        : "inline-flex"
+                    }
                     transform={{ base: "scale(0.8)", sm: "scale(0.93)" }}
                   />
                 )

--- a/src/components/LiveGraphPanel.tsx
+++ b/src/components/LiveGraphPanel.tsx
@@ -1,4 +1,5 @@
 import {
+  BoxProps,
   Button,
   HStack,
   Icon,
@@ -85,7 +86,9 @@ const LiveGraphPanel = ({
           gap={10}
           justifyContent="center"
         >
-          <MicrobitWarningIllustration />
+          <MicrobitWarningIllustration
+            display={{ base: "none", sm: "block" }}
+          />
           <VStack gap={3} alignItems="self-start">
             <Text fontWeight="bold">
               <FormattedMessage id="microbit-not-connected" />
@@ -204,8 +207,8 @@ const LiveGraphPanel = ({
   );
 };
 
-const MicrobitWarningIllustration = () => (
-  <HStack position="relative" aria-hidden>
+const MicrobitWarningIllustration = (props: BoxProps) => (
+  <HStack position="relative" aria-hidden {...props}>
     <Image src={microbitImage} objectFit="contain" boxSize="120px" bottom={0} />
     <Icon
       as={AlertIcon}


### PR DESCRIPTION
Not practical to connect/collect data but useful as a preview of what to expect. Face only logo would be useful, will review that at some point.