### PR TITLE
Wire up the Google credential for the Play upload

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -96,6 +96,7 @@ platform :android do
     upload_to_play_store(
       track: "internal",
       aab: "android/app/build/outputs/bundle/release/app-release.aab",
+      json_key: ENV["GOOGLE_APPLICATION_CREDENTIALS"],
       skip_upload_apk: true,
       skip_upload_metadata: true,
       skip_upload_images: true,


### PR DESCRIPTION
This failed for the latest release because these were missing. Auth looked good though.