### PR TITLE
Handle local storage quota exceeding error

### DIFF
--- a/lang/ui.en.json
+++ b/lang/ui.en.json
@@ -1447,6 +1447,14 @@
     "defaultMessage": "Stop recording",
     "description": "Button label to stop recording movement data while recording multiple samples"
   },
+  "storage-quota-exceeded-dialog-body": {
+    "defaultMessage": "You have reached your session's storage limit. Recent changes made on your session cannot be saved. Please reload the page to continue your session.",
+    "description": "Body of storage error dialog"
+  },
+  "storage-quota-exceeded-dialog-title": {
+    "defaultMessage": "Error auto-saving your session",
+    "description": "Title of storage error dialog"
+  },
   "support-request": {
     "defaultMessage": "Please consider <link>raising a support request</link>.",
     "description": "Support request link text"

--- a/src/components/DefaultPageLayout.tsx
+++ b/src/components/DefaultPageLayout.tsx
@@ -37,6 +37,7 @@ import NotCreateAiHexImportDialog from "./NotCreateAiHexImportDialog";
 import PreReleaseNotice from "./PreReleaseNotice";
 import ProjectDropTarget from "./ProjectDropTarget";
 import SaveDialogs from "./SaveDialogs";
+import StorageQuotaExceededErrorDialog from "./StorageQuotaExceededErrorDialog";
 
 interface DefaultPageLayoutProps {
   titleId?: string;
@@ -92,6 +93,7 @@ const DefaultPageLayout = ({
         isOpen={postImportDialogState === PostImportDialogState.Error}
       />
       <MakeCodeLoadErrorDialog />
+      <StorageQuotaExceededErrorDialog />
       <FeedbackForm isOpen={isFeedbackOpen} onClose={closeDialog} />
       <ProjectDropTarget
         isEnabled={!isNonConnectionDialogOpen && !isConnectionDialogOpen}

--- a/src/components/DefaultPageLayout.tsx
+++ b/src/components/DefaultPageLayout.tsx
@@ -24,7 +24,7 @@ import { useProject } from "../hooks/project-hooks";
 import { keyboardShortcuts, useShortcut } from "../keyboard-shortcut-hooks";
 import { PostImportDialogState } from "../model";
 import Tour from "../pages/Tour";
-import { useStore } from "../store";
+import { isStorageQuotaExceeded, useStore } from "../store";
 import { createHomePageUrl } from "../urls";
 import ActionBar from "./ActionBar/ActionBar";
 import ItemsRight from "./ActionBar/ActionBarItemsRight";
@@ -77,11 +77,14 @@ const DefaultPageLayout = ({
 
   const isFeedbackOpen = useStore((s) => s.isFeedbackFormOpen);
   const closeDialog = useStore((s) => s.closeDialog);
+  const isStorageQuotaExceededDialogOpen = isStorageQuotaExceeded();
 
   return (
     <>
       {/* Suppress dialogs to prevent overlapping dialogs */}
-      {!isNonConnectionDialogOpen && <ConnectionDialogs />}
+      {!isNonConnectionDialogOpen && !isStorageQuotaExceededDialogOpen && (
+        <ConnectionDialogs />
+      )}
       <Tour />
       <SaveDialogs />
       <NotCreateAiHexImportDialog
@@ -93,7 +96,9 @@ const DefaultPageLayout = ({
         isOpen={postImportDialogState === PostImportDialogState.Error}
       />
       <MakeCodeLoadErrorDialog />
-      <StorageQuotaExceededErrorDialog />
+      <StorageQuotaExceededErrorDialog
+        isOpen={isStorageQuotaExceededDialogOpen}
+      />
       <FeedbackForm isOpen={isFeedbackOpen} onClose={closeDialog} />
       <ProjectDropTarget
         isEnabled={!isNonConnectionDialogOpen && !isConnectionDialogOpen}

--- a/src/components/StorageQuotaExceededErrorDialog.tsx
+++ b/src/components/StorageQuotaExceededErrorDialog.tsx
@@ -1,0 +1,60 @@
+/**
+ * (c) 2024, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import {
+  Button,
+  HStack,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import { FormattedMessage } from "react-intl";
+import { useStore } from "../store";
+
+const StorageQuotaExceededErrorDialog = () => {
+  const isOpen = useStore((s) => s.isStorageQuotaExceededDialogOpen);
+  return (
+    <Modal
+      motionPreset="none"
+      isOpen={isOpen}
+      onClose={() => {}}
+      size="2xl"
+      isCentered
+    >
+      <ModalOverlay>
+        <ModalContent>
+          <ModalHeader>
+            <FormattedMessage id="storage-quota-exceeded-dialog-title" />
+          </ModalHeader>
+          <ModalBody>
+            <VStack textAlign="left" w="100%">
+              <Text w="100%">
+                <FormattedMessage id="storage-quota-exceeded-dialog-body" />
+              </Text>
+            </VStack>
+          </ModalBody>
+          <ModalFooter justifyContent="flex-end">
+            <HStack gap={5}>
+              <Button
+                onClick={() => window.location.reload()}
+                variant="primary"
+                size="lg"
+              >
+                <FormattedMessage id="reload-action" />
+              </Button>
+            </HStack>
+          </ModalFooter>
+        </ModalContent>
+      </ModalOverlay>
+    </Modal>
+  );
+};
+
+export default StorageQuotaExceededErrorDialog;

--- a/src/components/StorageQuotaExceededErrorDialog.tsx
+++ b/src/components/StorageQuotaExceededErrorDialog.tsx
@@ -16,10 +16,14 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { FormattedMessage } from "react-intl";
-import { useStore } from "../store";
 
-const StorageQuotaExceededErrorDialog = () => {
-  const isOpen = useStore((s) => s.isStorageQuotaExceededDialogOpen);
+interface StorageQuotaExceededErrorDialogProps {
+  isOpen: boolean;
+}
+
+const StorageQuotaExceededErrorDialog = ({
+  isOpen,
+}: StorageQuotaExceededErrorDialogProps) => {
   return (
     <Modal
       motionPreset="none"

--- a/src/messages/ui.en.json
+++ b/src/messages/ui.en.json
@@ -2563,6 +2563,18 @@
       "value": "Stop recording"
     }
   ],
+  "storage-quota-exceeded-dialog-body": [
+    {
+      "type": 0,
+      "value": "You have reached your session's storage limit. Recent changes made on your session cannot be saved. Please reload the page to continue your session."
+    }
+  ],
+  "storage-quota-exceeded-dialog-title": [
+    {
+      "type": 0,
+      "value": "Error auto-saving your session"
+    }
+  ],
   "support-request": [
     {
       "type": 0,

--- a/src/store.ts
+++ b/src/store.ts
@@ -589,51 +589,39 @@ const createMlStore = (logging: Logging) => {
           },
 
           loadDataset(newActions: ActionData[]) {
-            try {
-              set(({ project, projectEdited, settings }) => {
-                const dataWindow = getDataWindowFromActions(newActions);
-                return {
-                  settings: {
-                    ...settings,
-                    toursCompleted: Array.from(
-                      new Set([
-                        ...settings.toursCompleted,
-                        "DataSamplesRecorded",
-                      ])
-                    ),
-                  },
-                  actions: (() => {
-                    const copy = newActions.map((a) => ({ ...a }));
-                    for (const a of copy) {
-                      if (!a.icon) {
-                        a.icon = actionIcon({
-                          isFirstAction: false,
-                          existingActions: copy,
-                        });
-                      }
-                    }
-                    return copy;
-                  })(),
-                  dataWindow,
-                  model: undefined,
-                  timestamp: Date.now(),
-                  ...updateProject(
-                    project,
-                    projectEdited,
-                    newActions,
-                    undefined,
-                    dataWindow
+            set(({ project, projectEdited, settings }) => {
+              const dataWindow = getDataWindowFromActions(newActions);
+              return {
+                settings: {
+                  ...settings,
+                  toursCompleted: Array.from(
+                    new Set([...settings.toursCompleted, "DataSamplesRecorded"])
                   ),
-                };
-              });
-            } catch (e) {
-              if ((e as Error).name === "QuotaExceededError") {
-                return set({
-                  isStorageQuotaExceededDialogOpen: true,
-                });
-              }
-              throw e;
-            }
+                },
+                actions: (() => {
+                  const copy = newActions.map((a) => ({ ...a }));
+                  for (const a of copy) {
+                    if (!a.icon) {
+                      a.icon = actionIcon({
+                        isFirstAction: false,
+                        existingActions: copy,
+                      });
+                    }
+                  }
+                  return copy;
+                })(),
+                dataWindow,
+                model: undefined,
+                timestamp: Date.now(),
+                ...updateProject(
+                  project,
+                  projectEdited,
+                  newActions,
+                  undefined,
+                  dataWindow
+                ),
+              };
+            });
           },
 
           /**

--- a/src/store.ts
+++ b/src/store.ts
@@ -1216,6 +1216,7 @@ const createMlStore = (logging: Logging) => {
   );
 };
 
+const storageQuotaExceededKey = "QuotaExceededError";
 const mlStorage = {
   getItem: localStorage.getItem,
   setItem: (name: string, value: string) => {
@@ -1223,17 +1224,16 @@ const mlStorage = {
       localStorage.setItem(name, value);
     } catch (e) {
       if ((e as Error).name === "QuotaExceededError") {
-        const prevValue = JSON.parse(value) as object;
-        const newValue = {
-          ...prevValue,
-          isStorageQuotaExceededDialogOpen: true,
-        };
-        return localStorage.setItem(name, JSON.stringify(newValue));
+        return localStorage.setItem(storageQuotaExceededKey, "1");
       }
       throw e;
     }
   },
   removeItem: localStorage.removeItem,
+};
+
+export const isStorageQuotaExceeded = () => {
+  return localStorage.getItem(storageQuotaExceededKey) === "1";
 };
 
 export const useStore = createMlStore(deployment.logging);
@@ -1244,6 +1244,9 @@ const getDataWindowFromActions = (actions: ActionData[]): DataWindow => {
     ? legacyDataWindow
     : currentDataWindow;
 };
+
+// Reset storage quota exceeded state
+localStorage.setItem(storageQuotaExceededKey, "0");
 
 // Get data window from actions on app load.
 const { actions } = useStore.getState();


### PR DESCRIPTION
The following error can occur when users import a large hex / large number of data samples, adding action / data samples, or when adding to their MakeCode project:

`QuotaExceededError: Failed to execute 'setItem' on 'Storage': Setting the value of 'ml' exceeded the quota.`

To mitigate the issue, I have proposed adding a dialog to handle the error. 



