### PR TITLE
Remove not needed validation for onChangeMicrobitName

### DIFF
--- a/src/connection-stage-actions.ts
+++ b/src/connection-stage-actions.ts
@@ -172,9 +172,6 @@ export class ConnectionStageActions {
   };
 
   onChangeMicrobitName = (name: string) => {
-    if (this.stage.connType !== "bluetooth") {
-      throw new Error("Microbit name can only be set for bluetooth flow");
-    }
     this.setStage({
       ...this.stage,
       connType: "bluetooth",


### PR DESCRIPTION
The validation is incorrect and causes an error to be thrown incorrectly. 

**Error thrown incorrectly repro steps:**
1. Connect via radio connection.
2. Unplug radio link micro:bit and click reconnect to reach the fail twice dialog.
3. Change to bluetooth and update bluetooth pattern and see following error in console:
```
Uncaught Error: Microbit name can only be set for bluetooth flow
```
The bluetooth micro:bit name is not being updated. 