### PR TITLE
Fix live graph performance issues on browser zoom

### DIFF
--- a/src/components/LiveGraph.tsx
+++ b/src/components/LiveGraph.tsx
@@ -55,6 +55,7 @@ const LiveGraph = () => {
         borderVisible: false,
       },
       interpolation: "linear",
+      enableDpiScaling: false,
     });
 
     smoothieChart.addTimeSeries(lineX, { lineWidth, strokeStyle: colors.x });


### PR DESCRIPTION
The live graph lines don't look amazing at high zoom, but it's much better than the app crashing.