### PR TITLE
Remove data samples page column navigation shortcut

### DIFF
--- a/src/components/DataSamplesTable.tsx
+++ b/src/components/DataSamplesTable.tsx
@@ -153,12 +153,6 @@ const DataSamplesTable = ({
     (idx: number) => document.getElementById(recordButtonId(actions[idx])),
     [actions]
   );
-  useShortcut(keyboardShortcuts.focusRecordButton, () =>
-    recordButtonEl(selectedActionIdx)?.focus()
-  );
-  useShortcut(keyboardShortcuts.focusActionName, () =>
-    actionNameInputEl(selectedActionIdx)?.focus()
-  );
   const renameActionShortcutScopeRef = useShortcut(
     keyboardShortcuts.renameAction,
     () => actionNameInputEl(selectedActionIdx)?.focus()
@@ -170,28 +164,15 @@ const DataSamplesTable = ({
         return;
       }
       const nextRecordButton = recordButtonEl(idx);
-      const nextActionNameInput = actionNameInputEl(idx);
-      if (document.activeElement === actionNameInputEl(selectedActionIdx)) {
-        // When focused on an action name input.
-        return nextActionNameInput?.focus();
+      // If record button exists, focus on it, otherwise focus on name input instead.
+      if (nextRecordButton) {
+        nextRecordButton.focus();
+      } else {
+        actionNameInputEl(idx)?.focus();
       }
-      if (
-        document.activeElement === recordButtonEl(selectedActionIdx) &&
-        nextRecordButton
-      ) {
-        // When focused on a record button and next record button exists.
-        return nextRecordButton.focus();
-      }
-      nextActionNameInput?.focus();
       setSelectedActionIdx(idx);
     },
-    [
-      actionNameInputEl,
-      actions.length,
-      recordButtonEl,
-      selectedActionIdx,
-      setSelectedActionIdx,
-    ]
+    [actionNameInputEl, actions.length, recordButtonEl, setSelectedActionIdx]
   );
   useShortcut(keyboardShortcuts.focusBelowAction, () =>
     focusAction(selectedActionIdx + 1)

--- a/src/keyboard-shortcut-hooks.tsx
+++ b/src/keyboard-shortcut-hooks.tsx
@@ -11,8 +11,6 @@ export const keyboardShortcuts = {
   settings: ["ctrl+shift+p", "meta+shift+p"],
   focusBelowAction: ["down"],
   focusAboveAction: ["up"],
-  focusActionName: ["left"],
-  focusRecordButton: ["right"],
   renameAction: ["F2"],
   connect: ["ctrl+shift+u", "meta+shift+u"],
   disconnect: ["ctrl+shift+k", "meta+shift+k"],


### PR DESCRIPTION
As discussed, left right navigation is needed in name text input field to change the cursor position in the string so we should not hijack it. Additionally, F2 can be used to focus on the action name input field if needed anyway. 