### PR TITLE
Fix download flow not using new Bluetooth name after pattern change

### DIFF
--- a/src/device/mockBluetooth.ts
+++ b/src/device/mockBluetooth.ts
@@ -257,7 +257,15 @@ export class MockBluetoothConnection
 
   async disconnect(): Promise<void> {}
   async serialWrite(_data: string): Promise<void> {}
-  setNameFilter(_name: string): void {}
+  /**
+   * The most recent name filter set via setNameFilter().
+   * Exposed for e2e test assertions.
+   */
+  nameFilter: string | undefined;
+
+  setNameFilter(name: string): void {
+    this.nameFilter = name;
+  }
 
   private async progressStage(
     progressCallback: FlashOptions["progress"],

--- a/src/download-flow/download-actions.ts
+++ b/src/download-flow/download-actions.ts
@@ -195,7 +195,7 @@ const executeAction = async (
  * from IndexedDB or updated mid-flow are reflected on the connection.
  */
 const syncConnectionSettings = (deps: DownloadDependencies) => {
-  const { bluetoothMicrobitName } = useStore.getState().settings;
+  const { bluetoothMicrobitName } = getDownloadState();
   if (bluetoothMicrobitName) {
     deps.connections.bluetooth.setNameFilter(bluetoothMicrobitName);
   }

--- a/src/e2e/app/download-dialogs.ts
+++ b/src/e2e/app/download-dialogs.ts
@@ -132,11 +132,30 @@ export class DownloadDialogs {
   }
 
   async enterBluetoothPattern() {
-    const numCols = 5;
-    for (let i = 0; i < numCols; i++) {
-      const n = (i + 1).toString();
-      await this.page.getByLabel(`Column ${n} - number of LEDs lit`).fill(n);
+    await this.enterBluetoothPatternValues([1, 2, 3, 4, 5]);
+  }
+
+  async enterBluetoothPatternValues(values: number[]) {
+    for (let i = 0; i < values.length; i++) {
+      await this.page
+        .getByLabel(`Column ${i + 1} - number of LEDs lit`)
+        .fill(values[i].toString());
     }
+  }
+
+  async clickMyPatternIsDifferent() {
+    await this.page
+      .getByRole("button", { name: "My pattern is different" })
+      .click();
+  }
+
+  async getBluetoothNameFilter(): Promise<string | undefined> {
+    return this.page.evaluate(() => {
+      const mockBluetooth =
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+        (window as any).mockBluetooth as MockBluetoothConnection;
+      return mockBluetooth.nameFilter;
+    });
   }
 
   /**

--- a/src/e2e/native-bluetooth.spec.ts
+++ b/src/e2e/native-bluetooth.spec.ts
@@ -8,6 +8,7 @@
  */
 import * as fs from "fs";
 import * as path from "path";
+import { expect } from "@playwright/test";
 import { ConnectionStatus, ProgressStage } from "@microbit/microbit-connection";
 import { test } from "./fixtures";
 
@@ -445,5 +446,69 @@ test.describe("native bluetooth", () => {
     await downloadDialogs.waitForText(
       downloadDialogs.titles.nativeBluetooth.resetToBluetooth
     );
+  });
+
+  test("download flow - change pattern during FindingDevice", async ({
+    homePage,
+    dataSamplesPage,
+    testModelPage,
+  }) => {
+    await homePage.goto(["android"]);
+    await homePage.importProject("test-data/dataset.json");
+    await dataSamplesPage.welcomeDialog.close();
+
+    const trainModelDialog = await dataSamplesPage.trainModel();
+    await trainModelDialog.train();
+
+    const makecodeEditor = await testModelPage.editInMakeCode();
+    await makecodeEditor.closeTourDialog();
+    const downloadDialogs = await makecodeEditor.clickDownload();
+
+    // Navigate to pattern entry
+    await downloadDialogs.waitForText(
+      downloadDialogs.titles.nativeBluetooth.help
+    );
+    await downloadDialogs.clickNext();
+    await downloadDialogs.waitForText(
+      downloadDialogs.titles.nativeBluetooth.resetToBluetooth
+    );
+    await downloadDialogs.clickNext();
+    await downloadDialogs.waitForText(
+      downloadDialogs.titles.nativeBluetooth.copyPattern
+    );
+
+    // Enter first pattern (1,2,3,4,5) and start connecting
+    await downloadDialogs.enterBluetoothPatternValues([1, 2, 3, 4, 5]);
+    await downloadDialogs.setBluetoothProgressPause(
+      ProgressStage.FindingDevice,
+      undefined
+    );
+    await downloadDialogs.clickNext();
+
+    // Paused at FindingDevice — click "My pattern is different"
+    await downloadDialogs.clickMyPatternIsDifferent();
+
+    // Should be back at pattern entry
+    await downloadDialogs.waitForText(
+      downloadDialogs.titles.nativeBluetooth.copyPattern
+    );
+
+    // Enter a different pattern (5,4,3,2,1) and start connecting again
+    await downloadDialogs.enterBluetoothPatternValues([5, 4, 3, 2, 1]);
+    await downloadDialogs.setBluetoothProgressPause(
+      ProgressStage.FindingDevice,
+      undefined
+    );
+    await downloadDialogs.clickNext();
+
+    // Verify the name filter was updated to match the new pattern.
+    // Pattern (5,4,3,2,1) corresponds to micro:bit name "tegoz".
+    const nameFilter = await downloadDialogs.getBluetoothNameFilter();
+    expect(nameFilter).toBe("tegoz");
+
+    // Resume and let the download complete
+    await downloadDialogs.resumeBluetoothProgress();
+    await downloadDialogs.setBluetoothProgressPause(undefined, undefined);
+    await downloadDialogs.expectDialogClosed();
   });
 });


### PR DESCRIPTION
syncConnectionSettings in the download flow read the micro:bit name from persisted settings, but since 97fc5262 setMicrobitName only writes to download state (deferring persistence until connection succeeds). This meant changing the pattern via "My pattern is different" during FindingDevice left the old name filter on the Bluetooth connection, preventing it from finding the new micro:bit.

Read from download state instead, matching the analogous fix already applied to the data connection flow in 97fc5262.

Adds an e2e test that changes the pattern mid-download and asserts the correct name filter is applied.

There's a slightly odd behaviour where we write to settings the last micro:bit you successfully used (in either flow) but the connection flows keep their own state. I think this is OK if we don't / until we do support explicit same/different. I guess one option would be not to persist the name in the download flow unless no name was persisted at all but I think it's unclear what the user would prefer without explicit same/different.