### PR TITLE
Update the project when an action recording is added

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -472,7 +472,7 @@ const createMlStore = (logging: Logging) => {
           },
 
           addActionRecordings(id: ActionData["ID"], recs: RecordingData[]) {
-            return set(({ actions }) => {
+            return set(({ actions, dataWindow, project, projectEdited }) => {
               const updatedActions = actions.map((action) => {
                 if (action.ID === id) {
                   return {
@@ -485,6 +485,13 @@ const createMlStore = (logging: Logging) => {
               return {
                 actions: updatedActions,
                 model: undefined,
+                ...updateProject(
+                  project,
+                  projectEdited,
+                  updatedActions,
+                  undefined,
+                  dataWindow
+                ),
               };
             });
           },


### PR DESCRIPTION
This fixes a bug that occurs when a user saves the hex file immediately after adding recordings. When the project is reloaded from the hex file, the recordings are missing. This is because the project is not updated after the recordings are added.