### PR TITLE
Improve logging around MakeCode use

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -21,7 +21,9 @@ const Editor = forwardRef<MakeCodeFrameDriver, EditorProps>(function Editor(
   const logging = useLogging();
   const { project, editorCallbacks } = useProject();
   const initialProjects = useCallback(() => {
-    logging.log(`Initialising MakeCode with header ID: ${project.header?.id}`);
+    logging.log(
+      `[MakeCode] Initialising with header ID: ${project.header?.id}`
+    );
     return Promise.resolve([project]);
   }, [logging, project]);
   const [{ languageId }] = useSettings();

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -6,6 +6,7 @@ import React, { forwardRef, useCallback } from "react";
 import { getMakeCodeLang } from "../settings";
 import { useProject } from "../hooks/project-hooks";
 import { useSettings } from "../store";
+import { useLogging } from "../logging/logging-hooks";
 
 const controllerId = "MicrobitMachineLearningTool";
 
@@ -17,10 +18,12 @@ const Editor = forwardRef<MakeCodeFrameDriver, EditorProps>(function Editor(
   props,
   ref
 ) {
+  const logging = useLogging();
   const { project, editorCallbacks } = useProject();
   const initialProjects = useCallback(() => {
+    logging.log(`Initialising MakeCode with header ID: ${project.header?.id}`);
     return Promise.resolve([project]);
-  }, [project]);
+  }, [logging, project]);
   const [{ languageId }] = useSettings();
   return (
     <MakeCodeFrame

--- a/src/hooks/project-hooks.tsx
+++ b/src/hooks/project-hooks.tsx
@@ -66,7 +66,7 @@ interface ProjectContext {
 
   editorCallbacks: Pick<
     MakeCodeFrameProps,
-    "onDownload" | "onWorkspaceSave" | "onSave" | "onBack"
+    "onDownload" | "onWorkspaceSave" | "onWorkspaceLoaded" | "onSave" | "onBack"
   >;
 }
 
@@ -113,6 +113,9 @@ export const ProjectProvider = ({
   const toast = useToast();
   const logging = useLogging();
   const projectEdited = useStore((s) => s.projectEdited);
+  const onWorkspaceLoaded = useCallback(() => {
+    logging.log("MakeCode workspace loaded");
+  }, [logging]);
   const expectChangedHeader = useStore((s) => s.setChangedHeaderExpected);
   const projectFlushedToEditor = useStore((s) => s.projectFlushedToEditor);
   const checkIfProjectNeedsFlush = useStore((s) => s.checkIfProjectNeedsFlush);
@@ -327,6 +330,7 @@ export const ProjectProvider = ({
         onWorkspaceSave,
         onDownload,
         onBack,
+        onWorkspaceLoaded,
       },
     }),
     [
@@ -336,6 +340,7 @@ export const ProjectProvider = ({
       onDownload,
       onSave,
       onWorkspaceSave,
+      onWorkspaceLoaded,
       openEditor,
       project,
       projectEdited,

--- a/src/hooks/project-hooks.tsx
+++ b/src/hooks/project-hooks.tsx
@@ -114,7 +114,7 @@ export const ProjectProvider = ({
   const logging = useLogging();
   const projectEdited = useStore((s) => s.projectEdited);
   const onWorkspaceLoaded = useCallback(() => {
-    logging.log("MakeCode workspace loaded");
+    logging.log("[MakeCode] Workspace loaded");
   }, [logging]);
   const expectChangedHeader = useStore((s) => s.setChangedHeaderExpected);
   const projectFlushedToEditor = useStore((s) => s.projectFlushedToEditor);

--- a/src/store.ts
+++ b/src/store.ts
@@ -711,7 +711,7 @@ const createMlStore = (logging: Logging) => {
                 if (newProjectHeader !== previousProjectHeader) {
                   if (changedHeaderExpected) {
                     logging.log(
-                      `Detected new project in MakeCode, ignoring as expected due to import. ID change: ${prevProject.header?.id} -> ${newProject.header?.id}`
+                      `[MakeCode] Detected new project, ignoring as expected due to import. ID change: ${prevProject.header?.id} -> ${newProject.header?.id}`
                     );
                     return {
                       changedHeaderExpected: false,
@@ -719,7 +719,7 @@ const createMlStore = (logging: Logging) => {
                     };
                   }
                   logging.log(
-                    `Detected new project in MakeCode, loading actions. ID change: ${prevProject.header?.id} -> ${newProject.header?.id}`
+                    `[MakeCode] Detected new project, loading actions. ID change: ${prevProject.header?.id} -> ${newProject.header?.id}`
                   );
                   // It's a new project. Thanks user. We'll update our state.
                   // This will cause another write to MakeCode but that's OK as it gives us
@@ -748,14 +748,14 @@ const createMlStore = (logging: Logging) => {
                   };
                 } else if (isEditorOpen) {
                   logging.log(
-                    `Edit in MakeCode copied to project. ID ${newProject.header?.id}`
+                    `[MakeCode] Edit copied to project. ID ${newProject.header?.id}`
                   );
                   return {
                     project: newProject,
                   };
                 } else {
                   logging.log(
-                    `Edit in MakeCode ignored when closed. ID ${newProject.header?.id}`
+                    `[MakeCode] Edit ignored when closed. ID ${newProject.header?.id}`
                   );
                 }
                 return state;

--- a/src/store.ts
+++ b/src/store.ts
@@ -710,13 +710,16 @@ const createMlStore = (logging: Logging) => {
                 const previousProjectHeader = prevProject.header!.id;
                 if (newProjectHeader !== previousProjectHeader) {
                   if (changedHeaderExpected) {
+                    logging.log(
+                      `Detected new project in MakeCode, ignoring as expected due to import. ID change: ${prevProject.header?.id} -> ${newProject.header?.id}`
+                    );
                     return {
                       changedHeaderExpected: false,
                       project: newProject,
                     };
                   }
-                  console.log(
-                    "Detected new project in MakeCode, loading actions"
+                  logging.log(
+                    `Detected new project in MakeCode, loading actions. ID change: ${prevProject.header?.id} -> ${newProject.header?.id}`
                   );
                   // It's a new project. Thanks user. We'll update our state.
                   // This will cause another write to MakeCode but that's OK as it gives us
@@ -744,9 +747,16 @@ const createMlStore = (logging: Logging) => {
                     isEditorOpen: false,
                   };
                 } else if (isEditorOpen) {
+                  logging.log(
+                    `Edit in MakeCode copied to project. ID ${newProject.header?.id}`
+                  );
                   return {
                     project: newProject,
                   };
+                } else {
+                  logging.log(
+                    `Edit in MakeCode ignored when closed. ID ${newProject.header?.id}`
+                  );
                 }
                 return state;
               },


### PR DESCRIPTION
This helps confirm that:
- The initial workspace sync uses the same ID as the project in storage 
- Importing projects into MakeCode always results in a new ID
- All the "spurious" edits we see during the workspace sync are before the workspaceloaded event