### PR TITLE
Prevent keyboard from obscuring action names on native

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation project(':capacitor-community-safe-area')
     implementation project(':capacitor-app')
     implementation project(':capacitor-filesystem')
+    implementation project(':capacitor-keyboard')
     implementation project(':capacitor-share')
     implementation project(':microbit-capacitor-community-nordic-dfu')
     implementation project(':microbit-capacitor-sqlite-vanilla')

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
             android:label="@string/title_activity_main"
             android:theme="@style/AppTheme.NoActionBarLaunch"
             android:launchMode="singleTask"
+            android:windowSoftInputMode="adjustNothing"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/android/app/src/main/java/org/microbit/createai/MainActivity.java
+++ b/android/app/src/main/java/org/microbit/createai/MainActivity.java
@@ -3,6 +3,8 @@ package org.microbit.createai;
 import android.os.Bundle;
 
 import androidx.activity.EdgeToEdge;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 
 import com.getcapacitor.BridgeActivity;
 
@@ -22,6 +24,18 @@ public class MainActivity extends BridgeActivity {
         // to make status/navigation bars transparent and allow content underneath.
         // The @capacitor-community/safe-area plugin handles icon colors via config.
         EdgeToEdge.enable(this);
+        // Prevent the keyboard from resizing the WebView (match iOS behavior).
+        // Must be set after EdgeToEdge.enable() as it installs its own insets
+        // listener that would otherwise override ours.
+        ViewCompat.setOnApplyWindowInsetsListener(
+            getWindow().getDecorView(),
+            (view, insets) -> {
+                // Strip out IME insets so the layout doesn't resize for the keyboard
+                return new WindowInsetsCompat.Builder(insets)
+                    .setInsets(WindowInsetsCompat.Type.ime(), androidx.core.graphics.Insets.NONE)
+                    .build();
+            }
+        );
     }
 
 }

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -14,6 +14,9 @@ project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/
 include ':capacitor-filesystem'
 project(':capacitor-filesystem').projectDir = new File('../node_modules/@capacitor/filesystem/android')
 
+include ':capacitor-keyboard'
+project(':capacitor-keyboard').projectDir = new File('../node_modules/@capacitor/keyboard/android')
+
 include ':capacitor-share'
 project(':capacitor-share').projectDir = new File('../node_modules/@capacitor/share/android')
 

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -19,6 +19,11 @@ const config: CapacitorConfig = {
     SystemBars: {
       insetsHandling: "disable",
     },
+    Keyboard: {
+      // Prevent iOS from resizing the WebView when the keyboard opens.
+      // We handle scroll-into-view manually via useKeyboardHeight.
+      resize: "none",
+    },
   },
 };
 

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -15,6 +15,7 @@ def capacitor_pods
   pod 'CapacitorCommunitySafeArea', :path => '../../node_modules/@capacitor-community/safe-area'
   pod 'CapacitorApp', :path => '../../node_modules/@capacitor/app'
   pod 'CapacitorFilesystem', :path => '../../node_modules/@capacitor/filesystem'
+  pod 'CapacitorKeyboard', :path => '../../node_modules/@capacitor/keyboard'
   pod 'CapacitorShare', :path => '../../node_modules/@capacitor/share'
   pod 'MicrobitCapacitorCommunityNordicDfu', :path => '../../node_modules/@microbit/capacitor-community-nordic-dfu'
   pod 'MicrobitCapacitorSqliteVanilla', :path => '../../node_modules/@microbit/capacitor-sqlite-vanilla'

--- a/ios/App/Podfile.lock
+++ b/ios/App/Podfile.lock
@@ -11,10 +11,12 @@ PODS:
   - CapacitorFilesystem (7.1.6):
     - Capacitor
     - IONFilesystemLib (~> 1.0.1)
+  - CapacitorKeyboard (7.0.5):
+    - Capacitor
   - CapacitorShare (7.0.4):
     - Capacitor
   - IONFilesystemLib (1.0.1)
-  - MicrobitCapacitorCommunityNordicDfu (7.0.0-microbit.3):
+  - MicrobitCapacitorCommunityNordicDfu (7.0.0-microbit.4):
     - Capacitor
     - NordicDFU (~> 4.16.0)
   - MicrobitCapacitorSqliteVanilla (0.1.0-alpha.5):
@@ -30,6 +32,7 @@ DEPENDENCIES:
   - "CapacitorCommunitySafeArea (from `../../node_modules/@capacitor-community/safe-area`)"
   - "CapacitorCordova (from `../../node_modules/@capacitor/ios`)"
   - "CapacitorFilesystem (from `../../node_modules/@capacitor/filesystem`)"
+  - "CapacitorKeyboard (from `../../node_modules/@capacitor/keyboard`)"
   - "CapacitorShare (from `../../node_modules/@capacitor/share`)"
   - "MicrobitCapacitorCommunityNordicDfu (from `../../node_modules/@microbit/capacitor-community-nordic-dfu`)"
   - "MicrobitCapacitorSqliteVanilla (from `../../node_modules/@microbit/capacitor-sqlite-vanilla`)"
@@ -53,6 +56,8 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/@capacitor/ios"
   CapacitorFilesystem:
     :path: "../../node_modules/@capacitor/filesystem"
+  CapacitorKeyboard:
+    :path: "../../node_modules/@capacitor/keyboard"
   CapacitorShare:
     :path: "../../node_modules/@capacitor/share"
   MicrobitCapacitorCommunityNordicDfu:
@@ -67,13 +72,14 @@ SPEC CHECKSUMS:
   CapacitorCommunitySafeArea: 211e919d3f0ff6020a3b2acb3b772fa30fb685ef
   CapacitorCordova: 31bbe4466000c6b86d9b7f1181ee286cff0205aa
   CapacitorFilesystem: 66f05ee0d8b1ccdc00d509091273a9b3b57c4a0b
+  CapacitorKeyboard: 2fa1e17aec16aef8b01adbc20e8fc295db46104d
   CapacitorShare: 25f7fc5dd0e4edbde5d6801c6de5d14a8b450a41
   IONFilesystemLib: 89258b8e3e85465da93127d25d7ce37f977e8a6f
-  MicrobitCapacitorCommunityNordicDfu: 2fc86a9ebd698d5609023cafd74ece8b5d64a59e
+  MicrobitCapacitorCommunityNordicDfu: fd00d14531eb46f4cc5cfc989d59f46ac12bbcac
   MicrobitCapacitorSqliteVanilla: 007363ee4be41cd778997dda58b6827173ffb67f
   NordicDFU: 116a4ec458945889f8e0e71759e03b23c39c3482
   ZIPFoundation: b8c29ea7ae353b309bc810586181fd073cb3312c
 
-PODFILE CHECKSUM: aca8c4db8121622a7efd1d29db532fd66374756e
+PODFILE CHECKSUM: 24f63ab351c0eda2e1130251dc39df3235af6d9e
 
 COCOAPODS: 1.16.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@capacitor/core": "^7.4.4",
         "@capacitor/filesystem": "^7.1.5",
         "@capacitor/ios": "^7.4.4",
+        "@capacitor/keyboard": "^7.0.5",
         "@capacitor/share": "^7.0.3",
         "@chakra-ui/icons": "^2.1.1",
         "@chakra-ui/react": "^2.8.2",
@@ -583,6 +584,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^7.4.0"
+      }
+    },
+    "node_modules/@capacitor/keyboard": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@capacitor/keyboard/-/keyboard-7.0.5.tgz",
+      "integrity": "sha512-XGqTXvoZLx4gm5TZnH9uDKg9doy8NFhabytyjDOlXDqxNitz9IPWAANUoOyu2W4Ng9a/YaY5csCnAsoUPZesTA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
       }
     },
     "node_modules/@capacitor/share": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@capacitor/core": "^7.4.4",
     "@capacitor/filesystem": "^7.1.5",
     "@capacitor/ios": "^7.4.4",
+    "@capacitor/keyboard": "^7.0.5",
     "@capacitor/share": "^7.0.3",
     "@chakra-ui/icons": "^2.1.1",
     "@chakra-ui/react": "^2.8.2",

--- a/src/components/DataSamplesTable.tsx
+++ b/src/components/DataSamplesTable.tsx
@@ -6,7 +6,9 @@
  */
 import { Grid, GridProps, HStack, Text } from "@chakra-ui/react";
 import { ButtonData } from "@microbit/microbit-connection";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import useKeyboardHeight from "../hooks/use-keyboard-height";
+import { isIOS } from "../platform";
 import { FormattedMessage, useIntl } from "react-intl";
 import { useMicrobitButtonListener } from "../hooks/use-microbit-button-listener";
 import { useDataConnected } from "../data-connection-flow";
@@ -62,6 +64,37 @@ const DataSamplesTable = ({
   hint,
 }: DataSamplesTableProps) => {
   const actions = useStore((s) => s.actions);
+  const keyboardHeight = useKeyboardHeight();
+  const gridRef = useRef<HTMLDivElement>(null);
+
+  // Calculate how much of the grid is actually obscured by the keyboard.
+  // The keyboard covers bottomContent first, so the grid loses less than
+  // the full keyboard height. Extra padding ensures the last item isn't
+  // flush against the keyboard edge.
+  const extraPadding = isIOS() ? 32 : 16;
+  const [gridPadding, setGridPadding] = useState(0);
+  useEffect(() => {
+    if (keyboardHeight > 0 && gridRef.current) {
+      const gridBottom = gridRef.current.getBoundingClientRect().bottom;
+      const visibleBottom = window.innerHeight - keyboardHeight;
+      const obscured = gridBottom - visibleBottom;
+      setGridPadding(obscured > 0 ? obscured + extraPadding : 0);
+    } else {
+      setGridPadding(0);
+    }
+  }, [extraPadding, keyboardHeight]);
+
+  // Scroll the focused element into view after the padding has been applied,
+  // so the scroll container has enough room.
+  useEffect(() => {
+    if (gridPadding > 0 && document.activeElement instanceof HTMLElement) {
+      document.activeElement.scrollIntoView({
+        block: "center",
+        behavior: "smooth",
+      });
+    }
+  }, [gridPadding]);
+
   // Default to first action being selected if last action is deleted.
   const selectedAction: ActionData = actions[selectedActionIdx] ?? actions[0];
 
@@ -206,8 +239,10 @@ const DataSamplesTable = ({
         headings={headings}
       />
       <Grid
+        ref={gridRef}
         {...gridCommonProps}
         py={2}
+        pb={gridPadding > 0 ? `${gridPadding}px` : 2}
         alignItems="start"
         autoRows="max-content"
         overflow="auto"

--- a/src/hooks/use-keyboard-height.ts
+++ b/src/hooks/use-keyboard-height.ts
@@ -1,0 +1,38 @@
+/**
+ * (c) 2026, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { Keyboard } from "@capacitor/keyboard";
+import { useEffect, useState } from "react";
+import { isNativePlatform } from "../platform";
+
+/**
+ * Returns the current on-screen keyboard height in pixels.
+ *
+ * Uses the Capacitor Keyboard plugin on native platforms.
+ * Returns 0 on web or when the keyboard is closed.
+ */
+const useKeyboardHeight = (): number => {
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
+
+  useEffect(() => {
+    if (!isNativePlatform()) {
+      return;
+    }
+    const showListener = Keyboard.addListener("keyboardWillShow", (info) => {
+      setKeyboardHeight(info.keyboardHeight);
+    });
+    const hideListener = Keyboard.addListener("keyboardWillHide", () => {
+      setKeyboardHeight(0);
+    });
+    return () => {
+      void showListener.then((h) => h.remove());
+      void hideListener.then((h) => h.remove());
+    };
+  }, []);
+
+  return keyboardHeight;
+};
+
+export default useKeyboardHeight;

--- a/src/pages/DataSamplesPage.tsx
+++ b/src/pages/DataSamplesPage.tsx
@@ -16,6 +16,7 @@ import { RiAddLine, RiArrowRightLine } from "react-icons/ri";
 import { FormattedMessage, IntlFormatters, useIntl } from "react-intl";
 import { useNavigate } from "react-router";
 import { useHasMoved } from "../buffered-data-hooks";
+import { actionNameInputId } from "../components/ActionNameCard";
 import DataSamplesTable from "../components/DataSamplesTable";
 import {
   AddActionHint,
@@ -84,6 +85,15 @@ const DataSamplesPage = () => {
   const handleAddNewAction = useCallback(async () => {
     setSelectedActionIdx(actions.length);
     await addNewAction();
+    requestAnimationFrame(() => {
+      const updatedActions = useStore.getState().actions;
+      const newAction = updatedActions[updatedActions.length - 1];
+      if (newAction) {
+        document
+          .getElementById(actionNameInputId(newAction))
+          ?.scrollIntoView({ block: "center", behavior: "smooth" });
+      }
+    });
   }, [addNewAction, actions]);
   useShortcut(keyboardShortcuts.addAction, handleAddNewAction, {
     enabled: !isAddNewActionDisabled,


### PR DESCRIPTION
Add @capacitor/keyboard and disable automatic WebView resizing:
- iOS: set Keyboard.resize to "none" in Capacitor config
- Android: strip IME insets in MainActivity so EdgeToEdge doesn't resize the layout

The useKeyboardHeight hook reports the keyboard height so DataSamplesTable can add padding and scroll the focused input into view manually.

Previously iOS did a reasonable but not perfect job of keeping the input in view (sometimes only when you typed the 2nd character) but Android squished the whole viewport into the space left above the keyboard making a mess.