### PR TITLE
Add a beta stage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
     env:
       AWS_DEFAULT_REGION: eu-west-1
       PRODUCTION_CLOUDFRONT_DISTRIBUTION_ID: EDKYRQ3JZCXQ5
+      # As per production because beta stage is served from there
+      BETA_CLOUDFRONT_DISTRIBUTION_ID: EDKYRQ3JZCXQ5
       STAGING_CLOUDFRONT_DISTRIBUTION_ID: E37K3V5Y65XQIX
       REVIEW_CLOUDFRONT_DISTRIBUTION_ID: E3KUGPF02I4CJ4
       VITE_FOUNDATION_BUILD: ${{ github.repository_owner == 'microbit-foundation' }}
@@ -37,19 +39,19 @@ jobs:
       - run: npm ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: npm install --no-save @microbit-foundation/ml-trainer-microbit@0.2.0-dev.75 @microbit-foundation/website-deploy-aws@0.6 @microbit-foundation/website-deploy-aws-config@0.9
+      - run: npm install --no-save @microbit-foundation/ml-trainer-microbit@0.2.0-dev.75 @microbit-foundation/website-deploy-aws@0.6 @microbit-foundation/website-deploy-aws-config@0.10
         if: github.repository_owner == 'microbit-foundation'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: node ./bin/print-ci-env.cjs >> $GITHUB_ENV
       - run: npm run ci
       - name: Run Playwright tests
-        if: env.STAGE == 'REVIEW' || env.STAGE == 'STAGING'
+        if: env.STAGE == 'REVIEW' || env.STAGE == 'STAGING' || env.STAGE == 'BETA'
         uses: docker://mcr.microsoft.com/playwright:v1.45.0-jammy
         with:
           args: npx playwright test
       - name: Store reports
-        if: (env.STAGE == 'REVIEW' || env.STAGE == 'STAGING') && failure()
+        if: (env.STAGE == 'REVIEW' || env.STAGE == 'STAGING' || env.STAGE == 'BETA') && failure()
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report

--- a/bin/print-ci-env.cjs
+++ b/bin/print-ci-env.cjs
@@ -2,18 +2,20 @@
 
 const ref = process.env.GITHUB_REF;
 let stage;
-if (ref === 'refs/heads/main') {
-  stage = 'STAGING';
-} else if (ref.startsWith('refs/tags/v')) {
-  stage = 'PRODUCTION';
+if (ref === "refs/heads/beta") {
+  stage = "BETA";
+} else if (ref === "refs/heads/main") {
+  stage = "STAGING";
+} else if (ref.startsWith("refs/tags/v")) {
+  stage = "PRODUCTION";
 } else {
-  stage = 'REVIEW';
+  stage = "REVIEW";
 }
 
 process.env.STAGE = stage;
 // STAGE must be defined before this is imported
-const { bucketName, bucketPrefix } = require('../deployment.cjs');
-const baseUrl = !bucketPrefix ? '/' : `/${bucketPrefix}/`;
+const { bucketName, bucketPrefix } = require("../deployment.cjs");
+const baseUrl = !bucketPrefix ? "/" : `/${bucketPrefix}/`;
 const fullUrl = `https://${bucketName}${baseUrl}`;
 
 console.log(`STAGE=${stage}`);

--- a/deployment.cjs
+++ b/deployment.cjs
@@ -16,6 +16,11 @@ const { s3Config } = createDeploymentDetailsFromOptions({
   staging: {
     bucket: "stage-createai.microbit.org",
   },
+  beta: {
+    bucket: "review-createai.microbit.org",
+    hostname: "createai.microbit.org",
+    prefix: "v/beta",
+  },
   review: {
     bucket: "review-createai.microbit.org",
     mode: "branch-prefix",

--- a/src/components/ConnectCableDialog.tsx
+++ b/src/components/ConnectCableDialog.tsx
@@ -5,12 +5,12 @@
  */
 import { Button, Image, Text, VStack } from "@chakra-ui/react";
 import { FormattedMessage, useIntl } from "react-intl";
+import { ConnectionFlowType } from "../connection-stage-hooks";
+import { isLocalStage } from "../environment";
 import connectCableImage from "../images/connect-cable.gif";
 import ConnectContainerDialog, {
   ConnectContainerDialogProps,
 } from "./ConnectContainerDialog";
-import { ConnectionFlowType } from "../connection-stage-hooks";
-import { stage } from "../environment";
 
 type LinkType = "switch" | "skip" | "none";
 interface Config {
@@ -36,7 +36,7 @@ export const getConnectionCableDialogConfig = (
       return {
         headingId: "connect-data-collection-heading",
         subtitleId: "connect-data-collection-subtitle",
-        ...(stage === "local"
+        ...(isLocalStage()
           ? {
               linkTextId: "connect-cable-skip",
               linkType: "skip",

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -6,10 +6,18 @@
 
 // See CI & package.json scripts.
 export const version = import.meta.env.VITE_VERSION || "local";
-export type Stage = "local" | "review" | "staging" | "production";
+export type Stage = "local" | "review" | "staging" | "beta" | "production";
+export const isLocalStage = () => stage === "local";
+export const isPublicFacingStage = () =>
+  stage === "beta" || stage === "production";
+/**
+ * Prefer the functions in environment.ts.
+ */
 export const stage: Stage = (() => {
   const value = (import.meta.env.VITE_STAGE || "LOCAL").toLowerCase();
-  if (["local", "review", "staging", "production"].indexOf(value) === -1) {
+  if (
+    ["local", "review", "staging", "beta", "production"].indexOf(value) === -1
+  ) {
     throw new Error(`Unknown stage: ${value}`);
   }
   return value as Stage;

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -59,13 +59,14 @@ const allFlags: FlagMetadata[] = [
   { name: "e2e", defaultOnStages: [] },
   {
     name: "preReleaseNotice",
-    defaultOnStages: ["staging"],
+    defaultOnStages: ["staging", "beta"],
   },
   { name: "translate", defaultOnStages: [] },
-  { name: "translationPreview", defaultOnStages: [] },
+  { name: "translationPreview", defaultOnStages: ["beta"] },
+  // We can probably remove this flag now it's enabled everywhere!
   {
     name: "websiteContent",
-    defaultOnStages: ["local", "review", "staging", "production"],
+    defaultOnStages: ["local", "review", "staging", "beta", "production"],
   },
 ];
 

--- a/src/utils/external-links.ts
+++ b/src/utils/external-links.ts
@@ -3,14 +3,13 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { stage } from "../environment";
+import { isPublicFacingStage } from "../environment";
 
 // We might move these into the deployment config in future
 // They'll also need to become language aware
-const microbitOrgBaseUrl =
-  stage === "production"
-    ? "https://microbit.org/"
-    : "https://stage.microbit.org/";
+const microbitOrgBaseUrl = isPublicFacingStage()
+  ? "https://microbit.org/"
+  : "https://stage.microbit.org/";
 
 const langPath = (languageId: string) =>
   languageId === "en" ? "" : `${languageId.toLowerCase()}/`;


### PR DESCRIPTION
This will also need CF configuration to serve it from live as we've not deployed to the live bucket.

I think we should do the same from staging too so we can easily test the routing.

I'm not sure this is the final answer as using the review bucket is a bit odd but it's a safe way to make this change for now. I'd like to consider consolidating to a single bucket for apps that have a CF function.

I've skipped CI to allow some review before we run the CI workflow.