### PR TITLE
Set fingerprint tooltip placement to not shift layout

### DIFF
--- a/src/components/RecordingFingerprint.tsx
+++ b/src/components/RecordingFingerprint.tsx
@@ -34,6 +34,7 @@ const RecordingFingerprint = ({
     >
       {Object.keys(dataFeatures).map((k, idx) => (
         <ClickableTooltip
+          placement="auto"
           key={idx}
           label={
             <Text p={3}>

--- a/src/components/RecordingFingerprint.tsx
+++ b/src/components/RecordingFingerprint.tsx
@@ -34,7 +34,7 @@ const RecordingFingerprint = ({
     >
       {Object.keys(dataFeatures).map((k, idx) => (
         <ClickableTooltip
-          placement="auto"
+          placement="end-end"
           key={idx}
           label={
             <Text p={3}>


### PR DESCRIPTION
To prevent scrollbars from appearing and shifting layout

Private link to task: https://microbit-global.monday.com/boards/1550536443/pulses/1690593017