### PR TITLE
Fix bad firmware scenario

### DIFF
--- a/lang/ui.en.json
+++ b/lang/ui.en.json
@@ -703,10 +703,6 @@
     "defaultMessage": "Firmware update required",
     "description": "Connection error dialog"
   },
-  "firmware-outdated-skip": {
-    "defaultMessage": "Skip and transfer manually",
-    "description": "Connection error dialog content - firmware"
-  },
   "get-started-action": {
     "defaultMessage": "Get started",
     "description": "Get started action"

--- a/src/components/BrokenFirmwareDialog.tsx
+++ b/src/components/BrokenFirmwareDialog.tsx
@@ -26,13 +26,11 @@ interface BrokenFirmwareDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onTryAgain: () => void;
-  onSkip: () => void;
 }
 
 const BrokenFirmwareDialog = ({
   isOpen,
   onClose,
-  onSkip,
   onTryAgain,
 }: BrokenFirmwareDialogProps) => {
   const { supportLinks } = useDeployment();
@@ -99,9 +97,6 @@ const BrokenFirmwareDialog = ({
             <HStack gap={5}>
               <Button onClick={onClose} variant="secondary" size="lg">
                 <FormattedMessage id="cancel-action" />
-              </Button>
-              <Button onClick={onSkip} variant="secondary" size="lg">
-                <FormattedMessage id="firmware-outdated-skip" />
               </Button>
               <Button onClick={onTryAgain} variant="primary" size="lg">
                 <FormattedMessage id="try-again-action" />

--- a/src/components/ConnectionFlowDialogs.tsx
+++ b/src/components/ConnectionFlowDialogs.tsx
@@ -211,9 +211,6 @@ const ConnectionDialogs = () => {
       return (
         <BrokenFirmwareDialog
           {...dialogCommonProps}
-          onSkip={() =>
-            actions.setFlowStep(ConnectionFlowStep.ManualFlashingTutorial)
-          }
           onTryAgain={actions.onTryAgain}
         />
       );

--- a/src/connection-stage-actions.ts
+++ b/src/connection-stage-actions.ts
@@ -150,16 +150,14 @@ export class ConnectionStageActions {
   };
 
   private handleConnectAndFlashFail = (result: ConnectAndFlashFailResult) => {
+    if (result === ConnectResult.ErrorBadFirmware) {
+      return this.setFlowStep(ConnectionFlowStep.BadFirmware);
+    }
     if (this.stage.flowType === ConnectionFlowType.ConnectBluetooth) {
       downloadHex(bluetoothUniversalHex);
       return this.setFlowStep(ConnectionFlowStep.ManualFlashingTutorial);
     }
-
-    // TODO: Not sure if this is a good way of error handling because it means
-    // there are 2 levels of switch statements to go through to provide UI
     switch (result) {
-      case ConnectResult.ErrorBadFirmware:
-        return this.setFlowStep(ConnectionFlowStep.BadFirmware);
       case ConnectResult.ErrorNoDeviceSelected:
         return this.setFlowStep(
           ConnectionFlowStep.TryAgainWebUsbSelectMicrobit

--- a/src/messages/ui.en.json
+++ b/src/messages/ui.en.json
@@ -1207,12 +1207,6 @@
       "value": "Firmware update required"
     }
   ],
-  "firmware-outdated-skip": [
-    {
-      "type": 0,
-      "value": "Skip and transfer manually"
-    }
-  ],
   "get-started-action": [
     {
       "type": 0,


### PR DESCRIPTION
- Ensure that the bad firmware dialog is triggered in the bluetooth flow (not only in the radio flow). Previously, bad firmware would just prompt a manual flashing dialog for bluetooth flow.
- Remove "Skip and transfer manually" option in bad firmware dialog.