### PR TITLE
An approach to tagging apps releases

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,17 +1,20 @@
 name: Android Build
 
 on:
+  release:
+    types: [created]
   push:
     branches:
-      - apps
-      - apps-*
+      - "**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/apps' }}
+  group: ${{ github.workflow }}-${{ startsWith(github.ref, 'refs/tags/v') && 'release' || github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/v') }}
 
 jobs:
   build-android:
+    # Only run for apps releases, not web releases
+    if: ${{ github.event_name != 'release' || contains(github.event.release.tag_name, '-apps') }}
     timeout-minutes: 15
     runs-on: ubuntu-latest
     permissions:
@@ -25,6 +28,12 @@ jobs:
           node-version: 20
           cache: "npm"
           registry-url: "https://npm.pkg.github.com"
+
+      - uses: microbit-foundation/npm-package-versioner-action@v1
+
+      # Strip prerelease suffix - app stores require X.Y.Z format
+      - name: Set marketing version
+        run: echo "MARKETING_VERSION=$(jq -r .version package.json | sed 's/-.*//')" >> $GITHUB_ENV
 
       - uses: actions/setup-java@v4
         with:
@@ -65,6 +74,7 @@ jobs:
           SIGNING_KEY_PASSWORD: ${{ secrets.ANDROID_SIGNING_PASSWORD }}
           SIGNING_STORE_PASSWORD: ${{ secrets.ANDROID_SIGNING_PASSWORD }}
           BUILD_NUMBER: ${{ github.run_number }}
+          MARKETING_VERSION: ${{ env.MARKETING_VERSION }}
 
       - name: Clean up keystore
         run: rm -f "$RUNNER_TEMP/keystore.jks"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ concurrency:
 
 jobs:
   build:
+    # Skip apps releases - handled by ios-build.yml and android-build.yml
+    if: ${{ github.event_name != 'release' || !contains(github.event.release.tag_name, '-apps') }}
     timeout-minutes: 10
     runs-on: ubuntu-latest
     permissions:
@@ -61,12 +63,16 @@ jobs:
           path: playwright-report/
           retention-days: 3
       - run: npx website-deploy-aws
-        if: github.repository_owner == 'microbit-foundation' && (env.STAGE == 'REVIEW' || success())
+        # TODO: Reinstate after first apps branch tagged release.
+        if: false
+        # if: github.repository_owner == 'microbit-foundation' && (env.STAGE == 'REVIEW' || success())
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.WEB_DEPLOY_ML_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.WEB_DEPLOY_ML_AWS_SECRET_ACCESS_KEY }}
       - run: npx invalidate-cloudfront-distribution
-        if: github.repository_owner == 'microbit-foundation' && (env.STAGE == 'REVIEW' || success())
+        # TODO: Reinstate after first apps branch tagged release.
+        if: false
+        # if: github.repository_owner == 'microbit-foundation' && (env.STAGE == 'REVIEW' || success())
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.WEB_DEPLOY_ML_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.WEB_DEPLOY_ML_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -1,17 +1,20 @@
 name: iOS Build
 
 on:
+  release:
+    types: [created]
   push:
     branches:
-      - apps
-      - apps-*
+      - "**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/apps' }}
+  group: ${{ github.workflow }}-${{ startsWith(github.ref, 'refs/tags/v') && 'release' || github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/v') }}
 
 jobs:
   build-ios:
+    # Only run for apps releases, not web releases
+    if: ${{ github.event_name != 'release' || contains(github.event.release.tag_name, '-apps') }}
     timeout-minutes: 25
     runs-on: macos-latest
     permissions:
@@ -25,6 +28,12 @@ jobs:
           node-version: 20
           cache: "npm"
           registry-url: "https://npm.pkg.github.com"
+
+      - uses: microbit-foundation/npm-package-versioner-action@v1
+
+      # Strip prerelease suffix - app stores require X.Y.Z format
+      - name: Set marketing version
+        run: echo "MARKETING_VERSION=$(jq -r .version package.json | sed 's/-.*//')" >> $GITHUB_ENV
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -63,6 +72,7 @@ jobs:
         env:
           MATCH_PASSWORD: ${{ secrets.FASTLANE_MATCH_PASSWORD }}
           BUILD_NUMBER: ${{ github.run_number }}
+          MARKETING_VERSION: ${{ env.MARKETING_VERSION }}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -84,6 +84,22 @@ Or you can use Homebrew via `brew install fastlane` and drop the `bundle exec` (
 
 Android builds require the signing keystore and passwords via environment variables. iOS builds require Match credentials to fetch certificates.
 
+### App versioning
+
+App releases use tags with an `-apps` suffix to distinguish them from web releases on main until we merge the apps work back. The marketing version is derived from the tag with the suffix stripped (store limitation).
+
+When creating an apps tag we target next unreleased minor version, so if main is on v1.2.3:
+
+| Stage    | Example tag              | Marketing version | Build number  |
+| -------- | ------------------------ | ----------------- | ------------- |
+| Internal | `v1.3.0-apps.internal.1` | 1.3.0             | CI run number |
+| Beta     | `v1.3.0-apps.beta.1`     | 1.3.0             | CI run number |
+| Public   | `v1.3.0-apps`            | 1.3.0             | CI run number |
+
+If main releases a new minor version (e.g., 1.3.0) before apps ships, then we'll bump the next apps version (assuming we've merged main into apps).
+
+If we've merged apps back into main before we get to a public release we can drop the apps suffix.
+
 ## Deployments
 
 Most users should use the supported Foundation deployment at https://createai.microbit.org/

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -19,6 +19,14 @@ platform :ios do
       )
     end
 
+    # Set marketing version from CI
+    if ENV["MARKETING_VERSION"]
+      increment_version_number(
+        xcodeproj: "ios/App/App.xcodeproj",
+        version_number: ENV["MARKETING_VERSION"]
+      )
+    end
+
     build_app(
       workspace: "ios/App/App.xcworkspace",
       scheme: "App",
@@ -42,6 +50,11 @@ platform :android do
     # Set version code from CI or leave as-is for local builds
     if ENV["BUILD_NUMBER"]
       sh("sed -i'' -e 's/versionCode [0-9]*/versionCode #{ENV["BUILD_NUMBER"]}/' ../android/app/build.gradle")
+    end
+
+    # Set marketing version from CI
+    if ENV["MARKETING_VERSION"]
+      sh("sed -i'' -e 's/versionName \"[^\"]*\"/versionName \"#{ENV["MARKETING_VERSION"]}\"/' ../android/app/build.gradle")
     end
 
     gradle(


### PR DESCRIPTION
Keeping them on the apps branch for now for two reasons:

1. We're using the -apps version of microbit-connection which has a
different BLE implementation that hasn't been adequately tested (especially on
Windows).

2. More generally aiming to reduce risk to releases from main until changes stabilize.

Includes logic to ensure we don't release the web app from the apps branch and
a temporary backstop for the first tag in case I screwed that up.

See README.md changes for the plan.

This is based on #686 so I've targetted that branch for now for a pretty diff; will retarget after that is merged.