### PR TITLE
Fix crash when training model without a connected micro:bit

### DIFF
--- a/src/device/mockBluetooth.ts
+++ b/src/device/mockBluetooth.ts
@@ -58,6 +58,13 @@ export class MockBluetoothConnection
   status: ConnectionStatus = ConnectionStatus.NoAuthorizedDevice;
 
   /**
+   * Whether a successful connection has occurred.
+   * Mirrors the real implementation where getBoardVersion() caches
+   * the board version after the first successful connection.
+   */
+  private hasConnected = false;
+
+  /**
    * Queue of behaviors for subsequent connect() calls.
    * Each call to connect() shifts one behavior from this queue.
    * When empty, defaults to success.
@@ -210,6 +217,7 @@ export class MockBluetoothConnection
         this.setStatus(ConnectionStatus.Connecting);
         await this.progressStage(progress, ProgressStage.Connecting, undefined);
         this.setStatus(ConnectionStatus.Connected);
+        this.hasConnected = true;
         await this.delay();
         break;
 
@@ -241,6 +249,9 @@ export class MockBluetoothConnection
   }
 
   getBoardVersion(): BoardVersion {
+    if (!this.hasConnected) {
+      return notConnected();
+    }
     return "V2";
   }
 
@@ -294,6 +305,7 @@ export class MockBluetoothConnection
     this.setStatus(ConnectionStatus.Disconnected);
     await this.delay();
     this.setStatus(ConnectionStatus.NoAuthorizedDevice);
+    this.hasConnected = false;
   }
 
   getAccelerometerData = notConnected;

--- a/src/device/mockUsb.ts
+++ b/src/device/mockUsb.ts
@@ -24,6 +24,13 @@ export class MockUSBConnection
 {
   status: ConnectionStatus = ConnectionStatus.NoAuthorizedDevice;
 
+  /**
+   * Whether a successful connection has occurred.
+   * Mirrors the real implementation where getBoardVersion()/getDeviceId()
+   * cache values after the first successful connection.
+   */
+  private hasConnected = false;
+
   private fakeDeviceId: number | undefined = 123;
 
   constructor() {
@@ -77,13 +84,25 @@ export class MockUSBConnection
     progress?.(ProgressStage.Connecting);
     await new Promise((resolve) => setTimeout(resolve, 100));
     this.setStatus(ConnectionStatus.Connected);
+    this.hasConnected = true;
+  }
+
+  private assertConnected(): void {
+    if (!this.hasConnected) {
+      throw new DeviceError({
+        code: "not-connected",
+        message: "Not connected",
+      });
+    }
   }
 
   getDeviceId(): number {
+    this.assertConnected();
     return this.fakeDeviceId ?? 0;
   }
 
   getBoardVersion(): BoardVersion {
+    this.assertConnected();
     return "V2";
   }
 
@@ -123,6 +142,7 @@ export class MockUSBConnection
 
   clearDevice(): void {
     this.fakeDeviceId = undefined;
+    this.hasConnected = false;
     this.setStatus(ConnectionStatus.NoAuthorizedDevice);
   }
 

--- a/src/hooks/use-board-version.ts
+++ b/src/hooks/use-board-version.ts
@@ -3,17 +3,25 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { BoardVersion } from "@microbit/microbit-connection";
+import { BoardVersion, DeviceError } from "@microbit/microbit-connection";
 import { useConnections } from "../connections-hooks";
 
 /**
- * Returns the connected micro:bit's board version.
+ * Returns the connected micro:bit's board version, or undefined
+ * when no device is connected.
  *
  * For bluetooth connections, reads from the connection object.
  * For radio connections, defaults to V2 because V1 boards are blocked
  * during the connection flow.
  */
-export const useBoardVersion = (): BoardVersion => {
+export const useBoardVersion = (): BoardVersion | undefined => {
   const connections = useConnections();
-  return connections.bluetooth.getBoardVersion() ?? "V2";
+  try {
+    return connections.bluetooth.getBoardVersion() ?? "V2";
+  } catch (e) {
+    if (e instanceof DeviceError && e.code === "not-connected") {
+      return undefined;
+    }
+    throw e;
+  }
 };


### PR DESCRIPTION
useBoardVersion() called getBoardVersion() unconditionally, which throws DeviceError("not-connected") since the connection library update. Handle this by catching the error and returning undefined.

Also update mock Bluetooth/USB connections to match the real library's caching behavior: getBoardVersion()/getDeviceId() now throw pre-connect and persist after disconnect until clearDevice().