### PR TITLE
Fix import page default name

### DIFF
--- a/src/hooks/project-hooks.tsx
+++ b/src/hooks/project-hooks.tsx
@@ -85,7 +85,7 @@ interface ProjectProviderProps {
   children: ReactNode;
 }
 
-const useDefaultProjectName = (): string => {
+export const useDefaultProjectName = (): string => {
   const intl = useIntl();
   return intl.formatMessage({ id: "default-project-name" });
 };

--- a/src/pages/ImportPage.tsx
+++ b/src/pages/ImportPage.tsx
@@ -17,7 +17,7 @@ import DefaultPageLayout, {
   HomeToolbarItem,
 } from "../components/DefaultPageLayout";
 import { useDeployment } from "../deployment";
-import { useProjectName, useProject } from "../hooks/project-hooks";
+import { useDefaultProjectName, useProject } from "../hooks/project-hooks";
 import { useLogging } from "../logging/logging-hooks";
 import { MicrobitOrgResource } from "../model";
 import { validateProjectName } from "../project-name";
@@ -29,7 +29,7 @@ const ImportPage = () => {
   const navigate = useNavigate();
   const { activitiesBaseUrl } = useDeployment();
   const [params] = useSearchParams();
-  const defaultProjectName = useProjectName();
+  const defaultProjectName = useDefaultProjectName();
   const [name, setName] = useState<string>(defaultProjectName);
   const isValidSetup = validateProjectName(name);
   const [fetchingProject, setFetchingProject] = useState<boolean>(true);


### PR DESCRIPTION
Import page default project name should be untitled.

Currently, if the current session has a project name, it uses that name instead. 

**Repro steps**
1. Start a new session.
2. Save project so that you can name it as something other than "Untitled".
3. Change path to /import.

**Current behaviour:** You will see project name set in step 2 in the field.
**Expected behaviour:** Should show "untitled" as project name given that no project is imported. 
