### PR TITLE
Disable autofocus on mobile to prevent keyboard popup

### DIFF
--- a/src/components/ActionNameCard.tsx
+++ b/src/components/ActionNameCard.tsx
@@ -9,6 +9,7 @@ import {
   CloseButton,
   HStack,
   Input,
+  useBreakpointValue,
   useToast,
 } from "@chakra-ui/react";
 import { useCallback, useMemo, useState } from "react";
@@ -62,6 +63,8 @@ const ActionNameCard = ({
     viewMode === ActionCardNameViewMode.ReadOnly
       ? predictionResult?.detected?.ID === value.ID
       : undefined;
+  // Avoid autofocus on mobile as it triggers the keyboard
+  const allowAutoFocus = useBreakpointValue({ base: false, md: true });
 
   const debouncedSetActionName = useMemo(
     () =>
@@ -152,7 +155,7 @@ const ActionNameCard = ({
           </HStack>
           <Input
             id={actionNameInputId(value)}
-            autoFocus={localName.length === 0}
+            autoFocus={allowAutoFocus && localName.length === 0}
             isTruncated
             readOnly={viewMode !== ActionCardNameViewMode.Editable}
             value={localName}


### PR DESCRIPTION
On mobile devices, autofocusing an input field automatically triggers the keyboard, which is disruptive to the user experience. This uses Chakra's useBreakpointValue to only enable autofocus on medium and larger screens.

I'll merge main into apps later.

Broken out of #684 which needs more work for the dialog part.

Closes https://github.com/microbit-foundation/ml-trainer/issues/657