### PR TITLE
Always assume project has been edited if MakeCode was opened

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -406,10 +406,10 @@ const createMlStore = (logging: Logging) => {
 
           setEditorOpen(open: boolean) {
             set(
-              ({ download, model }) => ({
+              ({ download }) => ({
                 isEditorOpen: open,
                 // We just assume its been edited as spurious changes from MakeCode happen that we can't identify
-                projectEdited: model ? true : false,
+                projectEdited: true,
                 download: {
                   ...download,
                   usbDevice: undefined,


### PR DESCRIPTION
Bug was introduced in [this PR](https://github.com/microbit-foundation/ml-trainer/pull/416/files), but I don't understand why the change was made.