### PR TITLE
Set initial value for smoothen function to zero

### DIFF
--- a/src/recording-graph.ts
+++ b/src/recording-graph.ts
@@ -12,7 +12,7 @@ const smoothen = (d: number[]): number[] => {
     return d;
   }
   const newData: number[] = [];
-  let prevValue = d[0];
+  let prevValue = 0;
   d.forEach((v) => {
     const newValue = v * 0.25 + prevValue * 0.75;
     newData.push(newValue);


### PR DESCRIPTION
This removes exaggerated starting values for the recording graphs.