### PR TITLE
Use macOS 26 runner for iOS CI builds

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -16,7 +16,7 @@ jobs:
     # Only run for apps releases, not web releases
     if: ${{ github.event_name != 'release' || contains(github.event.release.tag_name, '-apps') }}
     timeout-minutes: 25
-    runs-on: macos-latest
+    runs-on: macos-26
     permissions:
       contents: read
       packages: read


### PR DESCRIPTION
Hopefully fixes this App Store Connect warning:

> TMS-90725: SDK version issue - This app was built with the iOS 18.5 SDK.
> Starting April 28, 2026, all iOS and iPadOS apps must be built with the iOS
> 26 SDK or later, included in Xcode 26 or later, in order to be uploaded to
> App Store Connect or submitted for distribution.

This is technically still a beta (the build image, not the XCode version) but assuming it builds I think we're better off using it than switching at a riskier point in the app project. See https://github.com/actions/runner-images/issues/13008