### PR TITLE
Round confidence value before use

### DIFF
--- a/src/components/ActionCertaintyCard.tsx
+++ b/src/components/ActionCertaintyCard.tsx
@@ -47,7 +47,9 @@ const ActionCertaintyCard = ({
     [onThresholdChange]
   );
   const sliderValue = requiredConfidence * 100;
-  const currentConfidence = predictionResult?.confidences[actionId] ?? 0;
+  const currentConfidence = Math.round(
+    (predictionResult?.confidences[actionId] ?? 0) * 100
+  );
   return (
     <Card
       py={2}

--- a/src/components/PercentageDisplay.tsx
+++ b/src/components/PercentageDisplay.tsx
@@ -26,7 +26,7 @@ const PercentageDisplay = ({
         w="60px"
         aria-hidden={!!ariaLabel}
         {...rest}
-      >{`${Math.round(value * 100)}%`}</Text>
+      >{`${value}%`}</Text>
     </>
   );
 };

--- a/src/components/PercentageMeter.tsx
+++ b/src/components/PercentageMeter.tsx
@@ -26,7 +26,7 @@ const PercentageMeter = ({
         // Use inline style attribute to avoid style tags being
         // constantly appended to the <head/> element.
         style={{
-          width: `${Math.round(value * 100)}%`,
+          width: `${value}%`,
         }}
         h={height}
         rounded="full"


### PR DESCRIPTION
This is now done in parent component, with the rounded value passed down. Closes #508 