### PR TITLE
Update hint when a hex is loaded and recording is deleted

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -945,6 +945,7 @@ const createMlStore = (logging: Logging) => {
           const timestamp = Date.now();
           set({
             actions: updatedActions,
+            hint: getHint(updatedActions, false),
             dataWindow: newDataWindow,
             model: undefined,
             timestamp,
@@ -1459,6 +1460,7 @@ const createMlStore = (logging: Logging) => {
                     projectEdited: updatedProjectEdited,
                     actions: newActions,
                     dataWindow: getDataWindowFromActions(newActions),
+                    hint: getHint(newActions, true),
                     model: undefined,
                     isEditorOpen: false,
                     isEditorLoadingFile: false,


### PR DESCRIPTION
Recover updating hint in `editorChange` and `deleteActionRecording` as they were removed unintentionally [here](https://redirect.github.com/microbit-foundation/ml-trainer/commit/c765589fe358a7bd47ac052cc0f66a76fe5c6be2#diff-2717c7fb31c2070dd96f07394997809bc9be7f3fff03ab638db696cc480f39b6).

Fixes https://github.com/microbit-foundation/ml-trainer/issues/745

