### PR TITLE
Share permission steps between data connection and download flows

### DIFF
--- a/src/components/BluetoothPermissionErrorDialog.tsx
+++ b/src/components/BluetoothPermissionErrorDialog.tsx
@@ -18,7 +18,6 @@ import {
 import { ReactNode, useEffect, useRef, useState } from "react";
 import { FormattedMessage } from "react-intl";
 import { useDeployment } from "../deployment";
-import { useStore } from "../store";
 
 export interface PermissionErrorDialogProps {
   headingId: string;
@@ -27,6 +26,11 @@ export interface PermissionErrorDialogProps {
   onClose: () => void;
   onTryAgain: () => void;
   onOpenSettings?: () => void;
+  /**
+   * Whether a permission check is in progress.
+   * Shows loading state on the "Try Again" button.
+   */
+  isCheckingPermissions: boolean;
 }
 
 const PermissionErrorDialog = ({
@@ -36,11 +40,9 @@ const PermissionErrorDialog = ({
   onClose,
   onTryAgain,
   onOpenSettings,
+  isCheckingPermissions,
 }: PermissionErrorDialogProps) => {
   const { appNameShort } = useDeployment();
-  const isCheckingPermissions = useStore(
-    (s) => s.dataConnection.isCheckingPermissions
-  );
 
   // Ensure spinner shows for minimum 200ms so it's perceivable
   const loadingStartRef = useRef<number>(0);

--- a/src/components/DataConnectionDialogs.tsx
+++ b/src/components/DataConnectionDialogs.tsx
@@ -235,6 +235,7 @@ const DataConnectionDialogs = () => {
           bodyId="bluetooth-disabled-body"
           {...dialogCommonProps}
           onTryAgain={actions.onTryAgain}
+          isCheckingPermissions={state.isCheckingPermissions}
         />
       );
     case DataConnectionStep.BluetoothPermissionDenied:
@@ -249,6 +250,7 @@ const DataConnectionDialogs = () => {
           {...dialogCommonProps}
           onTryAgain={actions.onTryAgain}
           onOpenSettings={actions.openAppSettings}
+          isCheckingPermissions={state.isCheckingPermissions}
         />
       );
     case DataConnectionStep.LocationDisabled:
@@ -259,6 +261,7 @@ const DataConnectionDialogs = () => {
           {...dialogCommonProps}
           onTryAgain={actions.onTryAgain}
           onOpenSettings={actions.openLocationSettings}
+          isCheckingPermissions={state.isCheckingPermissions}
         />
       );
   }

--- a/src/components/DownloadDialogs.tsx
+++ b/src/components/DownloadDialogs.tsx
@@ -5,7 +5,9 @@
  */
 import { useDownloadActions } from "../download-flow/download-hooks";
 import { DownloadStep } from "../download-flow/download-types";
+import { isAndroid } from "../platform";
 import { useStore } from "../store";
+import PermissionErrorDialog from "./BluetoothPermissionErrorDialog";
 import ConnectCableDialog from "./ConnectCableDialog";
 import ConnectRadioDataCollectionMicrobitDialog from "./ConnectRadioDataCollectionMicrobitDialog";
 import DownloadChooseMicrobitDialog from "./DownloadChooseMicrobitDialog";
@@ -137,6 +139,45 @@ const DownloadDialogs = () => {
           onClose={downloadActions.close}
           onBack={downloadActions.getOnBack()}
           stage="flashDevice"
+        />
+      );
+    case DownloadStep.BluetoothDisabled:
+      return (
+        <PermissionErrorDialog
+          headingId="bluetooth-disabled-heading"
+          bodyId="bluetooth-disabled-body"
+          isOpen
+          onClose={downloadActions.close}
+          onTryAgain={downloadActions.onTryAgain}
+          isCheckingPermissions={stage.isCheckingPermissions}
+        />
+      );
+    case DownloadStep.BluetoothPermissionDenied:
+      return (
+        <PermissionErrorDialog
+          headingId="bluetooth-permission-denied-heading"
+          bodyId={
+            isAndroid()
+              ? "bluetooth-permission-denied-body-android"
+              : "bluetooth-permission-denied-body-ios"
+          }
+          isOpen
+          onClose={downloadActions.close}
+          onTryAgain={downloadActions.onTryAgain}
+          onOpenSettings={downloadActions.openAppSettings}
+          isCheckingPermissions={stage.isCheckingPermissions}
+        />
+      );
+    case DownloadStep.LocationDisabled:
+      return (
+        <PermissionErrorDialog
+          headingId="location-disabled-heading"
+          bodyId="location-disabled-body"
+          isOpen
+          onClose={downloadActions.close}
+          onTryAgain={downloadActions.onTryAgain}
+          onOpenSettings={downloadActions.openLocationSettings}
+          isCheckingPermissions={stage.isCheckingPermissions}
         />
       );
   }

--- a/src/components/TryAgainDialog.tsx
+++ b/src/components/TryAgainDialog.tsx
@@ -63,7 +63,16 @@ const CloseTabsContent = () => {
   );
 };
 
-const configs = {
+type TryAgainStepType =
+  | typeof DataConnectionStep.TryAgainReplugMicrobit
+  | typeof DataConnectionStep.TryAgainCloseTabs
+  | typeof DataConnectionStep.TryAgainWebUsbSelectMicrobit
+  | typeof DataConnectionStep.TryAgainBluetoothSelectMicrobit;
+
+const configs: Record<
+  TryAgainStepType,
+  { headingId: string; children: React.ReactNode }
+> = {
   [DataConnectionStep.TryAgainReplugMicrobit]: {
     headingId: "other-tabs-heading",
     children: <ReplugMicrobitContent />,
@@ -88,11 +97,7 @@ interface TryAgainDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onTryAgain: () => void;
-  type:
-    | DataConnectionStep.TryAgainReplugMicrobit
-    | DataConnectionStep.TryAgainCloseTabs
-    | DataConnectionStep.TryAgainWebUsbSelectMicrobit
-    | DataConnectionStep.TryAgainBluetoothSelectMicrobit;
+  type: TryAgainStepType;
 }
 
 const TryAgainDialog = ({

--- a/src/data-connection-flow/data-connection-machine-native-bluetooth.ts
+++ b/src/data-connection-flow/data-connection-machine-native-bluetooth.ts
@@ -18,30 +18,15 @@ import {
 } from "./data-connection-machine-common";
 import { DataConnectionStep } from "./data-connection-types";
 import { always } from "../state-machine";
-
-// Permission error transitions from checkPermissions
-const permissionErrorTransitions = {
-  bluetoothDisabled: {
-    target: DataConnectionStep.BluetoothDisabled,
-  },
-  permissionDenied: {
-    target: DataConnectionStep.BluetoothPermissionDenied,
-  },
-  locationDisabled: {
-    target: DataConnectionStep.LocationDisabled,
-  },
-};
+import {
+  createPermissionErrorStateHandlers,
+  createStartStepWithPermissionHandlers,
+} from "../shared-steps";
 
 // Shared handlers for Start and StartOver - check permissions before tutorial
-const startStepHandlers = {
-  next: {
-    actions: [{ type: "checkPermissions" as const }],
-  },
-  permissionsOk: {
-    target: DataConnectionStep.NativeBluetoothPreConnectTutorial,
-  },
-  ...permissionErrorTransitions,
-};
+const startStepHandlers = createStartStepWithPermissionHandlers(
+  DataConnectionStep.NativeBluetoothPreConnectTutorial
+);
 
 // Connect failure handlers that route permission errors to appropriate states
 const connectFlashFailureWithPermissionHandling = [
@@ -63,37 +48,10 @@ const connectFlashFailureWithPermissionHandling = [
   },
 ];
 
-// Permission error state handlers - tryAgain re-runs permission check.
-// After successful permission check, always go to the tutorial step.
-// The stored micro:bit name (if any) will be pre-filled, so users can
-// just click Next to continue without re-entering the pattern.
-const createPermissionErrorStateHandlers = () => ({
-  // Re-check permissions when user tries again
-  tryAgain: {
-    actions: [
-      { type: "setCheckingPermissions" as const, value: true },
-      { type: "checkPermissions" as const },
-    ],
-  },
-  // Permission check passed - go to tutorial (name will be pre-filled if stored)
-  permissionsOk: {
-    target: DataConnectionStep.NativeBluetoothPreConnectTutorial,
-    actions: [{ type: "setCheckingPermissions" as const, value: false }],
-  },
-  // Permission check failed - stay in error state or switch to appropriate one
-  bluetoothDisabled: {
-    target: DataConnectionStep.BluetoothDisabled,
-    actions: [{ type: "setCheckingPermissions" as const, value: false }],
-  },
-  permissionDenied: {
-    target: DataConnectionStep.BluetoothPermissionDenied,
-    actions: [{ type: "setCheckingPermissions" as const, value: false }],
-  },
-  locationDisabled: {
-    target: DataConnectionStep.LocationDisabled,
-    actions: [{ type: "setCheckingPermissions" as const, value: false }],
-  },
-});
+// Permission error state handlers using shared factory
+const permissionErrorStateHandlers = createPermissionErrorStateHandlers(
+  DataConnectionStep.NativeBluetoothPreConnectTutorial
+);
 
 export const nativeBluetoothFlow: DataConnectionFlowDef = {
   ...globalHandlers,
@@ -115,13 +73,13 @@ export const nativeBluetoothFlow: DataConnectionFlowDef = {
   // Permission error states with retry option.
   // tryAgain re-attempts connect (which will re-check permissions internally).
   [DataConnectionStep.BluetoothDisabled]: {
-    on: createPermissionErrorStateHandlers(),
+    on: permissionErrorStateHandlers,
   },
   [DataConnectionStep.BluetoothPermissionDenied]: {
-    on: createPermissionErrorStateHandlers(),
+    on: permissionErrorStateHandlers,
   },
   [DataConnectionStep.LocationDisabled]: {
-    on: createPermissionErrorStateHandlers(),
+    on: permissionErrorStateHandlers,
   },
 
   [DataConnectionStep.NativeBluetoothPreConnectTutorial]: {

--- a/src/data-connection-flow/data-connection-types.ts
+++ b/src/data-connection-flow/data-connection-types.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 import { isNativePlatform } from "../platform";
+import { PermissionStep } from "../shared-steps";
 
 /**
  * This is the connection type from the perspective of how we end up talking
@@ -55,62 +56,51 @@ export const dataConnectionTypeToTransport = (
   }
 };
 
-export enum DataConnectionStep {
-  /**
-   * Idle/not started - no connection flow dialog open, no device monitoring.
-   */
-  Idle = "Idle",
-  /**
-   * Successfully connected - device is ready to use.
-   */
-  Connected = "Connected",
+/**
+ * Steps in the data connection flow.
+ * Using const object pattern with string literal union types.
+ */
+export const DataConnectionStep = {
+  // Idle/not started - no connection flow dialog open, no device monitoring.
+  Idle: "Idle",
+  // Successfully connected - device is ready to use.
+  Connected: "Connected",
 
   // Happy flow stages.
-  Start = "Start",
-  ConnectCable = "ConnectCable",
-  WebUsbFlashingTutorial = "WebUsbFlashingTutorial",
-  ManualFlashingTutorial = "ManualFlashingTutorial",
-  ConnectBattery = "ConnectBattery",
-  BluetoothPattern = "BluetoothPattern",
-  WebBluetoothPreConnectTutorial = "WebBluetoothPreConnectTutorial",
-  /**
-   * Reset to pairing mode.
-   */
-  NativeBluetoothPreConnectTutorial = "NativeBluetoothPreConnectTutorial",
+  Start: "Start",
+  ConnectCable: "ConnectCable",
+  WebUsbFlashingTutorial: "WebUsbFlashingTutorial",
+  ConnectBattery: "ConnectBattery",
+  BluetoothPattern: "BluetoothPattern",
+  NativeBluetoothPreConnectTutorial: "NativeBluetoothPreConnectTutorial",
+  WebBluetoothPreConnectTutorial: "WebBluetoothPreConnectTutorial",
 
   // Transient stages (not user-controlled, not navigable).
-  WebUsbChooseMicrobit = "WebUsbChooseMicrobit",
-  BluetoothConnect = "BluetoothConnect",
-  ConnectingMicrobits = "ConnectingMicrobits",
-  FlashingInProgress = "FlashingInProgress",
+  WebUsbChooseMicrobit: "WebUsbChooseMicrobit",
+  BluetoothConnect: "BluetoothConnect",
+  ConnectingMicrobits: "ConnectingMicrobits",
+  FlashingInProgress: "FlashingInProgress",
 
   // Failure stages.
-  TryAgainReplugMicrobit = "TryAgainReplugMicrobit",
-  TryAgainCloseTabs = "TryAgainCloseTabs",
-  TryAgainWebUsbSelectMicrobit = "TryAgainWebUsbSelectMicrobit",
-  TryAgainBluetoothSelectMicrobit = "TryAgainBluetoothSelectMicrobit",
-  ConnectFailed = "ConnectFailed",
-  BadFirmware = "BadFirmware",
-  MicrobitUnsupported = "MicrobitUnsupported",
-  WebUsbBluetoothUnsupported = "WebUsbBluetoothUnsupported",
+  TryAgainReplugMicrobit: "TryAgainReplugMicrobit",
+  TryAgainCloseTabs: "TryAgainCloseTabs",
+  TryAgainWebUsbSelectMicrobit: "TryAgainWebUsbSelectMicrobit",
+  TryAgainBluetoothSelectMicrobit: "TryAgainBluetoothSelectMicrobit",
+  ConnectFailed: "ConnectFailed",
+  BadFirmware: "BadFirmware",
+  MicrobitUnsupported: "MicrobitUnsupported",
+  WebUsbBluetoothUnsupported: "WebUsbBluetoothUnsupported",
+  ManualFlashingTutorial: "ManualFlashingTutorial",
 
-  // Permission error stages (native Bluetooth only).
-  /**
-   * Bluetooth is disabled on the device.
-   */
-  BluetoothDisabled = "BluetoothDisabled",
-  /**
-   * User denied Bluetooth permission request.
-   */
-  BluetoothPermissionDenied = "BluetoothPermissionDenied",
-  /**
-   * Location services are disabled (Android < 12 only).
-   */
-  LocationDisabled = "LocationDisabled",
+  ConnectionLost: "ConnectionLost",
+  StartOver: "StartOver",
 
-  ConnectionLost = "ConnectionLost",
-  StartOver = "StartOver",
-}
+  // Permission error steps (shared with download flow)
+  ...PermissionStep,
+} as const;
+
+export type DataConnectionStep =
+  (typeof DataConnectionStep)[keyof typeof DataConnectionStep];
 
 export interface DataConnectionState {
   // For connection flow.

--- a/src/download-flow/download-actions.ts
+++ b/src/download-flow/download-actions.ts
@@ -27,6 +27,7 @@ import { getTotalNumSamples } from "../utils/actions";
 import { downloadHex } from "../utils/fs-util";
 import { StoredConnectionConfig } from "../hooks/use-connection-config-storage";
 import { DownloadState, SameOrDifferentChoice } from "./download-types";
+import { checkPermissions } from "../shared-steps";
 
 /**
  * Dependencies needed for download actions.
@@ -145,6 +146,17 @@ const executeAction = async (
       // to Idle and stop auto-reconnect attempts before proceeding
       await deps.disconnect();
       break;
+
+    case "checkPermissions":
+      await performCheckPermissions(deps);
+      break;
+
+    case "setCheckingPermissions":
+      setDownloadState({
+        ...getDownloadState(),
+        isCheckingPermissions: action.value,
+      });
+      break;
   }
 };
 
@@ -195,6 +207,13 @@ const performConnectFlash = async (
       throw e;
     }
   }
+};
+
+const performCheckPermissions = async (
+  deps: DownloadDependencies
+): Promise<void> => {
+  const event = await checkPermissions(deps.connections.bluetooth);
+  await sendEvent(event, deps);
 };
 
 /**

--- a/src/download-flow/download-types.ts
+++ b/src/download-flow/download-types.ts
@@ -4,6 +4,7 @@ import {
 } from "@microbit/microbit-connection";
 import { BluetoothPairingMethod } from "../data-connection-flow/data-connection-types";
 import { HexData } from "../model";
+import { PermissionStep } from "../shared-steps";
 
 /**
  * Steps in the flow to download a hex from MakeCode.
@@ -16,31 +17,37 @@ import { HexData } from "../model";
  * Native bluetooth users use the same micro:bit for now.
  *
  * Note: The flow to download the data collection hex is part of ConnectionFlowStep.
+ *
+ * Using const object pattern with string literal union types.
  */
-export enum DownloadStep {
-  None = "None",
-  Help = "Help",
-  ChooseSameOrDifferentMicrobit = "ChooseSameOrDifferentMicrobit",
+export const DownloadStep = {
+  None: "None",
+  Help: "Help",
+  ChooseSameOrDifferentMicrobit: "ChooseSameOrDifferentMicrobit",
 
   // WebUSB/radio
-  ConnectCable = "ConnectCable",
-  ConnectRadioRemoteMicrobit = "ConnectRadioRemoteMicrobit",
-  WebUsbFlashingTutorial = "WebUsbFlashingTutorial",
+  ConnectCable: "ConnectCable",
+  WebUsbFlashingTutorial: "WebUsbFlashingTutorial",
+  ConnectRadioRemoteMicrobit: "ConnectRadioRemoteMicrobit",
+  ManualFlashingTutorial: "ManualFlashingTutorial",
 
-  // Bluetooth (native only for download). There's a good chance we can skip
-  // connection steps because we'll already be connected.
-  BluetoothPattern = "BluetoothPattern",
-  NativeBluetoothPreConnectTutorial = "NativeBluetoothPreConnectTutorial",
-  BluetoothSearchConnect = "BluetoothSearchConnect",
+  // Bluetooth (native only for download)
+  BluetoothPattern: "BluetoothPattern",
+  NativeBluetoothPreConnectTutorial: "NativeBluetoothPreConnectTutorial",
+  BluetoothSearchConnect: "BluetoothSearchConnect",
 
   // Common
-  IncompatibleDevice = "IncompatibleDevice",
-  FlashingInProgress = "FlashingInProgress",
+  FlashingInProgress: "FlashingInProgress",
+  IncompatibleDevice: "IncompatibleDevice",
 
   // WebUSB/radio
-  ManualFlashingTutorial = "ManualFlashingTutorial",
-  UnplugRadioBridgeMicrobit = "UnplugRadioBridgeMicrobit",
-}
+  UnplugRadioBridgeMicrobit: "UnplugRadioBridgeMicrobit",
+
+  // Permission error steps (shared with data connection flow)
+  ...PermissionStep,
+} as const;
+
+export type DownloadStep = (typeof DownloadStep)[keyof typeof DownloadStep];
 
 export enum SameOrDifferentChoice {
   // No micro:bit is connected.
@@ -70,4 +77,9 @@ export interface DownloadState {
    * Which pairing method variant to show in the Bluetooth tutorial dialog.
    */
   pairingMethod: BluetoothPairingMethod;
+  /**
+   * True while a permission check is in progress (native Bluetooth only).
+   * Used to show loading state on "Try Again" button in permission error dialogs.
+   */
+  isCheckingPermissions: boolean;
 }

--- a/src/shared-steps/index.ts
+++ b/src/shared-steps/index.ts
@@ -1,0 +1,20 @@
+/**
+ * (c) 2026, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+export { PermissionStep } from "./shared-steps";
+
+export type {
+  PermissionEvent,
+  PermissionDialogEvent,
+} from "./permission-events";
+
+export {
+  permissionErrorTransitions,
+  createPermissionErrorStateHandlers,
+  createStartStepWithPermissionHandlers,
+  type PermissionAction,
+} from "./permission-handlers";
+
+export { checkPermissions } from "./permission-check";

--- a/src/shared-steps/permission-check.ts
+++ b/src/shared-steps/permission-check.ts
@@ -1,0 +1,45 @@
+/**
+ * (c) 2026, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { ConnectionAvailabilityStatus } from "@microbit/microbit-connection";
+import { PermissionEvent } from "./permission-events";
+
+/**
+ * Interface for a connection that can check Bluetooth availability.
+ */
+interface BluetoothAvailabilityChecker {
+  checkAvailability(): Promise<ConnectionAvailabilityStatus>;
+}
+
+/**
+ * Check Bluetooth permissions and return the appropriate event.
+ * Used by native Bluetooth flows to provide better error feedback.
+ *
+ * @param bluetooth - Connection with checkAvailability method
+ * @returns The permission event to dispatch
+ */
+export const checkPermissions = async (
+  bluetooth: BluetoothAvailabilityChecker
+): Promise<PermissionEvent> => {
+  let status: ConnectionAvailabilityStatus;
+  try {
+    status = await bluetooth.checkAvailability();
+  } catch {
+    // Treat unexpected errors as permission denied
+    return { type: "permissionDenied" };
+  }
+  switch (status) {
+    case "available":
+      return { type: "permissionsOk" };
+    case "disabled":
+    case "unsupported":
+      // Treat unsupported the same as disabled - no meaningful devices lack BLE
+      return { type: "bluetoothDisabled" };
+    case "permission-denied":
+      return { type: "permissionDenied" };
+    case "location-disabled":
+      return { type: "locationDisabled" };
+  }
+};

--- a/src/shared-steps/permission-events.ts
+++ b/src/shared-steps/permission-events.ts
@@ -1,0 +1,20 @@
+/**
+ * (c) 2026, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Permission check result events shared by both data connection and download flows.
+ * These events are sent after checking Bluetooth permissions on native platforms.
+ */
+export type PermissionEvent =
+  | { type: "permissionsOk" }
+  | { type: "bluetoothDisabled" }
+  | { type: "permissionDenied" }
+  | { type: "locationDisabled" };
+
+/**
+ * Events for permission error dialogs.
+ */
+export type PermissionDialogEvent = { type: "tryAgain" };

--- a/src/shared-steps/permission-handlers.ts
+++ b/src/shared-steps/permission-handlers.ts
@@ -1,0 +1,101 @@
+/**
+ * (c) 2026, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { PermissionStep } from "./shared-steps";
+
+/**
+ * Action to check Bluetooth permissions.
+ */
+type CheckPermissionsAction = { type: "checkPermissions" };
+
+/**
+ * Action to set the checking permissions flag.
+ */
+type SetCheckingPermissionsAction = {
+  type: "setCheckingPermissions";
+  value: boolean;
+};
+
+/**
+ * Actions used by permission handlers.
+ */
+export type PermissionAction =
+  | CheckPermissionsAction
+  | SetCheckingPermissionsAction;
+
+/**
+ * Permission error transitions from checkPermissions action.
+ * Use these in the starting step where permissions are first checked.
+ */
+export const permissionErrorTransitions = {
+  bluetoothDisabled: {
+    target: PermissionStep.BluetoothDisabled,
+  },
+  permissionDenied: {
+    target: PermissionStep.BluetoothPermissionDenied,
+  },
+  locationDisabled: {
+    target: PermissionStep.LocationDisabled,
+  },
+} as const;
+
+/**
+ * Create handlers for permission error states (BluetoothDisabled, BluetoothPermissionDenied, LocationDisabled).
+ *
+ * @param successTarget - The step to go to after permissions are OK
+ * @returns Event handlers for permission error states
+ */
+export const createPermissionErrorStateHandlers = <TTarget extends string>(
+  successTarget: TTarget
+) => ({
+  tryAgain: {
+    actions: [
+      { type: "setCheckingPermissions", value: true },
+      { type: "checkPermissions" },
+    ] satisfies PermissionAction[],
+  },
+  permissionsOk: {
+    target: successTarget,
+    actions: [
+      { type: "setCheckingPermissions", value: false },
+    ] satisfies PermissionAction[],
+  },
+  bluetoothDisabled: {
+    target: PermissionStep.BluetoothDisabled,
+    actions: [
+      { type: "setCheckingPermissions", value: false },
+    ] satisfies PermissionAction[],
+  },
+  permissionDenied: {
+    target: PermissionStep.BluetoothPermissionDenied,
+    actions: [
+      { type: "setCheckingPermissions", value: false },
+    ] satisfies PermissionAction[],
+  },
+  locationDisabled: {
+    target: PermissionStep.LocationDisabled,
+    actions: [
+      { type: "setCheckingPermissions", value: false },
+    ] satisfies PermissionAction[],
+  },
+});
+
+/**
+ * Create handlers for a step that needs to check permissions before proceeding.
+ *
+ * @param successTarget - The step to go to after permissions are OK
+ * @returns Event handlers that include permission checking on "next"
+ */
+export const createStartStepWithPermissionHandlers = <TTarget extends string>(
+  successTarget: TTarget
+) => ({
+  next: {
+    actions: [{ type: "checkPermissions" }] satisfies PermissionAction[],
+  },
+  permissionsOk: {
+    target: successTarget,
+  },
+  ...permissionErrorTransitions,
+});

--- a/src/shared-steps/shared-steps.ts
+++ b/src/shared-steps/shared-steps.ts
@@ -1,0 +1,18 @@
+/**
+ * (c) 2026, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Permission error steps shared between data connection and download flows.
+ * These have common handler logic via createPermissionErrorStateHandlers.
+ */
+export const PermissionStep = {
+  BluetoothDisabled: "BluetoothDisabled",
+  BluetoothPermissionDenied: "BluetoothPermissionDenied",
+  LocationDisabled: "LocationDisabled",
+} as const;
+
+export type PermissionStep =
+  (typeof PermissionStep)[keyof typeof PermissionStep];

--- a/src/store.ts
+++ b/src/store.ts
@@ -347,6 +347,7 @@ const createMlStore = (logging: Logging) => {
             step: DownloadStep.None,
             microbitChoice: SameOrDifferentChoice.Default,
             pairingMethod: "triple-reset",
+            isCheckingPermissions: false,
           },
           downloadFlashingProgress: { stage: undefined, value: undefined },
           dataConnection: getInitialDataConnectionState(),


### PR DESCRIPTION
After this PR if you either skip straight to MakeCode (because you previously collected data) or remove BT permissions after a  data connection was made, then you will be re-prompted for permissions in the MakeCode download flow.