### PR TITLE
Align recording data features and graph widths

### DIFF
--- a/src/components/RecordingFingerprint.tsx
+++ b/src/components/RecordingFingerprint.tsx
@@ -22,7 +22,7 @@ const RecordingFingerprint = ({
 
   return (
     <Grid
-      w={`${size === "md" ? 152 : 92}px`}
+      w={`${size === "md" ? 158 : 92}px`}
       h="100%"
       position="relative"
       borderRadius="md"


### PR DESCRIPTION
So that toggling between data-features-only view and graphs-only view won't shift action recording width length

Private link to task: https://microbit-global.monday.com/boards/1550536443/pulses/1687726853