### PR TITLE
Align micro:bit name reading between the flows

### DIFF
--- a/src/data-connection-flow/data-connection-actions.ts
+++ b/src/data-connection-flow/data-connection-actions.ts
@@ -61,6 +61,15 @@ const progressCallback = (stage: ProgressStage, value: number | undefined) => {
   useStore.getState().setDataConnectionFlashingProgress(stage, value);
 };
 
+/**
+ * Build the flow context from state and settings.
+ * Context is rebuilt fresh for each transition.
+ */
+const buildContext = (state: DataConnectionState) => ({
+  ...state,
+  bluetoothMicrobitName: useStore.getState().settings.bluetoothMicrobitName,
+});
+
 // =============================================================================
 // State machine event handling
 // =============================================================================
@@ -72,7 +81,9 @@ const sendEvent = async (
   event: DataConnectionEvent,
   deps: DataConnectionDeps
 ): Promise<void> => {
-  const result = dataConnectionTransition(getDataConnectionState(), event);
+  const state = getDataConnectionState();
+  const context = buildContext(state);
+  const result = dataConnectionTransition(context, event);
 
   if (!result) {
     return;
@@ -285,16 +296,6 @@ const executeAction = async (
     case "checkPermissions":
       await performCheckPermissions(deps);
       break;
-
-    case "checkMicrobitName": {
-      const currentState = getDataConnectionState();
-      const microbitName = useStore.getState().settings.bluetoothMicrobitName;
-      setDataConnectionState({
-        ...currentState,
-        hasMicrobitName: !!microbitName,
-      });
-      break;
-    }
 
     case "setCheckingPermissions":
       setDataConnectionState({

--- a/src/data-connection-flow/data-connection-machine-native-bluetooth.test.ts
+++ b/src/data-connection-flow/data-connection-machine-native-bluetooth.test.ts
@@ -5,24 +5,23 @@
  */
 import {
   DataConnectionEvent,
+  DataConnectionFlowContext,
   dataConnectionTransition,
 } from "./data-connection-machine";
 import {
   DataConnectionStep,
   DataConnectionType,
-  DataConnectionState,
 } from "./data-connection-types";
 
-const createState = (
-  overrides: Partial<DataConnectionState> = {}
-): DataConnectionState => ({
+const createContext = (
+  overrides: Partial<DataConnectionFlowContext> = {}
+): DataConnectionFlowContext => ({
   type: DataConnectionType.NativeBluetooth,
   step: DataConnectionStep.Idle,
   isWebBluetoothSupported: true,
   isWebUsbSupported: true,
   hadSuccessfulConnection: false,
   hasSwitchedConnectionType: false,
-  hasMicrobitName: false,
   isReconnecting: false,
   hasFailedOnce: false,
   isStartingOver: false,
@@ -30,6 +29,7 @@ const createState = (
   isCheckingPermissions: false,
   pairingMethod: "triple-reset",
   connectionAbortController: undefined,
+  bluetoothMicrobitName: undefined,
   ...overrides,
 });
 
@@ -40,10 +40,10 @@ const connectEvent = (): DataConnectionEvent => ({
 const transition = (
   step: DataConnectionStep,
   event: DataConnectionEvent,
-  overrides: Partial<DataConnectionState> = {}
+  overrides: Partial<DataConnectionFlowContext> = {}
 ) => {
   return dataConnectionTransition(
-    createState({
+    createContext({
       type: DataConnectionType.NativeBluetooth,
       step,
       ...overrides,

--- a/src/data-connection-flow/data-connection-machine-native-bluetooth.ts
+++ b/src/data-connection-flow/data-connection-machine-native-bluetooth.ts
@@ -92,7 +92,6 @@ export const nativeBluetoothFlow: DataConnectionFlowDef = {
   },
 
   [DataConnectionStep.NativeBluetoothPreConnectTutorial]: {
-    entry: [{ type: "checkMicrobitName" }],
     on: {
       next: [
         {

--- a/src/data-connection-flow/data-connection-machine-radio.test.ts
+++ b/src/data-connection-flow/data-connection-machine-radio.test.ts
@@ -5,24 +5,23 @@
  */
 import {
   DataConnectionEvent,
+  DataConnectionFlowContext,
   dataConnectionTransition,
 } from "./data-connection-machine";
 import {
   DataConnectionStep,
   DataConnectionType,
-  DataConnectionState,
 } from "./data-connection-types";
 
-const createState = (
-  overrides: Partial<DataConnectionState> = {}
-): DataConnectionState => ({
+const createContext = (
+  overrides: Partial<DataConnectionFlowContext> = {}
+): DataConnectionFlowContext => ({
   type: DataConnectionType.Radio,
   step: DataConnectionStep.Idle,
   isWebBluetoothSupported: true,
   isWebUsbSupported: true,
   hadSuccessfulConnection: false,
   hasSwitchedConnectionType: false,
-  hasMicrobitName: false,
   isReconnecting: false,
   hasFailedOnce: false,
   isStartingOver: false,
@@ -30,6 +29,7 @@ const createState = (
   isCheckingPermissions: false,
   pairingMethod: "triple-reset",
   connectionAbortController: undefined,
+  bluetoothMicrobitName: undefined,
   ...overrides,
 });
 
@@ -40,10 +40,10 @@ const connectEvent = (): DataConnectionEvent => ({
 const transition = (
   step: DataConnectionStep,
   event: DataConnectionEvent,
-  overrides: Partial<DataConnectionState> = {}
+  overrides: Partial<DataConnectionFlowContext> = {}
 ) => {
   return dataConnectionTransition(
-    createState({ type: DataConnectionType.Radio, step, ...overrides }),
+    createContext({ type: DataConnectionType.Radio, step, ...overrides }),
     event
   );
 };

--- a/src/data-connection-flow/data-connection-machine-web-bluetooth.test.ts
+++ b/src/data-connection-flow/data-connection-machine-web-bluetooth.test.ts
@@ -5,24 +5,23 @@
  */
 import {
   DataConnectionEvent,
+  DataConnectionFlowContext,
   dataConnectionTransition,
 } from "./data-connection-machine";
 import {
   DataConnectionStep,
   DataConnectionType,
-  DataConnectionState,
 } from "./data-connection-types";
 
-const createState = (
-  overrides: Partial<DataConnectionState> = {}
-): DataConnectionState => ({
+const createContext = (
+  overrides: Partial<DataConnectionFlowContext> = {}
+): DataConnectionFlowContext => ({
   type: DataConnectionType.WebBluetooth,
   step: DataConnectionStep.Idle,
   isWebBluetoothSupported: true,
   isWebUsbSupported: true,
   hadSuccessfulConnection: false,
   hasSwitchedConnectionType: false,
-  hasMicrobitName: false,
   isReconnecting: false,
   hasFailedOnce: false,
   isStartingOver: false,
@@ -30,6 +29,7 @@ const createState = (
   isCheckingPermissions: false,
   pairingMethod: "triple-reset",
   connectionAbortController: undefined,
+  bluetoothMicrobitName: undefined,
   ...overrides,
 });
 
@@ -40,10 +40,14 @@ const connectEvent = (): DataConnectionEvent => ({
 const transition = (
   step: DataConnectionStep,
   event: DataConnectionEvent,
-  overrides: Partial<DataConnectionState> = {}
+  overrides: Partial<DataConnectionFlowContext> = {}
 ) => {
   return dataConnectionTransition(
-    createState({ type: DataConnectionType.WebBluetooth, step, ...overrides }),
+    createContext({
+      type: DataConnectionType.WebBluetooth,
+      step,
+      ...overrides,
+    }),
     event
   );
 };

--- a/src/data-connection-flow/data-connection-machine.ts
+++ b/src/data-connection-flow/data-connection-machine.ts
@@ -6,13 +6,13 @@
 import {
   DataConnectionAction,
   DataConnectionEvent,
+  DataConnectionFlowContext,
   DataConnectionFlowDef,
 } from "./data-connection-machine-common";
 import { nativeBluetoothFlow } from "./data-connection-machine-native-bluetooth";
 import { radioFlow } from "./data-connection-machine-radio";
 import { webBluetoothFlow } from "./data-connection-machine-web-bluetooth";
 import {
-  DataConnectionState,
   DataConnectionStep,
   DataConnectionType,
 } from "./data-connection-types";
@@ -22,6 +22,7 @@ import { transition } from "../state-machine";
 export type {
   DataConnectionAction,
   DataConnectionEvent,
+  DataConnectionFlowContext,
 } from "./data-connection-machine-common";
 
 const getFlow = (type: DataConnectionType): DataConnectionFlowDef => {
@@ -41,9 +42,9 @@ export type DataConnectionTransitionResult = {
 };
 
 export const dataConnectionTransition = (
-  state: DataConnectionState,
+  context: DataConnectionFlowContext,
   event: DataConnectionEvent
 ): DataConnectionTransitionResult | null => {
-  const flow = getFlow(state.type);
-  return transition(flow, state.step, event, state);
+  const flow = getFlow(context.type);
+  return transition(flow, context.step, event, context);
 };

--- a/src/data-connection-flow/data-connection-types.ts
+++ b/src/data-connection-flow/data-connection-types.ts
@@ -127,11 +127,6 @@ export interface DataConnectionState {
   hadSuccessfulConnection: boolean;
 
   /**
-   * True if a micro:bit name is stored.
-   */
-  hasMicrobitName: boolean;
-
-  /**
    * True when an auto or explicit reconnection is in progress.
    * Used by UI to show reconnecting indicator without changing step.
    */
@@ -225,7 +220,6 @@ export const getInitialDataConnectionState = (): DataConnectionState => {
     isWebUsbSupported: false,
     hadSuccessfulConnection: false,
     hasSwitchedConnectionType: false,
-    hasMicrobitName: false,
     isReconnecting: false,
     hasFailedOnce: false,
     isStartingOver: false,


### PR DESCRIPTION
Pull it from the settings into the context for the state machine Then there's no need for actions to do this.

Similar to download flow: https://github.com/microbit-foundation/ml-trainer/blob/apps/src/download-flow/download-actions.ts#L52-L69