### PR TITLE
Fix Android fastlane upload for draft apps

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -95,6 +95,7 @@ platform :android do
   lane :upload do
     upload_to_play_store(
       track: "internal",
+      release_status: "draft",
       aab: "android/app/build/outputs/bundle/release/app-release.aab",
       json_key: ENV["GOOGLE_APPLICATION_CREDENTIALS"],
       skip_upload_apk: true,


### PR DESCRIPTION
Google Play rejects non-draft releases for apps that haven't had their first manual release. Set release_status to "draft" so the upload succeeds while the app is still in draft state.