### PR TITLE
Keep system status bar out of the Action Bar area

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /dist/
-/.idea/
+.idea/
 /node_modules/
 
 .DS_Store

--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -9,7 +9,7 @@ android {
 
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
-    implementation project(':capacitor-status-bar')
+    implementation project(':capacitor-community-safe-area')
 
 }
 

--- a/android/app/src/main/java/org/microbit/createai/MainActivity.java
+++ b/android/app/src/main/java/org/microbit/createai/MainActivity.java
@@ -1,5 +1,15 @@
 package org.microbit.createai;
 
+import androidx.activity.EdgeToEdge;
+
 import com.getcapacitor.BridgeActivity;
 
-public class MainActivity extends BridgeActivity {}
+public class MainActivity extends BridgeActivity {
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        EdgeToEdge.enable(this);
+    }
+
+}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.2'
+        classpath 'com.android.tools.build:gradle:8.13.1'
         classpath 'com.google.gms:google-services:4.4.2'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -2,5 +2,5 @@
 include ':capacitor-android'
 project(':capacitor-android').projectDir = new File('../node_modules/@capacitor/android/capacitor')
 
-include ':capacitor-status-bar'
-project(':capacitor-status-bar').projectDir = new File('../node_modules/@capacitor/status-bar/android')
+include ':capacitor-community-safe-area'
+project(':capacitor-community-safe-area').projectDir = new File('../node_modules/@capacitor-community/safe-area/android')

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -3,7 +3,10 @@ import type { CapacitorConfig } from '@capacitor/cli';
 const config: CapacitorConfig = {
   appId: 'org.microbit.createai',
   appName: 'micro:bit CreateAI',
-  webDir: 'dist'
+  webDir: 'dist',
+  android: {
+    adjustMarginsForEdgeToEdge: 'disable'
+  }
 };
 
 export default config;

--- a/index.html
+++ b/index.html
@@ -62,8 +62,6 @@
     style="
       overscroll-behavior-y: none;
       height: 100%;
-      padding-top: env(safe-area-inset-top);
-      padding-bottom: env(safe-area-inset-bottom);
     "
   >
     <div id="root" style="overscroll-behavior-y: none; height: 100%"></div>

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -11,7 +11,7 @@ install! 'cocoapods', :disable_input_output_paths => true
 def capacitor_pods
   pod 'Capacitor', :path => '../../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../../node_modules/@capacitor/ios'
-  pod 'CapacitorStatusBar', :path => '../../node_modules/@capacitor/status-bar'
+  pod 'CapacitorCommunitySafeArea', :path => '../../node_modules/@capacitor-community/safe-area'
 end
 
 target 'App' do

--- a/ios/App/Podfile.lock
+++ b/ios/App/Podfile.lock
@@ -1,28 +1,28 @@
 PODS:
   - Capacitor (7.4.4):
     - CapacitorCordova
-  - CapacitorCordova (7.4.4)
-  - CapacitorStatusBar (7.0.3):
+  - CapacitorCommunitySafeArea (7.0.0-beta.5):
     - Capacitor
+  - CapacitorCordova (7.4.4)
 
 DEPENDENCIES:
   - "Capacitor (from `../../node_modules/@capacitor/ios`)"
+  - "CapacitorCommunitySafeArea (from `../../node_modules/@capacitor-community/safe-area`)"
   - "CapacitorCordova (from `../../node_modules/@capacitor/ios`)"
-  - "CapacitorStatusBar (from `../../node_modules/@capacitor/status-bar`)"
 
 EXTERNAL SOURCES:
   Capacitor:
     :path: "../../node_modules/@capacitor/ios"
+  CapacitorCommunitySafeArea:
+    :path: "../../node_modules/@capacitor-community/safe-area"
   CapacitorCordova:
     :path: "../../node_modules/@capacitor/ios"
-  CapacitorStatusBar:
-    :path: "../../node_modules/@capacitor/status-bar"
 
 SPEC CHECKSUMS:
-  Capacitor: 09d9ff8e9618e8c4b3cab2bbee34a17215dd2fef
+  Capacitor: 358dd1c3fdd71d969547b17e159fd8a7736cb45f
+  CapacitorCommunitySafeArea: 53e3ad999bada9892cb4e9aca8fa8012aabad4b2
   CapacitorCordova: bf648a636f3c153f652d312ae145fb508b6ffced
-  CapacitorStatusBar: 7d8fcbd6768db014bd721d75e246590b014928e8
 
-PODFILE CHECKSUM: 2dda0cc353931d1c074294a0067df65453b878b5
+PODFILE CHECKSUM: b14023669789a78b7a53c7515766b1a886b64d37
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@capacitor-community/safe-area": "^7.0.0-beta.5",
         "@capacitor/android": "^7.4.4",
         "@capacitor/core": "^7.4.4",
         "@capacitor/ios": "^7.4.4",
-        "@capacitor/status-bar": "^7.0.3",
         "@chakra-ui/icons": "^2.1.1",
         "@chakra-ui/react": "^2.8.2",
         "@emotion/react": "^11.11.4",
@@ -374,6 +374,15 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@capacitor-community/safe-area": {
+      "version": "7.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@capacitor-community/safe-area/-/safe-area-7.0.0-beta.5.tgz",
+      "integrity": "sha512-IP7+O+oU9Z8uX+lGfe/hDdQBmWcWqa/Bu0L49GAGSWnEARTKsgTrN6Rs3RQaEKlojOcc6BhX91bYNxOBPzPQ1Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
+      }
+    },
     "node_modules/@capacitor/android": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-7.4.4.tgz",
@@ -519,15 +528,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^7.4.0"
-      }
-    },
-    "node_modules/@capacitor/status-bar": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@capacitor/status-bar/-/status-bar-7.0.3.tgz",
-      "integrity": "sha512-JyRpVnKwHij9hgPWolF6PK+HT3e2HSPjN11/h2OmKxq8GAdPGARFLv+97eZl0pvuvm0Kka/LpiLb5whXISBg7Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@capacitor/core": ">=7.0.0"
       }
     },
     "node_modules/@chakra-ui/accordion": {

--- a/package.json
+++ b/package.json
@@ -58,10 +58,10 @@
     "vitest-dom": "^0.1.1"
   },
   "dependencies": {
+    "@capacitor-community/safe-area": "^7.0.0-beta.5",
     "@capacitor/android": "^7.4.4",
     "@capacitor/core": "^7.4.4",
     "@capacitor/ios": "^7.4.4",
-    "@capacitor/status-bar": "^7.0.3",
     "@chakra-ui/icons": "^2.1.1",
     "@chakra-ui/react": "^2.8.2",
     "@emotion/react": "^11.11.4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,8 +6,6 @@
  */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { ChakraProvider, useToast } from "@chakra-ui/react";
-import { Capacitor } from "@capacitor/core";
-import { StatusBar, Style } from "@capacitor/status-bar";
 import { MakeCodeFrameDriver } from "@microbit/makecode-embed/react";
 import {
   createRadioBridgeConnection,
@@ -59,6 +57,8 @@ import {
   createNewPageUrl,
   createTestingModelPageUrl,
 } from "./urls";
+import { SafeArea, SystemBarsStyle } from "@capacitor-community/safe-area";
+import { Capacitor } from "@capacitor/core";
 
 export interface ProviderLayoutProps {
   children: ReactNode;
@@ -208,13 +208,9 @@ const createRouter = () => {
 
 const App = () => {
   useEffect(() => {
-    // Configure status bar for native platforms
     if (Capacitor.isNativePlatform()) {
-      StatusBar.setStyle({ style: Style.Light }).catch((err) => {
-        logging.error(err);
-      });
-      StatusBar.setOverlaysWebView({ overlay: false }).catch((err) => {
-        logging.error(err);
+      void SafeArea.setSystemBarsStyle({
+        style: SystemBarsStyle.Dark,
       });
     }
 

--- a/src/components/ActionBar/ActionBar.tsx
+++ b/src/components/ActionBar/ActionBar.tsx
@@ -25,10 +25,15 @@ const ActionBar = ({
       as="header"
       alignItems="center"
       justifyContent="space-between"
-      bgColor="brand2.500"
-      h="64px"
       gap={0}
-      minH="64px"
+      sx={{
+        // Pad the action bar when it appears under the system status bar
+        maxHeight: "calc(64px + env(safe-area-inset-top))",
+        height: "calc(64px + env(safe-area-inset-top))",
+        paddingTop: "env(safe-area-inset-top)",
+        background:
+          "linear-gradient(to bottom, var(--chakra-colors-brand2-600) env(safe-area-inset-top), var(--chakra-colors-brand2-500) env(safe-area-inset-top))",
+      }}
       {...rest}
     >
       <HStack

--- a/src/components/EditCodeDialog.tsx
+++ b/src/components/EditCodeDialog.tsx
@@ -24,11 +24,14 @@ const EditCodeDialog = forwardRef<MakeCodeFrameDriver, EditCodeDialogProps>(
       <Flex
         w="100%"
         h="100%"
-        bgColor="white"
+        bgColor="#3454D1" // Matches MakeCode behind status bar, for edge-to-edge appearance
         left={isOpen ? undefined : "-150vw"}
         top={isOpen ? undefined : "-150vh"}
         visibility={isOpen ? "visible" : "hidden"}
         position={isOpen ? undefined : "absolute"}
+        sx={{
+          paddingTop: "env(safe-area-inset-top)",
+        }}
       >
         <Editor ref={ref} style={{ flexGrow: 1 }} />
       </Flex>


### PR DESCRIPTION
Google is transitioning all apps to work edge-to-edge. As CreateAI has a fixed ActionBar, it makes sense for this bar to be the component that extends to the top of the screen.

As a minor design decision: if you extend the ActionBar to the top of the screen, with the buttons appearing in the safe area beneath the status bar, the ActionBar buttons look misaligned on the vertical axis. As an initial approach I have darkened the colour beneath the status bar a little to provide contrast. MakeCode looks fine with solid blue, so I have kept the default colour.

Android Chromium webviews less than version 140 do not correctly support edge-to-edge. In versions of the WebView that do not have edge-to-edge capability, this functionality is inert and the [safe-area](https://github.com/capacitor-community/safe-area) plugin transitions us safely back to a non-edge-to-edge layout with a solid status bar. The introduction to the readme for safe-area contains additional context about why this is not always trivial on Android.

On android 35 emulator, the status bar seems inordinately big compared to android 36, but still usable.

iOS is always edge to edge.

## Screenshots

### Android 36, older webview

<img width="2560" height="1600" alt="Screenshot_20251202_103704" src="https://github.com/user-attachments/assets/a055f311-8824-4400-8da1-a17c15034369" />

<img width="2560" height="1600" alt="Screenshot_20251202_103854" src="https://github.com/user-attachments/assets/0bc9703a-94bc-4d1b-891f-14eb6a066104" />

### Android 36, newer webview

<img width="2560" height="1600" alt="Screenshot_20251202_103527" src="https://github.com/user-attachments/assets/1823eb5d-ae5f-4765-a07b-279e28828edd" />

<img width="2560" height="1600" alt="Screenshot_20251202_103607" src="https://github.com/user-attachments/assets/b1876097-812d-4860-be23-e4ec7c6bec45" />

### Android 35, older webview

<img width="2560" height="1600" alt="Screenshot_20251202_111616" src="https://github.com/user-attachments/assets/89a6f9cd-6a8e-40f2-99bb-967b1bd383a1" />

<img width="2560" height="1600" alt="Screenshot_20251202_112232" src="https://github.com/user-attachments/assets/5adfe7bc-265c-4d47-aea8-6f075a80f04d" />

### Android 35, newer webview

<img width="2560" height="1600" alt="Screenshot_20251202_111512" src="https://github.com/user-attachments/assets/3f4c6636-a649-47aa-9d29-1013d6ef590d" />

<img width="2560" height="1600" alt="Screenshot_20251202_111536" src="https://github.com/user-attachments/assets/fd79fcc0-cf02-482d-a626-7388f8ec216a" />

### iOS 16

<img width="2360" height="1640" alt="Simulator Screenshot - iPad Air 11-inch (M2) - 2025-12-02 at 10 44 59" src="https://github.com/user-attachments/assets/d563b888-6824-480c-8eb1-2afb07bcca53" />

<img width="2360" height="1640" alt="Simulator Screenshot - iPad Air 11-inch (M2) - 2025-12-02 at 10 46 42" src="https://github.com/user-attachments/assets/6ec85d88-4a95-4963-ab96-611c4285058c" />


