### PR TITLE
Fingerprints: split cards, larger fingerprint

### DIFF
--- a/lang/ui.en.json
+++ b/lang/ui.en.json
@@ -560,99 +560,99 @@
     "description": "Action to open a feedback dialog"
   },
   "fingerprint-acc-x-tooltip": {
-    "defaultMessage": "Sum of x-direction data for {action}",
+    "defaultMessage": "Sum of x-direction data",
     "description": "Tooltip for data feature of a recording"
   },
   "fingerprint-acc-y-tooltip": {
-    "defaultMessage": "Sum of y-direction data for {action}",
+    "defaultMessage": "Sum of y-direction data",
     "description": "Tooltip for data feature of a recording"
   },
   "fingerprint-acc-z-tooltip": {
-    "defaultMessage": "Sum of z-direction data for {action}",
+    "defaultMessage": "Sum of z-direction data",
     "description": "Tooltip for data feature of a recording"
   },
   "fingerprint-max-x-tooltip": {
-    "defaultMessage": "Maximum point among all x-direction data points in {action}",
+    "defaultMessage": "Maximum point among all x-direction data points",
     "description": "Tooltip for data feature of a recording"
   },
   "fingerprint-max-y-tooltip": {
-    "defaultMessage": "Maximum point among all y-direction data points in {action}",
+    "defaultMessage": "Maximum point among all y-direction data points",
     "description": "Tooltip for data feature of a recording"
   },
   "fingerprint-max-z-tooltip": {
-    "defaultMessage": "Maximum point among all z-direction data points in {action}",
+    "defaultMessage": "Maximum point among all z-direction data points",
     "description": "Tooltip for data feature of a recording"
   },
   "fingerprint-mean-x-tooltip": {
-    "defaultMessage": "Mean value for x-direction data in {action}",
+    "defaultMessage": "Mean value for x-direction data ",
     "description": "Tooltip for data feature of a recording"
   },
   "fingerprint-mean-y-tooltip": {
-    "defaultMessage": "Mean value for y-direction data in {action}",
+    "defaultMessage": "Mean value for y-direction data ",
     "description": "Tooltip for data feature of a recording"
   },
   "fingerprint-mean-z-tooltip": {
-    "defaultMessage": "Mean value for z-direction data in {action}",
+    "defaultMessage": "Mean value for z-direction data ",
     "description": "Tooltip for data feature of a recording"
   },
   "fingerprint-min-x-tooltip": {
-    "defaultMessage": "Minimum point among all x-direction data points in {action}",
+    "defaultMessage": "Minimum point among all x-direction data points",
     "description": "Tooltip for data feature of a recording"
   },
   "fingerprint-min-y-tooltip": {
-    "defaultMessage": "Minimum point among all y-direction data points in {action}",
+    "defaultMessage": "Minimum point among all y-direction data points",
     "description": "Tooltip for data feature of a recording"
   },
   "fingerprint-min-z-tooltip": {
-    "defaultMessage": "Minimum point among all z-direction data points in {action}",
+    "defaultMessage": "Minimum point among all z-direction data points",
     "description": "Tooltip for data feature of a recording"
   },
   "fingerprint-peaks-x-tooltip": {
-    "defaultMessage": "Number of extremes among all x-direction data points in {action}",
+    "defaultMessage": "Number of extremes among all x-direction data points",
     "description": "Tooltip for data feature of a recording"
   },
   "fingerprint-peaks-y-tooltip": {
-    "defaultMessage": "Number of extremes among all y-direction data points in {action}",
+    "defaultMessage": "Number of extremes among all y-direction data points",
     "description": "Tooltip for data feature of a recording"
   },
   "fingerprint-peaks-z-tooltip": {
-    "defaultMessage": "Number of extremes among all z-direction data points in {action}",
+    "defaultMessage": "Number of extremes among all z-direction data points",
     "description": "Tooltip for data feature of a recording"
   },
   "fingerprint-rms-x-tooltip": {
-    "defaultMessage": "Root mean square value for all x-direction data points in {action}",
+    "defaultMessage": "Root mean square value for all x-direction data points",
     "description": "Tooltip for data feature of a recording"
   },
   "fingerprint-rms-y-tooltip": {
-    "defaultMessage": "Root mean square value for all y-direction data points in {action}",
+    "defaultMessage": "Root mean square value for all y-direction data points",
     "description": "Tooltip for data feature of a recording"
   },
   "fingerprint-rms-z-tooltip": {
-    "defaultMessage": "Root mean square value for all z-direction data points in {action}",
+    "defaultMessage": "Root mean square value for all z-direction data points",
     "description": "Tooltip for data feature of a recording"
   },
   "fingerprint-std-x-tooltip": {
-    "defaultMessage": "Average deviation from 0 among all x-direction data points in {action}",
+    "defaultMessage": "Average deviation from 0 among all x-direction data points",
     "description": "Tooltip for data feature of a recording"
   },
   "fingerprint-std-y-tooltip": {
-    "defaultMessage": "Average deviation from 0 among all y-direction data points in {action}",
+    "defaultMessage": "Average deviation from 0 among all y-direction data points",
     "description": "Tooltip for data feature of a recording"
   },
   "fingerprint-std-z-tooltip": {
-    "defaultMessage": "Average deviation from 0 among all z-direction data points in {action}",
+    "defaultMessage": "Average deviation from 0 among all z-direction data points",
     "description": "Tooltip for data feature of a recording"
   },
   "fingerprint-zcr-x-tooltip": {
-    "defaultMessage": "Rate at which acceleration transitions between positive and negative for x-direction data points in {action}",
+    "defaultMessage": "Rate at which acceleration transitions between positive and negative for x-direction data points",
     "description": "Tooltip for data feature of a recording"
   },
   "fingerprint-zcr-y-tooltip": {
-    "defaultMessage": "Rate at which acceleration transitions between positive and negative for y-direction data points in {action}",
+    "defaultMessage": "Rate at which acceleration transitions between positive and negative for y-direction data points",
     "description": "Tooltip for data feature of a recording"
   },
   "fingerprint-zcr-z-tooltip": {
-    "defaultMessage": "Rate at which acceleration transitions between positive and negative for z-direction data points in {action}",
+    "defaultMessage": "Rate at which acceleration transitions between positive and negative for z-direction data points",
     "description": "Tooltip for data feature of a recording"
   },
   "firmware-outdated-content1": {

--- a/src/components/ActionDataSamplesCard.tsx
+++ b/src/components/ActionDataSamplesCard.tsx
@@ -32,6 +32,7 @@ interface ActionDataSamplesCardProps {
   onSelectRow?: () => void;
   onRecord: () => void;
   newRecordingId?: number;
+  clearNewRecordingId?: () => void;
 }
 
 const ActionDataSamplesCard = ({
@@ -40,6 +41,7 @@ const ActionDataSamplesCard = ({
   onSelectRow,
   onRecord,
   newRecordingId,
+  clearNewRecordingId,
 }: ActionDataSamplesCardProps) => {
   const deleteGestureRecording = useStore((s) => s.deleteGestureRecording);
   const view = useDataSamplesView();
@@ -81,6 +83,7 @@ const ActionDataSamplesCard = ({
               actionId={value.ID}
               recordingIndex={idx}
               isNew={newRecordingId === recording.ID}
+              onNewAnimationEnd={clearNewRecordingId}
               onDelete={deleteGestureRecording}
               view={view}
               hasClose={false}
@@ -105,6 +108,7 @@ const ActionDataSamplesCard = ({
           recording={recording}
           isNew={newRecordingId === recording.ID}
           onDelete={deleteGestureRecording}
+          onNewAnimationEnd={clearNewRecordingId}
           view={view}
         />
       ))}
@@ -187,6 +191,7 @@ const DataSample = ({
   actionId,
   recordingIndex,
   isNew,
+  onNewAnimationEnd,
   onDelete,
   view,
   hasClose = true,
@@ -195,6 +200,7 @@ const DataSample = ({
   actionId: number;
   recordingIndex: number;
   isNew: boolean;
+  onNewAnimationEnd?: () => void;
   onDelete: (gestureId: GestureData["ID"], recordingIdx: number) => void;
   view: DataSamplesView;
   hasClose?: boolean;
@@ -240,6 +246,7 @@ const DataSample = ({
             right={0}
             rounded="md"
             animation={isNew ? `${flash} 1s` : undefined}
+            onAnimationEnd={onNewAnimationEnd}
           />
         </RecordingGraph>
       )}

--- a/src/components/ActionDataSamplesCard.tsx
+++ b/src/components/ActionDataSamplesCard.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  BoxProps,
   Button,
   Card,
   CardBody,
@@ -9,6 +10,7 @@ import {
   Text,
   VStack,
 } from "@chakra-ui/react";
+import { ReactNode, useCallback } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { flags } from "../flags";
 import { DataSamplesView, GestureData, RecordingData } from "../model";
@@ -41,6 +43,87 @@ const ActionDataSamplesCard = ({
 }: ActionDataSamplesCardProps) => {
   const deleteGestureRecording = useStore((s) => s.deleteGestureRecording);
   const view = useDataSamplesView();
+  if (view === DataSamplesView.GraphAndDataFeatures) {
+    // We split the cards in this case
+    return (
+      <HStack>
+        <DataSamplesRowCard
+          onSelectRow={onSelectRow}
+          selected={selected}
+          position="relative"
+          className={tourElClassname.recordDataSamplesCard}
+        >
+          <RecordingArea
+            action={value}
+            selected={selected}
+            onRecord={onRecord}
+          />
+        </DataSamplesRowCard>
+        {value.recordings.map((recording, idx) => (
+          <DataSamplesRowCard
+            onSelectRow={onSelectRow}
+            selected={selected}
+            key={recording.ID}
+          >
+            <CloseButton
+              position="absolute"
+              top={-2}
+              right={-2}
+              rounded="full"
+              bgColor="white"
+              zIndex={1}
+              borderColor="blackAlpha.500"
+              boxShadow="sm"
+              onClick={() => deleteGestureRecording(value.ID, idx)}
+            />
+            <DataSample
+              recording={recording}
+              actionId={value.ID}
+              recordingIndex={idx}
+              isNew={newRecordingId === recording.ID}
+              onDelete={deleteGestureRecording}
+              view={view}
+              hasClose={false}
+            />
+          </DataSamplesRowCard>
+        ))}
+      </HStack>
+    );
+  }
+  return (
+    <DataSamplesRowCard
+      onSelectRow={onSelectRow}
+      selected={selected}
+      className={tourElClassname.recordDataSamplesCard}
+    >
+      <RecordingArea action={value} selected={selected} onRecord={onRecord} />
+      {value.recordings.map((recording, idx) => (
+        <DataSample
+          key={recording.ID}
+          actionId={value.ID}
+          recordingIndex={idx}
+          recording={recording}
+          isNew={newRecordingId === recording.ID}
+          onDelete={deleteGestureRecording}
+          view={view}
+        />
+      ))}
+    </DataSamplesRowCard>
+  );
+};
+
+interface DataSamplesRowCardProps extends BoxProps {
+  selected: boolean;
+  onSelectRow?: () => void;
+  children: ReactNode;
+}
+
+const DataSamplesRowCard = ({
+  selected,
+  onSelectRow,
+  children,
+  ...rest
+}: DataSamplesRowCardProps) => {
   return (
     <Card
       onClick={onSelectRow}
@@ -51,20 +134,10 @@ const ActionDataSamplesCard = ({
       width="fit-content"
       borderColor={selected ? "brand.500" : "transparent"}
       borderWidth={1}
-      className={tourElClassname.recordDataSamplesCard}
+      {...rest}
     >
       <CardBody display="flex" flexDirection="row" p={1} gap={3}>
-        <RecordingArea action={value} selected={selected} onRecord={onRecord} />
-        {value.recordings.map((recording, idx) => (
-          <DataSample
-            action={value}
-            key={recording.ID}
-            recording={recording}
-            isNew={newRecordingId === recording.ID}
-            onDelete={() => deleteGestureRecording(value.ID, idx)}
-            view={view}
-          />
-        ))}
+        {children}
       </CardBody>
     </Card>
   );
@@ -110,55 +183,71 @@ const RecordingArea = ({
 };
 
 const DataSample = ({
-  action,
   recording,
+  actionId,
+  recordingIndex,
   isNew,
   onDelete,
   view,
+  hasClose = true,
 }: {
-  action: GestureData;
   recording: RecordingData;
+  actionId: number;
+  recordingIndex: number;
   isNew: boolean;
-  onDelete: () => void;
+  onDelete: (gestureId: GestureData["ID"], recordingIdx: number) => void;
   view: DataSamplesView;
+  hasClose?: boolean;
 }) => {
+  const hasGraph =
+    view === DataSamplesView.Graph ||
+    view === DataSamplesView.GraphAndDataFeatures;
+  const hasFingerprint =
+    view === DataSamplesView.DataFeatures ||
+    view === DataSamplesView.GraphAndDataFeatures;
   const intl = useIntl();
+  const handleDelete = useCallback(() => {
+    onDelete(actionId, recordingIndex);
+  }, [actionId, onDelete, recordingIndex]);
   return (
     <HStack key={recording.ID} position="relative">
-      <Box
-        position="absolute"
-        h="100%"
-        w="100%"
-        rounded="md"
-        animation={isNew ? `${flash} 1s` : undefined}
-      />
-      <CloseButton
-        position="absolute"
-        top={0}
-        right={0}
-        zIndex={1}
-        size="sm"
-        aria-label={intl.formatMessage({
-          id: "delete-recording-aria",
-        })}
-        onClick={onDelete}
-      />
-      {(view === DataSamplesView.Graph ||
-        view === DataSamplesView.GraphAndDataFeatures) && (
+      {hasClose && (
+        <CloseButton
+          position="absolute"
+          top={0}
+          right={0}
+          zIndex={1}
+          size="sm"
+          aria-label={intl.formatMessage({
+            id: "delete-recording-aria",
+          })}
+          onClick={handleDelete}
+        />
+      )}
+      {hasGraph && (
         <RecordingGraph
           data={recording.data}
           role="image"
           aria-label={intl.formatMessage({
             id: "recording-graph-label",
           })}
-        />
+        >
+          <Box
+            position="absolute"
+            top={0}
+            bottom={0}
+            left={0}
+            right={0}
+            rounded="md"
+            animation={isNew ? `${flash} 1s` : undefined}
+          />
+        </RecordingGraph>
       )}
-      {(view === DataSamplesView.DataFeatures ||
-        view === DataSamplesView.GraphAndDataFeatures) && (
+      {hasFingerprint && (
         <RecordingFingerprint
+          size={view === DataSamplesView.GraphAndDataFeatures ? "sm" : "md"}
           data={recording.data}
           role="image"
-          gestureName={action.name}
           aria-label={intl.formatMessage({
             id: "recording-fingerprint-label",
           })}

--- a/src/components/DataSamplesTable.tsx
+++ b/src/components/DataSamplesTable.tsx
@@ -163,10 +163,7 @@ const DataSamplesTable = ({
               key={g.ID}
               gesture={g}
               newRecordingId={newRecordingId}
-              clearNewRecordingId={() => {
-                console.log("XXX");
-                setNewRecordingId(undefined);
-              }}
+              clearNewRecordingId={() => setNewRecordingId(undefined)}
               selected={selectedGesture.ID === g.ID}
               onSelectRow={() => setSelectedGestureIdx(idx)}
               onRecord={

--- a/src/components/DataSamplesTable.tsx
+++ b/src/components/DataSamplesTable.tsx
@@ -163,6 +163,10 @@ const DataSamplesTable = ({
               key={g.ID}
               gesture={g}
               newRecordingId={newRecordingId}
+              clearNewRecordingId={() => {
+                console.log("XXX");
+                setNewRecordingId(undefined);
+              }}
               selected={selectedGesture.ID === g.ID}
               onSelectRow={() => setSelectedGestureIdx(idx)}
               onRecord={

--- a/src/components/DataSamplesTableRow.tsx
+++ b/src/components/DataSamplesTableRow.tsx
@@ -18,6 +18,7 @@ interface DataSamplesTableRowProps {
   onRecord: () => void;
   showHints: boolean;
   newRecordingId?: number;
+  clearNewRecordingId: () => void;
 }
 
 const DataSamplesTableRow = ({
@@ -27,6 +28,7 @@ const DataSamplesTableRow = ({
   onRecord,
   showHints: showHints,
   newRecordingId,
+  clearNewRecordingId,
 }: DataSamplesTableRowProps) => {
   const intl = useIntl();
   const deleteConfirmDisclosure = useDisclosure();
@@ -76,6 +78,7 @@ const DataSamplesTableRow = ({
               selected={selected}
               onSelectRow={onSelectRow}
               onRecord={onRecord}
+              clearNewRecordingId={clearNewRecordingId}
             />
           )}
         </GridItem>

--- a/src/components/RecordingFingerprint.tsx
+++ b/src/components/RecordingFingerprint.tsx
@@ -1,19 +1,20 @@
 import { BoxProps, Grid, GridItem, Text } from "@chakra-ui/react";
+import React from "react";
 import { FormattedMessage } from "react-intl";
 import { applyFilters } from "../ml";
 import { XYZData } from "../model";
+import { useStore } from "../store";
 import { calculateGradientColor } from "../utils/gradient-calculator";
 import ClickableTooltip from "./ClickableTooltip";
-import { useStore } from "../store";
 
 interface RecordingFingerprintProps extends BoxProps {
   data: XYZData;
-  gestureName: string;
+  size: "sm" | "md";
 }
 
 const RecordingFingerprint = ({
   data,
-  gestureName,
+  size,
   ...rest
 }: RecordingFingerprintProps) => {
   const dataWindow = useStore((s) => s.dataWindow);
@@ -21,7 +22,7 @@ const RecordingFingerprint = ({
 
   return (
     <Grid
-      w="80px"
+      w={`${size === "md" ? 152 : 92}px`}
       h="100%"
       position="relative"
       borderRadius="md"
@@ -36,10 +37,7 @@ const RecordingFingerprint = ({
           key={idx}
           label={
             <Text p={3}>
-              <FormattedMessage
-                id={`fingerprint-${k}-tooltip`}
-                values={{ action: gestureName }}
-              />
+              <FormattedMessage id={`fingerprint-${k}-tooltip`} />
             </Text>
           }
         >
@@ -53,4 +51,4 @@ const RecordingFingerprint = ({
   );
 };
 
-export default RecordingFingerprint;
+export default React.memo(RecordingFingerprint);

--- a/src/components/RecordingGraph.tsx
+++ b/src/components/RecordingGraph.tsx
@@ -15,7 +15,7 @@ interface RecordingGraphProps extends BoxProps {
   data: XYZData;
 }
 
-const RecordingGraph = ({ data, ...rest }: RecordingGraphProps) => {
+const RecordingGraph = ({ data, children, ...rest }: RecordingGraphProps) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
   useEffect(() => {
@@ -40,9 +40,11 @@ const RecordingGraph = ({ data, ...rest }: RecordingGraphProps) => {
       borderColor="gray.200"
       w="158px"
       height="100%"
+      position="relative"
       {...rest}
     >
       <canvas width="158px" height="95px" ref={canvasRef} />
+      {children}
     </Box>
   );
 };

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -46,7 +46,7 @@ const allFlags: FlagMetadata[] = [
     name: "preReleaseNotice",
     defaultOnStages: ["review", "staging", "production"],
   },
-  { name: "fingerprints", defaultOnStages: ["local"] },
+  { name: "fingerprints", defaultOnStages: ["local", "review", "staging"] },
   { name: "exampleOptInA", defaultOnStages: ["review", "staging"] },
   { name: "exampleOptInB", defaultOnStages: [] },
 ];

--- a/src/messages/ui.en.json
+++ b/src/messages/ui.en.json
@@ -948,241 +948,145 @@
   "fingerprint-acc-x-tooltip": [
     {
       "type": 0,
-      "value": "Sum of x-direction data for "
-    },
-    {
-      "type": 1,
-      "value": "action"
+      "value": "Sum of x-direction data"
     }
   ],
   "fingerprint-acc-y-tooltip": [
     {
       "type": 0,
-      "value": "Sum of y-direction data for "
-    },
-    {
-      "type": 1,
-      "value": "action"
+      "value": "Sum of y-direction data"
     }
   ],
   "fingerprint-acc-z-tooltip": [
     {
       "type": 0,
-      "value": "Sum of z-direction data for "
-    },
-    {
-      "type": 1,
-      "value": "action"
+      "value": "Sum of z-direction data"
     }
   ],
   "fingerprint-max-x-tooltip": [
     {
       "type": 0,
-      "value": "Maximum point among all x-direction data points in "
-    },
-    {
-      "type": 1,
-      "value": "action"
+      "value": "Maximum point among all x-direction data points"
     }
   ],
   "fingerprint-max-y-tooltip": [
     {
       "type": 0,
-      "value": "Maximum point among all y-direction data points in "
-    },
-    {
-      "type": 1,
-      "value": "action"
+      "value": "Maximum point among all y-direction data points"
     }
   ],
   "fingerprint-max-z-tooltip": [
     {
       "type": 0,
-      "value": "Maximum point among all z-direction data points in "
-    },
-    {
-      "type": 1,
-      "value": "action"
+      "value": "Maximum point among all z-direction data points"
     }
   ],
   "fingerprint-mean-x-tooltip": [
     {
       "type": 0,
-      "value": "Mean value for x-direction data in "
-    },
-    {
-      "type": 1,
-      "value": "action"
+      "value": "Mean value for x-direction data "
     }
   ],
   "fingerprint-mean-y-tooltip": [
     {
       "type": 0,
-      "value": "Mean value for y-direction data in "
-    },
-    {
-      "type": 1,
-      "value": "action"
+      "value": "Mean value for y-direction data "
     }
   ],
   "fingerprint-mean-z-tooltip": [
     {
       "type": 0,
-      "value": "Mean value for z-direction data in "
-    },
-    {
-      "type": 1,
-      "value": "action"
+      "value": "Mean value for z-direction data "
     }
   ],
   "fingerprint-min-x-tooltip": [
     {
       "type": 0,
-      "value": "Minimum point among all x-direction data points in "
-    },
-    {
-      "type": 1,
-      "value": "action"
+      "value": "Minimum point among all x-direction data points"
     }
   ],
   "fingerprint-min-y-tooltip": [
     {
       "type": 0,
-      "value": "Minimum point among all y-direction data points in "
-    },
-    {
-      "type": 1,
-      "value": "action"
+      "value": "Minimum point among all y-direction data points"
     }
   ],
   "fingerprint-min-z-tooltip": [
     {
       "type": 0,
-      "value": "Minimum point among all z-direction data points in "
-    },
-    {
-      "type": 1,
-      "value": "action"
+      "value": "Minimum point among all z-direction data points"
     }
   ],
   "fingerprint-peaks-x-tooltip": [
     {
       "type": 0,
-      "value": "Number of extremes among all x-direction data points in "
-    },
-    {
-      "type": 1,
-      "value": "action"
+      "value": "Number of extremes among all x-direction data points"
     }
   ],
   "fingerprint-peaks-y-tooltip": [
     {
       "type": 0,
-      "value": "Number of extremes among all y-direction data points in "
-    },
-    {
-      "type": 1,
-      "value": "action"
+      "value": "Number of extremes among all y-direction data points"
     }
   ],
   "fingerprint-peaks-z-tooltip": [
     {
       "type": 0,
-      "value": "Number of extremes among all z-direction data points in "
-    },
-    {
-      "type": 1,
-      "value": "action"
+      "value": "Number of extremes among all z-direction data points"
     }
   ],
   "fingerprint-rms-x-tooltip": [
     {
       "type": 0,
-      "value": "Root mean square value for all x-direction data points in "
-    },
-    {
-      "type": 1,
-      "value": "action"
+      "value": "Root mean square value for all x-direction data points"
     }
   ],
   "fingerprint-rms-y-tooltip": [
     {
       "type": 0,
-      "value": "Root mean square value for all y-direction data points in "
-    },
-    {
-      "type": 1,
-      "value": "action"
+      "value": "Root mean square value for all y-direction data points"
     }
   ],
   "fingerprint-rms-z-tooltip": [
     {
       "type": 0,
-      "value": "Root mean square value for all z-direction data points in "
-    },
-    {
-      "type": 1,
-      "value": "action"
+      "value": "Root mean square value for all z-direction data points"
     }
   ],
   "fingerprint-std-x-tooltip": [
     {
       "type": 0,
-      "value": "Average deviation from 0 among all x-direction data points in "
-    },
-    {
-      "type": 1,
-      "value": "action"
+      "value": "Average deviation from 0 among all x-direction data points"
     }
   ],
   "fingerprint-std-y-tooltip": [
     {
       "type": 0,
-      "value": "Average deviation from 0 among all y-direction data points in "
-    },
-    {
-      "type": 1,
-      "value": "action"
+      "value": "Average deviation from 0 among all y-direction data points"
     }
   ],
   "fingerprint-std-z-tooltip": [
     {
       "type": 0,
-      "value": "Average deviation from 0 among all z-direction data points in "
-    },
-    {
-      "type": 1,
-      "value": "action"
+      "value": "Average deviation from 0 among all z-direction data points"
     }
   ],
   "fingerprint-zcr-x-tooltip": [
     {
       "type": 0,
-      "value": "Rate at which acceleration transitions between positive and negative for x-direction data points in "
-    },
-    {
-      "type": 1,
-      "value": "action"
+      "value": "Rate at which acceleration transitions between positive and negative for x-direction data points"
     }
   ],
   "fingerprint-zcr-y-tooltip": [
     {
       "type": 0,
-      "value": "Rate at which acceleration transitions between positive and negative for y-direction data points in "
-    },
-    {
-      "type": 1,
-      "value": "action"
+      "value": "Rate at which acceleration transitions between positive and negative for y-direction data points"
     }
   ],
   "fingerprint-zcr-z-tooltip": [
     {
       "type": 0,
-      "value": "Rate at which acceleration transitions between positive and negative for z-direction data points in "
-    },
-    {
-      "type": 1,
-      "value": "action"
+      "value": "Rate at which acceleration transitions between positive and negative for z-direction data points"
     }
   ],
   "firmware-outdated-content1": [


### PR DESCRIPTION
Use the full size when it's just the fingerprint
Split the cards when displaying both to pair the items
Remove action name from fingerprint tooltip copy for speed
Still behind a flag but I've enabled it for staging to aid discussion