### PR TITLE
Fix sharing issues

### DIFF
--- a/src/hooks/project-hooks.tsx
+++ b/src/hooks/project-hooks.tsx
@@ -444,9 +444,10 @@ export const ProjectProvider = ({
             saveType,
           },
         });
+        // Dismiss the progress dialog now that the hex is ready.
+        setSave({ hex, step: SaveStep.ChooseDestination, type: saveType });
         if (saveType === SaveType.Share) {
           try {
-            setSave({ hex, step: SaveStep.ChooseDestination, type: saveType });
             await shareHex(hex);
           } catch (e) {
             if (!isShareCanceled(e)) {
@@ -458,7 +459,7 @@ export const ProjectProvider = ({
         }
         setSave({ step: SaveStep.None, type: SaveType.Download });
         if (saveType === SaveType.Download && !isIOS()) {
-          // iOS share sheet provides its own feedback
+          // iOS share sheet provides its own feedback.
           toast({
             id: "save-complete",
             position: "top",

--- a/src/utils/share-util.ts
+++ b/src/utils/share-util.ts
@@ -6,6 +6,7 @@
 import { Encoding, Directory, Filesystem } from "@capacitor/filesystem";
 import { Share } from "@capacitor/share";
 import { HexData } from "../model";
+import { isIOS } from "../platform";
 
 const shareFromDirectory = "share";
 const tempStorageLocation = Directory.Temporary;
@@ -29,9 +30,13 @@ export const shareFile = async (
     recursive: true,
   });
 
+  // On iOS, UIActivityViewController treats `text` as a separate shareable
+  // item alongside the file, so saving via the share sheet produces an
+  // unwanted extra "text" file. Android uses EXTRA_TEXT which is handled
+  // correctly as message body metadata, so we keep it there.
   await Share.share({
     title,
-    text,
+    ...(isIOS() ? {} : { text }),
     files: [url],
   });
 };


### PR DESCRIPTION
Omit the `text` parameter from Share.share() on iOS where UIActivityViewController treats it as a second shareable item. Android still receives it as EXTRA_TEXT for email body pre-fill. Previously you got the intended file and a file called "text".

Dismiss the save progress dialog as soon as the hex is ready on all platforms, before entering platform-specific save/share logic. Previously the Download path on iOS left SaveStep.SaveProgress active while the share sheet was open. Nothing then dismissed it if you cancelled.