### PR TITLE
Fix .hex file import on Android

### DIFF
--- a/src/components/LoadProjectInput.tsx
+++ b/src/components/LoadProjectInput.tsx
@@ -12,6 +12,7 @@ import {
   useState,
 } from "react";
 import { LoadAction, useProject } from "../hooks/project-hooks";
+import { isAndroid } from "../platform";
 
 export interface LoadProjectInputProps {
   /**
@@ -77,12 +78,20 @@ const LoadProjectInput = forwardRef<LoadProjectInputRef, LoadProjectInputProps>(
       [onOpen]
     );
 
+    // On Android, the file picker filters by MIME type rather than extension.
+    // .hex files have no standard MIME type, so we add application/octet-stream
+    // to ensure they appear in the picker.
+    const effectiveAccept =
+      isAndroid() && accept.includes(".hex")
+        ? `${accept},application/octet-stream`
+        : accept;
+
     return (
       <Input
         type="file"
         display="none"
         multiple={false}
-        accept={accept}
+        accept={effectiveAccept}
         onChange={handleOpenFile}
         ref={inputRef}
       />


### PR DESCRIPTION
Android's WebView (Capacitor's BridgeWebChromeClient) converts the file input accept attribute to MIME types via MimeTypeMap. Since .hex has no registered MIME type, it gets silently dropped, leaving only .json in the file picker. Add application/octet-stream to the accept types on Android so hex files are selectable.

This is not an issue when using the web version via Chrome on Android (presumably it has a custom picker).