### PR TITLE
Remove ConnectResult; use DeviceErrorCode directly

### DIFF
--- a/src/connection-service-hooks.tsx
+++ b/src/connection-service-hooks.tsx
@@ -17,7 +17,6 @@ import {
   useState,
 } from "react";
 import { ConnectionService } from "./connection-service";
-import { useLogging } from "./logging/logging-hooks";
 
 interface ConnectionServiceContextValue {
   connectionService: ConnectionService;
@@ -40,12 +39,10 @@ export const ConnectionServiceProvider = ({
   radioBridge,
 }: ConnectionServiceProviderProps) => {
   const [isInitialized, setIsInitialized] = useState<boolean>(false);
-  const logging = useLogging();
   const connectionServiceRef = useRef<ConnectionService>();
 
   if (!connectionServiceRef.current) {
     connectionServiceRef.current = new ConnectionService(
-      logging,
       usb,
       bluetooth,
       radioBridge

--- a/src/connection-service.ts
+++ b/src/connection-service.ts
@@ -11,6 +11,7 @@ import {
   ConnectionStatusEvent,
   ConnectionStatus as DeviceConnectionStatus,
   DeviceError,
+  DeviceErrorCode,
   FlashOptions,
   MicrobitRadioBridgeConnection,
   MicrobitWebBluetoothConnection,
@@ -25,21 +26,10 @@ import {
 } from "./data-connection-flow";
 import { MicrobitConnection } from "./device/connection-utils";
 import { HexType, getFlashDataSource } from "./device/get-hex-file";
-import { Logging } from "./logging/logging";
 import { isNativePlatform } from "./platform";
 
-export enum ConnectResult {
-  Success = "Success",
-  Failed = "Failed",
-  ErrorBadFirmware = "ErrorBadFirmware",
-  ErrorNoDeviceSelected = "ErrorNoDeviceSelected",
-  ErrorUnableToClaimInterface = "ErrorUnableToClaimInterface",
-}
-
-export type ConnectAndFlashFailResult = Exclude<
-  ConnectResult,
-  ConnectResult.Success
->;
+export { DeviceError };
+export type { DeviceErrorCode };
 
 type EventCallback = (event: DataConnectionEvent) => void;
 
@@ -54,7 +44,6 @@ export interface ConnectionAndFlashOptions {
  */
 export class ConnectionService {
   constructor(
-    private logging: Logging,
     private usb: MicrobitWebUSBConnection,
     private bluetooth: MicrobitWebBluetoothConnection,
     private radioBridge: MicrobitRadioBridgeConnection
@@ -81,56 +70,27 @@ export class ConnectionService {
   async connect(
     connection: MicrobitConnection,
     options?: ConnectionAndFlashOptions
-  ): Promise<ConnectResult> {
-    try {
-      await connection.connect({ progress: options?.progress });
-      return ConnectResult.Success;
-    } catch (e) {
-      this.logging.error("USB request device failed/cancelled", e);
-      return this.handleConnectAndFlashError(e);
-    }
+  ): Promise<void> {
+    await connection.connect({ progress: options?.progress });
   }
 
   async flash(
     connection: MicrobitConnection,
     hex: string | HexType,
     progress: (stage: ProgressStage, value: number | undefined) => void
-  ): Promise<ConnectResult> {
+  ): Promise<void> {
     const data = Object.values(HexType).includes(hex as HexType)
       ? getFlashDataSource(hex as HexType)
       : createUniversalHexFlashDataSource(hex);
 
-    try {
-      const options: FlashOptions = {
-        partial: true,
-        // If we could improve the re-rendering due to progress further we can remove this and accept the
-        // default which updates 4x as often.
-        minimumProgressIncrement: 0.01,
-        progress,
-      };
-      await connection.flash(data, options);
-      return ConnectResult.Success;
-    } catch (e) {
-      this.logging.error("Flashing failed", e);
-      return this.handleConnectAndFlashError(e);
-    }
-  }
-
-  private handleConnectAndFlashError(err: unknown): ConnectAndFlashFailResult {
-    if (err instanceof DeviceError) {
-      switch (err.code) {
-        case "clear-connect":
-          return ConnectResult.ErrorUnableToClaimInterface;
-        case "no-device-selected":
-          return ConnectResult.ErrorNoDeviceSelected;
-        case "update-req":
-          return ConnectResult.ErrorBadFirmware;
-        // TODO: There are now bluetooth related codes to add which need custom UX.
-        default:
-          return ConnectResult.Failed;
-      }
-    }
-    return ConnectResult.Failed;
+    const options: FlashOptions = {
+      partial: true,
+      // If we could improve the re-rendering due to progress further we can remove this and accept the
+      // default which updates 4x as often.
+      minimumProgressIncrement: 0.01,
+      progress,
+    };
+    await connection.flash(data, options);
   }
 
   async connectMicrobitsSerial(deviceId: number): Promise<void> {

--- a/src/data-connection-flow/data-connection-machine-common.ts
+++ b/src/data-connection-flow/data-connection-machine-common.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { BoardVersion } from "@microbit/microbit-connection";
-import { ConnectResult } from "../connection-service";
+import { DeviceErrorCode } from "../connection-service";
 import {
   DataConnectionStep,
   DataConnectionType,
@@ -38,7 +38,7 @@ export type DataConnectionEvent =
   | { type: "connectSuccess" }
   | {
       type: "connectFailure";
-      reason: ConnectResult;
+      errorCode: DeviceErrorCode;
     }
   | {
       type: "flashSuccess";
@@ -46,7 +46,7 @@ export type DataConnectionEvent =
       deviceId?: number;
       bluetoothMicrobitName?: string;
     }
-  | { type: "flashFailure"; reason: ConnectResult }
+  | { type: "flashFailure"; errorCode: DeviceErrorCode }
   // Device status events - sent directly from the status listener.
   | { type: "deviceConnected" }
   | { type: "deviceDisconnected"; source?: "bridge" | "remote" }
@@ -167,29 +167,25 @@ export const guards = {
   // Browser tab visibility guard
   isTabHidden: (ctx: DataConnectionContext) => !ctx.isBrowserTabVisible,
 
-  // Guards that check event payload
+  // Guards that check event payload for specific error codes
   isBadFirmwareError: (
     _ctx: DataConnectionContext,
     event: DataConnectionEvent
-  ) =>
-    event.type === "connectFailure" &&
-    event.reason === ConnectResult.ErrorBadFirmware,
+  ) => event.type === "connectFailure" && event.errorCode === "update-req",
 
   isNoDeviceSelectedError: (
     _ctx: DataConnectionContext,
     event: DataConnectionEvent
   ) =>
     (event.type === "connectFailure" || event.type === "flashFailure") &&
-    (event as { reason?: ConnectResult }).reason ===
-      ConnectResult.ErrorNoDeviceSelected,
+    event.errorCode === "no-device-selected",
 
   isUnableToClaimError: (
     _ctx: DataConnectionContext,
     event: DataConnectionEvent
   ) =>
     (event.type === "connectFailure" || event.type === "flashFailure") &&
-    (event as { reason?: ConnectResult }).reason ===
-      ConnectResult.ErrorUnableToClaimInterface,
+    event.errorCode === "clear-connect",
 };
 
 // =============================================================================

--- a/src/data-connection-flow/data-connection-machine.test.ts
+++ b/src/data-connection-flow/data-connection-machine.test.ts
@@ -3,7 +3,8 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { ConnectResult } from "../connection-service";
+// DeviceErrorCode values used in tests:
+// "update-req" = bad firmware, "no-device-selected" = user cancelled, "clear-connect" = interface in use, "reconnect-microbit" = generic failure
 import {
   DataConnectionEvent,
   dataConnectionTransition,
@@ -252,7 +253,7 @@ describe("data-connection-machine", () => {
       it("connectFailure with bad firmware -> BadFirmware", () => {
         const result = transition(flow, DataConnectionStep.FlashingInProgress, {
           type: "connectFailure",
-          reason: ConnectResult.ErrorBadFirmware,
+          errorCode: "update-req",
         });
 
         expect(result?.step).toBe(DataConnectionStep.BadFirmware);
@@ -261,7 +262,7 @@ describe("data-connection-machine", () => {
       it("connectFailure (other) -> ManualFlashingTutorial with downloadHex", () => {
         const result = transition(flow, DataConnectionStep.FlashingInProgress, {
           type: "connectFailure",
-          reason: ConnectResult.Failed,
+          errorCode: "reconnect-microbit",
         });
 
         expect(result?.step).toBe(DataConnectionStep.ManualFlashingTutorial);
@@ -283,7 +284,7 @@ describe("data-connection-machine", () => {
       it("flashFailure -> ManualFlashingTutorial with downloadHex", () => {
         const result = transition(flow, DataConnectionStep.FlashingInProgress, {
           type: "flashFailure",
-          reason: ConnectResult.Failed,
+          errorCode: "reconnect-microbit",
         });
 
         expect(result?.step).toBe(DataConnectionStep.ManualFlashingTutorial);
@@ -576,7 +577,7 @@ describe("data-connection-machine", () => {
       it("connectFailure -> ConnectFailed", () => {
         const result = transition(flow, DataConnectionStep.FlashingInProgress, {
           type: "connectFailure",
-          reason: ConnectResult.Failed,
+          errorCode: "reconnect-microbit",
         });
 
         expect(result?.step).toBe(DataConnectionStep.ConnectFailed);
@@ -597,7 +598,7 @@ describe("data-connection-machine", () => {
       it("flashFailure -> ConnectFailed", () => {
         const result = transition(flow, DataConnectionStep.FlashingInProgress, {
           type: "flashFailure",
-          reason: ConnectResult.Failed,
+          errorCode: "reconnect-microbit",
         });
 
         expect(result?.step).toBe(DataConnectionStep.ConnectFailed);
@@ -832,7 +833,7 @@ describe("data-connection-machine", () => {
       it("connectFailure with bad firmware -> BadFirmware", () => {
         const result = transition(flow, DataConnectionStep.FlashingInProgress, {
           type: "connectFailure",
-          reason: ConnectResult.ErrorBadFirmware,
+          errorCode: "update-req",
         });
 
         expect(result?.step).toBe(DataConnectionStep.BadFirmware);
@@ -841,7 +842,7 @@ describe("data-connection-machine", () => {
       it("connectFailure with no device selected -> TryAgainWebUsbSelectMicrobit", () => {
         const result = transition(flow, DataConnectionStep.FlashingInProgress, {
           type: "connectFailure",
-          reason: ConnectResult.ErrorNoDeviceSelected,
+          errorCode: "no-device-selected",
         });
 
         expect(result?.step).toBe(
@@ -852,7 +853,7 @@ describe("data-connection-machine", () => {
       it("connectFailure with unable to claim -> TryAgainCloseTabs", () => {
         const result = transition(flow, DataConnectionStep.FlashingInProgress, {
           type: "connectFailure",
-          reason: ConnectResult.ErrorUnableToClaimInterface,
+          errorCode: "clear-connect",
         });
 
         expect(result?.step).toBe(DataConnectionStep.TryAgainCloseTabs);
@@ -861,7 +862,7 @@ describe("data-connection-machine", () => {
       it("connectFailure (other) -> TryAgainReplugMicrobit", () => {
         const result = transition(flow, DataConnectionStep.FlashingInProgress, {
           type: "connectFailure",
-          reason: ConnectResult.Failed,
+          errorCode: "reconnect-microbit",
         });
 
         expect(result?.step).toBe(DataConnectionStep.TryAgainReplugMicrobit);
@@ -882,7 +883,7 @@ describe("data-connection-machine", () => {
       it("flashFailure with no device selected -> TryAgainWebUsbSelectMicrobit", () => {
         const result = transition(flow, DataConnectionStep.FlashingInProgress, {
           type: "flashFailure",
-          reason: ConnectResult.ErrorNoDeviceSelected,
+          errorCode: "no-device-selected",
         });
 
         expect(result?.step).toBe(
@@ -893,7 +894,7 @@ describe("data-connection-machine", () => {
       it("flashFailure with unable to claim -> TryAgainCloseTabs", () => {
         const result = transition(flow, DataConnectionStep.FlashingInProgress, {
           type: "flashFailure",
-          reason: ConnectResult.ErrorUnableToClaimInterface,
+          errorCode: "clear-connect",
         });
 
         expect(result?.step).toBe(DataConnectionStep.TryAgainCloseTabs);
@@ -902,7 +903,7 @@ describe("data-connection-machine", () => {
       it("flashFailure (other) -> TryAgainReplugMicrobit", () => {
         const result = transition(flow, DataConnectionStep.FlashingInProgress, {
           type: "flashFailure",
-          reason: ConnectResult.Failed,
+          errorCode: "reconnect-microbit",
         });
 
         expect(result?.step).toBe(DataConnectionStep.TryAgainReplugMicrobit);
@@ -1186,7 +1187,7 @@ describe("data-connection-machine", () => {
       it("connectFailure with bad firmware -> BadFirmware", () => {
         const result = transition(flow, DataConnectionStep.FlashingInProgress, {
           type: "connectFailure",
-          reason: ConnectResult.ErrorBadFirmware,
+          errorCode: "update-req",
         });
 
         expect(result?.step).toBe(DataConnectionStep.BadFirmware);
@@ -1195,7 +1196,7 @@ describe("data-connection-machine", () => {
       it("connectFailure with no device selected -> TryAgainWebUsbSelectMicrobit", () => {
         const result = transition(flow, DataConnectionStep.FlashingInProgress, {
           type: "connectFailure",
-          reason: ConnectResult.ErrorNoDeviceSelected,
+          errorCode: "no-device-selected",
         });
 
         expect(result?.step).toBe(
@@ -1206,7 +1207,7 @@ describe("data-connection-machine", () => {
       it("connectFailure with unable to claim -> TryAgainCloseTabs", () => {
         const result = transition(flow, DataConnectionStep.FlashingInProgress, {
           type: "connectFailure",
-          reason: ConnectResult.ErrorUnableToClaimInterface,
+          errorCode: "clear-connect",
         });
 
         expect(result?.step).toBe(DataConnectionStep.TryAgainCloseTabs);
@@ -1215,7 +1216,7 @@ describe("data-connection-machine", () => {
       it("connectFailure (other) -> TryAgainReplugMicrobit", () => {
         const result = transition(flow, DataConnectionStep.FlashingInProgress, {
           type: "connectFailure",
-          reason: ConnectResult.Failed,
+          errorCode: "reconnect-microbit",
         });
 
         expect(result?.step).toBe(DataConnectionStep.TryAgainReplugMicrobit);
@@ -1239,7 +1240,7 @@ describe("data-connection-machine", () => {
       it("flashFailure with no device selected -> TryAgainWebUsbSelectMicrobit", () => {
         const result = transition(flow, DataConnectionStep.FlashingInProgress, {
           type: "flashFailure",
-          reason: ConnectResult.ErrorNoDeviceSelected,
+          errorCode: "no-device-selected",
         });
 
         expect(result?.step).toBe(
@@ -1250,7 +1251,7 @@ describe("data-connection-machine", () => {
       it("flashFailure with unable to claim -> TryAgainCloseTabs", () => {
         const result = transition(flow, DataConnectionStep.FlashingInProgress, {
           type: "flashFailure",
-          reason: ConnectResult.ErrorUnableToClaimInterface,
+          errorCode: "clear-connect",
         });
 
         expect(result?.step).toBe(DataConnectionStep.TryAgainCloseTabs);
@@ -1259,7 +1260,7 @@ describe("data-connection-machine", () => {
       it("flashFailure (other) -> TryAgainReplugMicrobit", () => {
         const result = transition(flow, DataConnectionStep.FlashingInProgress, {
           type: "flashFailure",
-          reason: ConnectResult.Failed,
+          errorCode: "reconnect-microbit",
         });
 
         expect(result?.step).toBe(DataConnectionStep.TryAgainReplugMicrobit);

--- a/src/download-flow/download-actions.ts
+++ b/src/download-flow/download-actions.ts
@@ -7,7 +7,7 @@ import {
   createWebUSBConnection,
   ProgressCallback,
 } from "@microbit/microbit-connection";
-import { ConnectionService, ConnectResult } from "../connection-service";
+import { ConnectionService, DeviceError } from "../connection-service";
 import { DataConnectionState } from "../data-connection-flow";
 import { isNativeBluetoothConnection } from "../device/connection-utils";
 import {
@@ -160,11 +160,10 @@ const performConnect = async (deps: DownloadDependencies): Promise<void> => {
     connection.setNameFilter(state.bluetoothMicrobitName);
   }
 
-  const result = await deps.connectionService.connect(connection, {
-    progress: deps.flashingProgressCallback,
-  });
-
-  if (result === ConnectResult.Success) {
+  try {
+    await deps.connectionService.connect(connection, {
+      progress: deps.flashingProgressCallback,
+    });
     const boardVersion = connection.getBoardVersion();
     // Store connection for potential reuse
     setDownloadState({ ...getDownloadState(), connection });
@@ -175,8 +174,12 @@ const performConnect = async (deps: DownloadDependencies): Promise<void> => {
       },
       deps
     );
-  } else {
-    await sendEvent({ type: "connectFailure", reason: result }, deps);
+  } catch (e) {
+    if (e instanceof DeviceError) {
+      await sendEvent({ type: "connectFailure", errorCode: e.code }, deps);
+    } else {
+      throw e;
+    }
   }
 };
 
@@ -191,16 +194,19 @@ const performFlash = async (deps: DownloadDependencies): Promise<void> => {
     throw new Error("Hex and connection required for flashing");
   }
 
-  const result = await deps.connectionService.flash(
-    connection,
-    hex.hex,
-    deps.flashingProgressCallback
-  );
-
-  if (result === ConnectResult.Success) {
+  try {
+    await deps.connectionService.flash(
+      connection,
+      hex.hex,
+      deps.flashingProgressCallback
+    );
     await sendEvent({ type: "flashSuccess" }, deps);
-  } else {
-    await sendEvent({ type: "flashFailure", reason: result }, deps);
+  } catch (e) {
+    if (e instanceof DeviceError) {
+      await sendEvent({ type: "flashFailure", errorCode: e.code }, deps);
+    } else {
+      throw e;
+    }
   }
 };
 

--- a/src/download-flow/download-machine-common.ts
+++ b/src/download-flow/download-machine-common.ts
@@ -8,7 +8,7 @@ import {
   MicrobitWebBluetoothConnection,
   MicrobitWebUSBConnection,
 } from "@microbit/microbit-connection";
-import { ConnectResult } from "../connection-service";
+import { DeviceErrorCode } from "../connection-service";
 import {
   DataConnectionType,
   dataConnectionTypeToTransport,
@@ -25,9 +25,9 @@ export type DownloadEvent =
   | { type: "choseSame" }
   | { type: "choseDifferent" }
   | { type: "connectSuccess"; boardVersion: "V1" | "V2" }
-  | { type: "connectFailure"; reason: ConnectResult }
+  | { type: "connectFailure"; errorCode: DeviceErrorCode }
   | { type: "flashSuccess" }
-  | { type: "flashFailure"; reason: ConnectResult };
+  | { type: "flashFailure"; errorCode: DeviceErrorCode };
 
 export type DownloadAction =
   | /**

--- a/src/download-flow/download-machine.test.ts
+++ b/src/download-flow/download-machine.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { ConnectionStatus as DeviceConnectionStatus } from "@microbit/microbit-connection";
-import { ConnectResult } from "../connection-service";
+// DeviceErrorCode "reconnect-microbit" is used as a generic failure code
 import { DataConnectionType } from "../data-connection-flow";
 import {
   DownloadEvent,
@@ -307,7 +307,7 @@ describe("download-machine", () => {
       it("connectFailure -> ManualFlashingTutorial", () => {
         const result = transition(flow, DownloadStep.FlashingInProgress, {
           type: "connectFailure",
-          reason: ConnectResult.Failed,
+          errorCode: "reconnect-microbit",
         });
 
         expect(result?.step).toBe(DownloadStep.ManualFlashingTutorial);
@@ -325,7 +325,7 @@ describe("download-machine", () => {
       it("flashFailure -> ManualFlashingTutorial", () => {
         const result = transition(flow, DownloadStep.FlashingInProgress, {
           type: "flashFailure",
-          reason: ConnectResult.Failed,
+          errorCode: "reconnect-microbit",
         });
 
         expect(result?.step).toBe(DownloadStep.ManualFlashingTutorial);


### PR DESCRIPTION
Thins out ConnectionService further (it's probably going away medium term in favour of state machine action using connections directly).

Exposes more error codes to the state machine so we can customise UI for Bluetooth error cases.

Parking this until `refactor` branch is in.