### PR TITLE
Add call to `startRunning` in `autogenerated.ts` file

### DIFF
--- a/src/makecode/generate-custom-scripts.ts
+++ b/src/makecode/generate-custom-scripts.ts
@@ -86,6 +86,7 @@ ${createEventListeners(actionNames)}
   };
 
   simulatorSendData();
+  startRunning();
 }
 
 // Auto-generated. Do not edit. Really.


### PR DESCRIPTION
This change ensures the model starts running on the micro:bit immediately, even if no ml event blocks are used.

Todo:

- [ ] Bump ml extension version - depends on https://github.com/microbit-foundation/pxt-microbit-ml/pull/41

Closes https://github.com/microbit-foundation/pxt-microbit-ml/issues/40