### PR TITLE
Start over if the initial connection fails twice

### DIFF
--- a/src/connection-stage-actions.ts
+++ b/src/connection-stage-actions.ts
@@ -214,10 +214,6 @@ export class ConnectionStageActions {
     };
   };
 
-  private handleConnectFail = () => {
-    this.setFlowStep(ConnectionFlowStep.ConnectFailed);
-  };
-
   private onConnected = () => {
     this.setFlowStep(ConnectionFlowStep.None);
     this.dataCollectionMicrobitConnected();
@@ -242,7 +238,11 @@ export class ConnectionStageActions {
         );
       }
       case ConnectionStatus.FailedToConnect: {
-        return this.handleConnectFail();
+        return this.setStage({
+          ...this.stage,
+          flowType,
+          flowStep: ConnectionFlowStep.ConnectFailed,
+        });
       }
       case ConnectionStatus.FailedToReconnectTwice: {
         return this.setStage({

--- a/src/get-next-connection-state.test.ts
+++ b/src/get-next-connection-state.test.ts
@@ -217,6 +217,25 @@ describe("getNextConnectionState for radio connection", () => {
       },
     });
   });
+  test("radio reconnecting automatically (changing tabs) and the link micro:bit gets unplugged", () => {
+    testGetNextConnectionState({
+      input: {
+        currConnType: "radio",
+        currStatus: ConnectionStatus.ReconnectingAutomatically,
+        deviceStatus: DeviceConnectionStatus.NO_AUTHORIZED_DEVICE,
+        prevDeviceStatus: DeviceConnectionStatus.DISCONNECTED,
+        type: "radioRemote",
+      },
+      initialOnFirstConnectAttempt: false,
+      expectedOnFirstConnectAttempt: false,
+      initialHasAttemptedReconnect: false,
+      expectedHasAttemptedReconnect: false,
+      expectedNextConnectionState: {
+        status: ConnectionStatus.ConnectionLost,
+        flowType: ConnectionFlowType.ConnectRadioBridge,
+      },
+    });
+  });
   test("radio bridge device connection lost by unplugging device", () => {
     testGetNextConnectionState({
       input: {

--- a/src/get-next-connection-state.test.ts
+++ b/src/get-next-connection-state.test.ts
@@ -342,9 +342,9 @@ describe("getNextConnectionState for radio connection", () => {
         type: "radioRemote",
       },
       initialOnFirstConnectAttempt: false,
-      expectedOnFirstConnectAttempt: false,
+      expectedOnFirstConnectAttempt: true,
       initialHasAttemptedReconnect: true,
-      expectedHasAttemptedReconnect: true,
+      expectedHasAttemptedReconnect: false,
       expectedNextConnectionState: {
         status: ConnectionStatus.FailedToReconnectTwice,
         flowType: ConnectionFlowType.ConnectRadioRemote,
@@ -548,9 +548,9 @@ describe("getNextConnectionState for bluetooth connection", () => {
         type: "bluetooth",
       },
       initialOnFirstConnectAttempt: false,
-      expectedOnFirstConnectAttempt: false,
+      expectedOnFirstConnectAttempt: true,
       initialHasAttemptedReconnect: true,
-      expectedHasAttemptedReconnect: true,
+      expectedHasAttemptedReconnect: false,
       expectedNextConnectionState: {
         status: ConnectionStatus.FailedToReconnectTwice,
         flowType: ConnectionFlowType.ConnectBluetooth,

--- a/src/get-next-connection-state.test.ts
+++ b/src/get-next-connection-state.test.ts
@@ -173,9 +173,9 @@ describe("getNextConnectionState for radio connection", () => {
         type: "radioRemote",
       },
       initialOnFirstConnectAttempt: true,
-      expectedOnFirstConnectAttempt: true,
+      expectedOnFirstConnectAttempt: false,
       initialHasAttemptedReconnect: false,
-      expectedHasAttemptedReconnect: false,
+      expectedHasAttemptedReconnect: true,
       expectedNextConnectionState: {
         status: ConnectionStatus.FailedToConnect,
         flowType: ConnectionFlowType.ConnectRadioRemote,
@@ -456,9 +456,9 @@ describe("getNextConnectionState for bluetooth connection", () => {
         type: "bluetooth",
       },
       initialOnFirstConnectAttempt: true,
-      expectedOnFirstConnectAttempt: true,
+      expectedOnFirstConnectAttempt: false,
       initialHasAttemptedReconnect: false,
-      expectedHasAttemptedReconnect: false,
+      expectedHasAttemptedReconnect: true,
       expectedNextConnectionState: {
         status: ConnectionStatus.FailedToConnect,
         flowType: ConnectionFlowType.ConnectBluetooth,

--- a/src/get-next-connection-state.ts
+++ b/src/get-next-connection-state.ts
@@ -108,7 +108,6 @@ export const getNextConnectionState = (
         : ConnectionStatus.FailedToReconnect;
     return { status, flowType };
   }
-
   if (
     // If user starts or restarts connection flow.
     // Disconnection happens for newly started / restarted
@@ -189,6 +188,18 @@ export const getNextConnectionState = (
     deviceStatus === DeviceConnectionStatus.RECONNECTING
   ) {
     return { status: ConnectionStatus.ReconnectingAutomatically, flowType };
+  }
+  if (
+    DeviceConnectionStatus.NO_AUTHORIZED_DEVICE &&
+    ConnectionStatus.ReconnectingAutomatically &&
+    currConnType === "radio"
+  ) {
+    // The link micro:bit was unplugged while the user was viewing another tab.
+    // On return, show failed to reconnect.
+    return {
+      status: ConnectionStatus.FailedToReconnect,
+      flowType: ConnectionFlowType.ConnectRadioBridge,
+    };
   }
   return undefined;
 };

--- a/src/get-next-connection-state.ts
+++ b/src/get-next-connection-state.ts
@@ -20,18 +20,22 @@ export type NextConnectionState =
   | { status: ConnectionStatus; flowType: ConnectionFlowType }
   | undefined;
 
-export const getNextConnectionState = ({
-  currConnType,
-  currStatus,
-  deviceStatus,
-  prevDeviceStatus,
-  type,
-  hasAttempedReconnect,
-  setHasAttemptedReconnect,
-  onFirstConnectAttempt,
-  setOnFirstConnectAttempt,
-  isBrowserTabVisible,
-}: GetNextConnectionStateInput): NextConnectionState => {
+export const getNextConnectionState = (
+  input: GetNextConnectionStateInput
+): NextConnectionState => {
+  const {
+    currConnType,
+    currStatus,
+    deviceStatus,
+    prevDeviceStatus,
+    type,
+    hasAttempedReconnect,
+    setHasAttemptedReconnect,
+    onFirstConnectAttempt,
+    setOnFirstConnectAttempt,
+    isBrowserTabVisible,
+  } = input;
+
   if (currStatus === ConnectionStatus.Disconnected) {
     // Do not update connection status when user explicitly disconnected connection
     // until user reconnects explicitly
@@ -48,7 +52,8 @@ export const getNextConnectionState = ({
   // status is already set to an error case.
   if (
     !isBrowserTabVisible &&
-    (currStatus === ConnectionStatus.ConnectionLost ||
+    (currStatus === ConnectionStatus.FailedToConnect ||
+      currStatus === ConnectionStatus.ConnectionLost ||
       currStatus === ConnectionStatus.FailedToReconnect ||
       currStatus === ConnectionStatus.FailedToReconnectTwice)
   ) {

--- a/src/get-next-connection-state.ts
+++ b/src/get-next-connection-state.ts
@@ -148,6 +148,9 @@ export const getNextConnectionState = ({
     hasAttempedReconnect &&
     deviceStatus === DeviceConnectionStatus.DISCONNECTED
   ) {
+    // Reset connection state fields so that the next connection attempt is clean.
+    setOnFirstConnectAttempt(true);
+    setHasAttemptedReconnect(false);
     return { status: ConnectionStatus.FailedToReconnectTwice, flowType };
   }
   if (

--- a/src/get-next-connection-state.ts
+++ b/src/get-next-connection-state.ts
@@ -190,14 +190,14 @@ export const getNextConnectionState = (
     return { status: ConnectionStatus.ReconnectingAutomatically, flowType };
   }
   if (
-    DeviceConnectionStatus.NO_AUTHORIZED_DEVICE &&
-    ConnectionStatus.ReconnectingAutomatically &&
+    deviceStatus === DeviceConnectionStatus.NO_AUTHORIZED_DEVICE &&
+    currStatus === ConnectionStatus.ReconnectingAutomatically &&
     currConnType === "radio"
   ) {
     // The link micro:bit was unplugged while the user was viewing another tab.
     // On return, show failed to reconnect.
     return {
-      status: ConnectionStatus.FailedToReconnect,
+      status: ConnectionStatus.ConnectionLost,
       flowType: ConnectionFlowType.ConnectRadioBridge,
     };
   }

--- a/src/get-next-connection-state.ts
+++ b/src/get-next-connection-state.ts
@@ -127,6 +127,11 @@ export const getNextConnectionState = ({
     currStatus === ConnectionStatus.Connecting &&
     deviceStatus === DeviceConnectionStatus.DISCONNECTED
   ) {
+    // We count this as the first connect failure.
+    // If we fail a second time, we should prompt the user to start over.
+    // Set the fields below appropriately to acheive this.
+    setOnFirstConnectAttempt(false);
+    setHasAttemptedReconnect(true);
     return { status: ConnectionStatus.FailedToConnect, flowType };
   }
   if (


### PR DESCRIPTION
Reset state after failing to connect or reconnect twice.
Additional fix when the link micro:bit is unplugged and the tab is not in focus.
Additional fix for to ensure radio connect fail dialog specifies the correct micro:bit (link/remote).