### PR TITLE
Enable flags via local storage

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -56,6 +56,14 @@ type Flags = Record<Flag, boolean>;
 // Exposed for testing.
 export const flagsForParams = (stage: Stage, params: URLSearchParams) => {
   const enableFlags = new Set(params.getAll("flag"));
+  try {
+    localStorage
+      .getItem("flags")
+      ?.split(",")
+      ?.forEach((f) => enableFlags.add(f.trim()));
+  } catch (e) {
+    // Ignore if there are local storage security issues
+  }
   const allFlagsDefault = enableFlags.has("none")
     ? false
     : enableFlags.has("*")


### PR DESCRIPTION
Flags can all be hardcoded to be removed via: 
```
localStorage.setItem("flags", "none")
```