### PR TITLE
Support native-like back navigation on Android

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@formatjs/intl-localematcher": "^0.8.0",
         "@microbit/capacitor-community-nordic-dfu": "^7.0.0-microbit.3",
         "@microbit/capacitor-sqlite-vanilla": "^0.1.0-alpha.5",
-        "@microbit/makecode-embed": "^0.3.0",
+        "@microbit/makecode-embed": "^0.5.0",
         "@microbit/microbit-connection": "^0.9.0-apps.alpha.15",
         "@microbit/ml-header-generator": "^0.4.3",
         "@microbit/smoothie": "^1.37.0-microbit.2",
@@ -3507,9 +3507,10 @@
       }
     },
     "node_modules/@microbit/makecode-embed": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@microbit/makecode-embed/-/makecode-embed-0.3.0.tgz",
-      "integrity": "sha512-RK0smAQD5UDoqG1Xh4LQvxbrN7CXnu6IdWtQmp5PR+6WRzK3yqx4tgsJMH+q+OKhEVMYSL0L7pM4R9z1lSugsQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@microbit/makecode-embed/-/makecode-embed-0.5.0.tgz",
+      "integrity": "sha512-z37koTrEGQVq/zwI5DKfYrmPYUxHiJYFr+86OXCIsqctTRM4DLPm4NZOz9dKRPj6Bwv9uyqF4qvMxcKFFtfX0A==",
+      "license": "MIT",
       "dependencies": {
         "tslib": ">=2.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@formatjs/intl-localematcher": "^0.8.0",
     "@microbit/capacitor-community-nordic-dfu": "^7.0.0-microbit.3",
     "@microbit/capacitor-sqlite-vanilla": "^0.1.0-alpha.5",
-    "@microbit/makecode-embed": "^0.3.0",
+    "@microbit/makecode-embed": "^0.5.0",
     "@microbit/microbit-connection": "^0.9.0-apps.alpha.15",
     "@microbit/ml-header-generator": "^0.4.3",
     "@microbit/smoothie": "^1.37.0-microbit.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import {
   BroadcastChannelData,
   BroadcastChannelMessageType,
 } from "./broadcast-channel";
+import { useNativeBackButton } from "./back-button";
 import { BufferedDataProvider } from "./buffered-data-hooks";
 import EditCodeDialog from "./components/EditCodeDialog";
 import ErrorBoundary from "./components/ErrorBoundary";
@@ -214,6 +215,9 @@ const Layout = () => {
     removeModel,
     updateProjectTimestampUrls,
   ]);
+
+  // Native back button / swipe-back handling (no-op on desktop).
+  useNativeBackButton();
 
   return (
     // We use this even though we have errorElement as this does logging.

--- a/src/back-button.ts
+++ b/src/back-button.ts
@@ -1,0 +1,228 @@
+/**
+ * (c) 2026, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Android back button handling.
+ *
+ * The Android back button fires Capacitor's "backButton" event. The
+ * handler inspects app state and either navigates back in the
+ * connection/download flow, closes a dialog or menu, exits the app
+ * from the home page, or performs normal history navigation.
+ *
+ * Dialogs and menus are closed directly from app state — no browser
+ * history entries are pushed or manipulated for them.
+ *
+ * On desktop browsers and iOS this is a no-op. Dialogs are dismissed
+ * via Escape or the close button; there is no swipe-back gesture.
+ *
+ * All setup is performed via {@link useNativeBackButton}.
+ */
+
+import { App as CapacitorApp } from "@capacitor/app";
+import { Capacitor } from "@capacitor/core";
+import { type MutableRefObject, useEffect, useRef } from "react";
+import {
+  DataConnectionStep,
+  isDataConnectionDialogOpen,
+} from "./data-connection-flow";
+import { canTransition as canDataConnectionTransition } from "./data-connection-flow/data-connection-actions";
+import { useDataConnectionMachine } from "./data-connection-flow/data-connection-internal-hooks";
+import { useDownloadActions } from "./download-flow/download-hooks";
+import { DownloadStep } from "./download-flow/download-types";
+import { SaveStep, TrainModelDialogStage } from "./model";
+import { type State, isCloseableDialogOpen, useStore } from "./store";
+import { createHomePageUrl } from "./urls";
+
+/**
+ * Data connection steps where an operation is in progress and
+ * back navigation must be completely ignored (swallowed).
+ */
+const nonCloseableDataConnectionSteps = new Set<DataConnectionStep>([
+  DataConnectionStep.FlashingInProgress,
+  DataConnectionStep.BluetoothConnect,
+  DataConnectionStep.ConnectingMicrobits,
+  // WebUSB browser picker is open — not a dialog we control.
+  DataConnectionStep.WebUsbChooseMicrobit,
+]);
+
+/**
+ * Download flow steps where an operation is in progress and
+ * back navigation must be completely ignored (swallowed).
+ */
+const nonCloseableDownloadSteps = new Set<DownloadStep>([
+  DownloadStep.FlashingInProgress,
+  DownloadStep.BluetoothSearchConnect,
+]);
+
+/**
+ * Callback registered by a menu component to close itself when the
+ * back button is pressed. Only one menu can be open at a time.
+ */
+let activeMenuClose: (() => void) | null = null;
+
+/**
+ * Register a callback that the back button handler will invoke to
+ * close the currently open menu. Called by the Menu component wrapper
+ * when a menu opens on native platforms.
+ */
+export const setActiveMenuClose = (cb: (() => void) | null): void => {
+  activeMenuClose = cb;
+};
+
+// ---------------------------------------------------------------------------
+// Single entry point
+// ---------------------------------------------------------------------------
+
+interface BackButtonDeps {
+  dataConnectionFireEvent: (
+    event: { type: "back" } | { type: "close" }
+  ) => void;
+  getDownloadOnBack: () => (() => void) | undefined;
+  downloadClose: () => void;
+}
+
+/**
+ * Set up the Android back button listener.
+ *
+ * No-op on non-native platforms.
+ */
+export const useNativeBackButton = (): void => {
+  const { fireEvent: dataConnectionFireEvent } = useDataConnectionMachine();
+  const downloadActions = useDownloadActions();
+  const depsRef = useRef<BackButtonDeps | null>(null);
+  depsRef.current = {
+    dataConnectionFireEvent,
+    getDownloadOnBack: downloadActions.getOnBack,
+    downloadClose: downloadActions.close,
+  };
+  useEffect(() => setupNativeBackButton(depsRef), []);
+};
+
+const setupNativeBackButton = (
+  depsRef: MutableRefObject<BackButtonDeps | null>
+): (() => void) => {
+  if (!Capacitor.isNativePlatform()) {
+    return () => {};
+  }
+
+  const backButtonListener = CapacitorApp.addListener("backButton", () => {
+    handleNativeBackButton(depsRef);
+  });
+
+  return () => {
+    void backButtonListener.then((l) => l.remove());
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Android back button handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle the Android back button.
+ *
+ * Priority:
+ * 1. Non-closeable dialog (flashing, BLE connect, training, etc.) → swallow
+ * 2. Data connection flow dialog with "back" step → go back in flow
+ * 3. Data connection flow dialog without "back" → close flow
+ * 4. Download flow dialog with "back" → go back in flow
+ * 5. Download flow dialog without "back" → close flow
+ * 6. Open menu → close menu
+ * 7. Open closeable dialog → close dialog
+ * 8. Home page → exit app
+ * 9. No dialog → history.back() (normal page navigation)
+ */
+const handleNativeBackButton = (
+  depsRef: MutableRefObject<BackButtonDeps | null>
+): void => {
+  const deps = depsRef.current!;
+  const state = useStore.getState();
+
+  // --- Non-closeable states: swallow ---
+  if (isNonCloseableState(state)) {
+    return;
+  }
+
+  // --- Data connection flow ---
+  const dcStep = state.dataConnection.step;
+  if (isDataConnectionDialogOpen(dcStep)) {
+    if (canDataConnectionTransition({ type: "back" }, state.dataConnection)) {
+      deps.dataConnectionFireEvent({ type: "back" });
+    } else {
+      deps.dataConnectionFireEvent({ type: "close" });
+    }
+    return;
+  }
+
+  // --- Download flow ---
+  const dlStep = state.download.step;
+  if (dlStep !== DownloadStep.None) {
+    const onBack = deps.getDownloadOnBack();
+    if (onBack) {
+      onBack();
+    } else {
+      deps.downloadClose();
+    }
+    return;
+  }
+
+  // --- Open menu → close it directly ---
+  if (activeMenuClose) {
+    const close = activeMenuClose;
+    activeMenuClose = null;
+    close();
+    return;
+  }
+
+  // --- Closeable dialog → close it directly ---
+  if (isCloseableDialogOpen(state)) {
+    state.closeDialog();
+    return;
+  }
+
+  // --- Home page: exit app (Android only) ---
+  if (window.location.pathname === createHomePageUrl()) {
+    void CapacitorApp.exitApp();
+    return;
+  }
+
+  // --- Normal page navigation ---
+  history.back();
+};
+
+/**
+ * Check if the current state has a non-closeable operation in progress.
+ */
+const isNonCloseableState = (state: State): boolean => {
+  // Data connection flow
+  if (nonCloseableDataConnectionSteps.has(state.dataConnection.step)) {
+    return true;
+  }
+
+  // Download flow
+  if (nonCloseableDownloadSteps.has(state.download.step)) {
+    return true;
+  }
+
+  // Training in progress
+  if (
+    state.trainModelDialogStage === TrainModelDialogStage.TrainingInProgress
+  ) {
+    return true;
+  }
+
+  // Save in progress
+  if (state.save.step === SaveStep.SaveProgress) {
+    return true;
+  }
+
+  // Recording in progress
+  if (state.isRecordingDialogOpen) {
+    return true;
+  }
+
+  return false;
+};

--- a/src/components/ActionDataSamplesCard.tsx
+++ b/src/components/ActionDataSamplesCard.tsx
@@ -15,7 +15,6 @@ import {
   HStack,
   Icon,
   keyframes,
-  Menu,
   MenuItem,
   MenuList,
   Portal,
@@ -26,6 +25,7 @@ import { ReactNode, useCallback } from "react";
 import { RiHashtag, RiTimerLine } from "react-icons/ri";
 import { FormattedMessage, useIntl } from "react-intl";
 import { DataSamplesView, ActionData, RecordingData } from "../model";
+import Menu from "./Menu";
 import { useStore } from "../store";
 import { tourElClassname } from "../tours";
 import MoreMenuButton from "./MoreMenuButton";

--- a/src/components/DataSamplesMenu.tsx
+++ b/src/components/DataSamplesMenu.tsx
@@ -6,7 +6,6 @@
 import {
   Icon,
   IconButton,
-  Menu,
   MenuButton,
   MenuDivider,
   MenuItem,
@@ -30,6 +29,7 @@ import LoadProjectMenuItem from "./LoadProjectMenuItem";
 import { NameProjectDialog } from "./NameProjectDialog";
 import ViewDataFeaturesMenuItem from "./ViewDataFeaturesMenuItem";
 import { useProjectIsUntitled } from "../hooks/project-hooks";
+import Menu from "./Menu";
 
 const DataSamplesMenu = () => {
   const intl = useIntl();

--- a/src/components/HelpMenu.tsx
+++ b/src/components/HelpMenu.tsx
@@ -7,7 +7,6 @@ import {
   Box,
   BoxProps,
   IconButton,
-  Menu,
   MenuButton,
   MenuList,
   Portal,
@@ -16,6 +15,7 @@ import { useRef } from "react";
 import { RiQuestionLine } from "react-icons/ri";
 import { useIntl } from "react-intl";
 import HelpMenuItems from "./HelpMenuItems";
+import Menu from "./Menu";
 import { TourTrigger } from "../model";
 
 interface HelpMenuProps extends BoxProps {

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,0 +1,55 @@
+/**
+ * (c) 2026, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { Capacitor } from "@capacitor/core";
+import { Menu as ChakraMenu, MenuProps } from "@chakra-ui/react";
+import { useCallback, useState } from "react";
+import { setActiveMenuClose } from "../back-button";
+
+const isNative = Capacitor.isNativePlatform();
+
+/**
+ * Wrapper around Chakra UI Menu that integrates with native back button
+ * handling. On Android, opening the menu registers a close callback so
+ * that the Anrdoid back button dismisses the menu.
+ *
+ * On native platforms the menu runs in controlled mode so the back button
+ * handler can close it.
+ *
+ * On desktop browsers this is a plain pass-through to Chakra Menu.
+ */
+const Menu = ({ onOpen, onClose, ...props }: MenuProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleOpen = useCallback(() => {
+    setIsOpen(true);
+    setActiveMenuClose(() => {
+      setIsOpen(false);
+      setActiveMenuClose(null);
+    });
+    onOpen?.();
+  }, [onOpen]);
+
+  const handleClose = useCallback(() => {
+    setIsOpen(false);
+    setActiveMenuClose(null);
+    onClose?.();
+  }, [onClose]);
+
+  if (!isNative) {
+    return <ChakraMenu onOpen={onOpen} onClose={onClose} {...props} />;
+  }
+
+  return (
+    <ChakraMenu
+      isOpen={isOpen}
+      onOpen={handleOpen}
+      onClose={handleClose}
+      {...props}
+    />
+  );
+};
+
+export default Menu;

--- a/src/components/ProjectCardActions.tsx
+++ b/src/components/ProjectCardActions.tsx
@@ -3,7 +3,6 @@ import {
   Checkbox,
   HStack,
   IconButton,
-  Menu,
   MenuButton,
   MenuItem,
   MenuList,
@@ -20,6 +19,7 @@ import {
 } from "react-icons/ri";
 import { FormattedMessage, useIntl } from "react-intl";
 import { ProjectNameDialogReason } from "../project-utils";
+import Menu from "./Menu";
 
 interface ProjectCardMenuProps {
   id: string;

--- a/src/components/SettingsMenu.tsx
+++ b/src/components/SettingsMenu.tsx
@@ -6,7 +6,6 @@
 import {
   Box,
   IconButton,
-  Menu,
   MenuButton,
   MenuList,
   Portal,
@@ -15,6 +14,7 @@ import { useRef } from "react";
 import { RiSettings2Line } from "react-icons/ri";
 import { useIntl } from "react-intl";
 import LanguageMenuItem from "./LanguageMenuItem";
+import Menu from "./Menu";
 import SettingsMenuItem from "./SettingsMenuItem";
 
 interface SettingsMenuProps {

--- a/src/components/ToolbarMenu.tsx
+++ b/src/components/ToolbarMenu.tsx
@@ -7,13 +7,13 @@ import {
   Box,
   BoxProps,
   IconButton,
-  Menu,
   MenuButton,
   MenuList,
   ThemeTypings,
 } from "@chakra-ui/react";
 import { ReactNode } from "react";
 import { RiMenuLine } from "react-icons/ri";
+import Menu from "./Menu";
 
 interface ToolbarMenuProps extends BoxProps {
   label: string;

--- a/src/hooks/project-hooks.tsx
+++ b/src/hooks/project-hooks.tsx
@@ -495,7 +495,7 @@ export const ProjectProvider = ({
     [downloadActions, saveHex]
   );
 
-  // Native app-specific handlers
+  // Native app URL open handler (e.g. opening a .hex file).
   useEffect(() => {
     if (Capacitor.isNativePlatform()) {
       const appUrlListener = CapacitorApp.addListener(
@@ -523,10 +523,7 @@ export const ProjectProvider = ({
       );
 
       return () => {
-        const removeListenerHandler = async () => {
-          void (await appUrlListener).remove();
-        };
-        void removeListenerHandler();
+        void appUrlListener.then((l) => l.remove());
       };
     }
   }, [importProjectFromHexText]);

--- a/src/pages/DataSamplesPage.tsx
+++ b/src/pages/DataSamplesPage.tsx
@@ -8,7 +8,6 @@ import {
   Button,
   Flex,
   HStack,
-  useDisclosure,
   usePrefersReducedMotion,
 } from "@chakra-ui/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -92,9 +91,16 @@ const DataSamplesPage = () => {
   });
   const intl = useIntl();
   const prefersReducedMotion = usePrefersReducedMotion();
-  const welcomeDialogDisclosure = useDisclosure({
-    defaultIsOpen: !isConnected && !model,
-  });
+  const initialiseWelcomeDialog = useRef<boolean>(false);
+  const isWelcomeDialogOpen = useStore((s) => s.isWelcomeDialogOpen);
+  const welcomeDialogOnOpen = useStore((s) => s.welcomeDialogOnOpen);
+  const closeDialog = useStore((s) => s.closeDialog);
+  useEffect(() => {
+    if (!initialiseWelcomeDialog.current && !isConnected && !model) {
+      welcomeDialogOnOpen();
+      initialiseWelcomeDialog.current = true;
+    }
+  }, [isConnected, model, welcomeDialogOnOpen]);
   const hasMoved = useHasMoved();
   const tourInProgress = useStore((s) => !!s.tourState);
   const isRecordingDialogOpen = useStore((s) => !!s.isRecordingDialogOpen);
@@ -102,7 +108,7 @@ const DataSamplesPage = () => {
     (s) => s.postImportDialogState !== PostImportDialogState.None
   );
   const isDialogOpen =
-    welcomeDialogDisclosure.isOpen ||
+    isWelcomeDialogOpen ||
     isConnectionDialogOpen ||
     tourInProgress ||
     isRecordingDialogOpen ||
@@ -151,11 +157,8 @@ const DataSamplesPage = () => {
 
   return (
     <>
-      {welcomeDialogDisclosure.isOpen && !isPostImportDialogOpen && (
-        <WelcomeDialog
-          onClose={welcomeDialogDisclosure.onClose}
-          isOpen={welcomeDialogDisclosure.isOpen}
-        />
+      {isWelcomeDialogOpen && !isPostImportDialogOpen && (
+        <WelcomeDialog onClose={closeDialog} isOpen={isWelcomeDialogOpen} />
       )}
       <TrainModelDialogs finalFocusRef={trainButtonRef} />
       <DefaultPageLayout

--- a/src/pages/TestingModelPage.tsx
+++ b/src/pages/TestingModelPage.tsx
@@ -9,7 +9,6 @@ import {
   ButtonGroup,
   Flex,
   HStack,
-  Menu,
   MenuItem,
   MenuList,
   Portal,
@@ -27,6 +26,7 @@ import DefaultPageLayout, {
 } from "../components/DefaultPageLayout";
 import IncompatibleEditorDevice from "../components/IncompatibleEditorDevice";
 import LiveGraphPanel from "../components/LiveGraphPanel";
+import Menu from "../components/Menu";
 import MoreMenuButton from "../components/MoreMenuButton";
 import TestingModelTable from "../components/TestingModelTable";
 import { useBoardVersion } from "../hooks/use-board-version";

--- a/src/store.ts
+++ b/src/store.ts
@@ -4,6 +4,7 @@
  *
  * SPDX-License-Identifier: MIT
  */
+import { Capacitor } from "@capacitor/core";
 import { MakeCodeProject } from "@microbit/makecode-embed/react";
 import { DeviceBondState, ProgressStage } from "@microbit/microbit-connection";
 import * as tf from "@tensorflow/tfjs";
@@ -11,9 +12,25 @@ import { v4 as uuid } from "uuid";
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 import { useShallow } from "zustand/react/shallow";
+import {
+  broadcastChannel,
+  BroadcastChannelData,
+  BroadcastChannelMessageType,
+} from "./broadcast-channel";
 import { BufferedData } from "./buffered-data";
+import {
+  DataConnectionState,
+  DataConnectionType,
+  getInitialDataConnectionState,
+} from "./data-connection-flow";
 import { deployment } from "./deployment";
+import {
+  DownloadState,
+  DownloadStep,
+  SameOrDifferentChoice,
+} from "./download-flow/download-types";
 import { flags } from "./flags";
+import { LoadAction } from "./hooks/project-hooks";
 import { createPromise, PromiseInfo } from "./hooks/use-promise-ref";
 import { Logging } from "./logging/logging";
 import {
@@ -24,13 +41,9 @@ import {
 import { Confidences, predict, trainModel } from "./ml";
 import { mlSettings } from "./mlConfig";
 import {
-  DataConnectionState,
-  DataConnectionType,
-  getInitialDataConnectionState,
-} from "./data-connection-flow";
-import {
   Action,
   ActionData,
+  DataSamplesPageHint,
   DataSamplesView,
   EditorStartUp,
   OldActionData,
@@ -39,7 +52,6 @@ import {
   SaveState,
   SaveStep,
   tourSequence,
-  DataSamplesPageHint,
   TourState,
   TourTrigger,
   TourTriggerName,
@@ -53,8 +65,8 @@ import {
   migrateLegacyActionDataAndAssignNewIds,
   untitledProjectName,
 } from "./project-utils";
+import { projectSessionStorage } from "./session-storage";
 import { defaultSettings, Settings } from "./settings";
-import { Capacitor } from "@capacitor/core";
 import { SqliteDatabase } from "./sqlite-storage";
 import {
   Database,
@@ -66,18 +78,6 @@ import { getTour as getTourSpec } from "./tours";
 import { getTotalNumSamples } from "./utils/actions";
 import { defaultIcons, MakeCodeIcon } from "./utils/icons";
 import { getDetectedAction } from "./utils/prediction";
-import {
-  DownloadState,
-  DownloadStep,
-  SameOrDifferentChoice,
-} from "./download-flow/download-types";
-import { LoadAction } from "./hooks/project-hooks";
-import {
-  broadcastChannel,
-  BroadcastChannelData,
-  BroadcastChannelMessageType,
-} from "./broadcast-channel";
-import { projectSessionStorage } from "./session-storage";
 
 // Use Capacitor.isNativePlatform() directly rather than the isNativePlatform()
 // helper (which also respects the simulateNative flag) because the Capacitor
@@ -227,6 +227,7 @@ export interface State {
   isNameProjectDialogOpen: boolean;
   isRecordingDialogOpen: boolean;
   isConnectToRecordDialogOpen: boolean;
+  isWelcomeDialogOpen: boolean;
 
   allProjectData: ProjectDataWithActions[];
 }
@@ -333,9 +334,39 @@ export interface Actions {
   connectToRecordDialogOnOpen(): void;
   closeDialog(): void;
   isNonConnectionDialogOpen(): boolean;
+  welcomeDialogOnOpen(): void;
 }
 
 type Store = State & Actions;
+
+/**
+ * Whether a closeable (simple, non-flow) dialog is currently open.
+ *
+ * Used by the Android back button handler to decide whether to dismiss a
+ * dialog via {@link closeDialog}. Must stay in sync with {@link closeDialog}.
+ *
+ * Excludes non-closeable operations (recording, training, saving) which
+ * swallow back navigation, and connection/download flows which have their
+ * own back/close logic.
+ */
+export const isCloseableDialogOpen = (state: State): boolean =>
+  state.isAboutDialogOpen ||
+  state.isSettingsDialogOpen ||
+  state.isConnectFirstDialogOpen ||
+  state.isLanguageDialogOpen ||
+  state.isFeedbackFormOpen ||
+  state.isDeleteAllActionsDialogOpen ||
+  state.isNameProjectDialogOpen ||
+  state.isConnectToRecordDialogOpen ||
+  state.isDeleteActionDialogOpen ||
+  state.isIncompatibleEditorDeviceDialogOpen ||
+  state.isWelcomeDialogOpen ||
+  state.isEditorTimedOutDialogOpen ||
+  state.postImportDialogState !== PostImportDialogState.None ||
+  (state.trainModelDialogStage !== TrainModelDialogStage.Closed &&
+    state.trainModelDialogStage !== TrainModelDialogStage.TrainingInProgress) ||
+  (state.save.step !== SaveStep.None &&
+    state.save.step !== SaveStep.SaveProgress);
 
 const createMlStore = (logging: Logging) => {
   return create<Store>()(
@@ -419,6 +450,7 @@ const createMlStore = (logging: Logging) => {
         isConnectToRecordDialogOpen: false,
         isDeleteActionDialogOpen: false,
         isIncompatibleEditorDeviceDialogOpen: false,
+        isWelcomeDialogOpen: false,
 
         allProjectData: [],
 
@@ -1819,6 +1851,9 @@ const createMlStore = (logging: Logging) => {
         incompatibleEditorDeviceDialogOnOpen() {
           set({ isIncompatibleEditorDeviceDialogOpen: true });
         },
+        welcomeDialogOnOpen() {
+          set({ isWelcomeDialogOpen: true });
+        },
         closeDialog() {
           set({
             isLanguageDialogOpen: false,
@@ -1832,6 +1867,11 @@ const createMlStore = (logging: Logging) => {
             isConnectToRecordDialogOpen: false,
             isDeleteActionDialogOpen: false,
             isIncompatibleEditorDeviceDialogOpen: false,
+            isWelcomeDialogOpen: false,
+            isEditorTimedOutDialogOpen: false,
+            trainModelDialogStage: TrainModelDialogStage.Closed,
+            postImportDialogState: PostImportDialogState.None,
+            save: { step: SaveStep.None },
           });
         },
 
@@ -1848,10 +1888,12 @@ const createMlStore = (logging: Logging) => {
             trainModelDialogStage,
             isEditorTimedOutDialogOpen,
             isDeleteAllActionsDialogOpen,
+            isNameProjectDialogOpen,
             isRecordingDialogOpen,
             isConnectToRecordDialogOpen,
             isDeleteActionDialogOpen,
             isIncompatibleEditorDeviceDialogOpen,
+            isWelcomeDialogOpen,
             save,
           } = get();
           return (
@@ -1861,6 +1903,7 @@ const createMlStore = (logging: Logging) => {
             isLanguageDialogOpen ||
             isFeedbackFormOpen ||
             isDeleteAllActionsDialogOpen ||
+            isNameProjectDialogOpen ||
             isRecordingDialogOpen ||
             isConnectToRecordDialogOpen ||
             isDeleteActionDialogOpen ||
@@ -1870,7 +1913,8 @@ const createMlStore = (logging: Logging) => {
             tourState !== undefined ||
             trainModelDialogStage !== TrainModelDialogStage.Closed ||
             isEditorTimedOutDialogOpen ||
-            save.step !== SaveStep.None
+            save.step !== SaveStep.None ||
+            isWelcomeDialogOpen
           );
         },
       }),


### PR DESCRIPTION
Based on @microbit-grace's #754 but tries to make the back button behave naturally.

We:
- navigate back in dialog flows or close the dialog (but take care not to mess with e.g. progress dialogs)
- close menus if they're open
- upgrade makecode-embed to fix an issue where MakeCode adds a history entry which causes an extra pointless back navigate

I investigated supporting this on iOS but it seems this isn't really the expectation there. Back navigation via swipe is common in true native apps for view stack navigation but not for dialogs and similar. So I'm just aiming this at Android where there's a stronger expectation (via nav bar or common gestures).

Fixes https://github.com/microbit-foundation/ml-trainer/issues/712