### PR TITLE
Don't center NameProjectDialog

### DIFF
--- a/src/components/NameProjectDialog.tsx
+++ b/src/components/NameProjectDialog.tsx
@@ -86,7 +86,6 @@ export const NameProjectDialog = ({
       isOpen={isOpen}
       onClose={onClose}
       size="md"
-      isCentered
       finalFocusRef={finalFocusRef}
       initialFocusRef={ref}
       onCloseComplete={onCloseComplete}


### PR DESCRIPTION
This avoids conflict with the virtual keyboard in the app (where we don't resize the viewport for the keyboard) and seems fine more broadly.