### PR TITLE
Close name project dialog onSubmit

### DIFF
--- a/src/components/NameProjectDialog.tsx
+++ b/src/components/NameProjectDialog.tsx
@@ -71,8 +71,9 @@ export const NameProjectDialog = ({
     (e: FormEvent) => {
       e.preventDefault();
       onSave(name);
+      onClose();
     },
-    [name, onSave]
+    [name, onClose, onSave]
   );
 
   useEffect(() => {


### PR DESCRIPTION
so that the useEffect in NameProjectDialog does not run after onSubmit.

Fixes https://github.com/microbit-foundation/ml-trainer/issues/749