### PR TITLE
Update flags for go-live

### DIFF
--- a/src/flags.test.ts
+++ b/src/flags.test.ts
@@ -8,10 +8,7 @@ describe("flags", () => {
 
     expect(
       Object.entries(flags).every(
-        ([flag, status]) =>
-          !status ||
-          (flag === "prototypeWarning" && status) ||
-          (flag === "preReleaseNotice" && status)
+        ([flag, status]) => !status || (flag === "websiteContent" && status)
       )
     ).toEqual(true);
   });

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -37,10 +37,13 @@ interface FlagMetadata {
 const allFlags: FlagMetadata[] = [
   // Alphabetical order.
   { name: "devtools", defaultOnStages: ["local"] },
-  { name: "websiteContent", defaultOnStages: ["local", "review", "staging"] },
+  {
+    name: "websiteContent",
+    defaultOnStages: ["local", "review", "staging", "production"],
+  },
   {
     name: "preReleaseNotice",
-    defaultOnStages: ["production"],
+    defaultOnStages: ["staging"],
   },
   { name: "exampleOptInA", defaultOnStages: ["review", "staging"] },
   { name: "exampleOptInB", defaultOnStages: [] },


### PR DESCRIPTION
We'll come back and remove the web content one.

Pre-release notice now applies only to staging, which we'll repurpose as a rolling beta some time after release.