### PR TITLE
Rename MakeCode projects when they are not the active project

### DIFF
--- a/src/project-utils.ts
+++ b/src/project-utils.ts
@@ -5,7 +5,7 @@
  */
 import { MakeCodeProject } from "@microbit/makecode-embed";
 import { v4 as uuid } from "uuid";
-import { generateProject } from "./makecode/utils";
+import { filenames, generateProject } from "./makecode/utils";
 import { ActionData, OldActionData } from "./model";
 
 export type ProjectNameDialogReason = "rename" | "duplicate";
@@ -99,4 +99,29 @@ export const migrateLegacyActionDataAndAssignNewIds = (
       })),
     } as ActionData;
   });
+};
+
+export const renameProject = (
+  project: MakeCodeProject,
+  name: string
+): MakeCodeProject => {
+  const pxtString = project.text?.[filenames.pxtJson];
+  const pxt = JSON.parse(pxtString ?? "{}") as Record<string, unknown>;
+
+  return {
+    ...project,
+    header: project.header
+      ? {
+          ...project.header,
+          name,
+        }
+      : undefined,
+    text: {
+      ...project.text,
+      [filenames.pxtJson]: JSON.stringify({
+        ...pxt,
+        name,
+      }),
+    },
+  };
 };

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -5,6 +5,7 @@ import { Action, ActionData, RecordingData } from "./model";
 import {
   migrateLegacyActionDataAndAssignNewIds,
   untitledProjectName,
+  renameProject as renameMakecodeProject,
 } from "./project-utils";
 import { defaultSettings, Settings } from "./settings";
 import { prepActionForStorage } from "./storageUtils";
@@ -866,21 +867,11 @@ export class IdbDatabase implements Database {
     );
     const makeCodeStore = tx.objectStore(DatabaseStore.EDITOR_PROJECT);
     const makeCodeData = assertData(await makeCodeStore.get(id));
-    await makeCodeStore.put(
-      {
-        ...makeCodeData,
-        project: {
-          ...makeCodeData.project,
-          header: makeCodeData.project.header
-            ? {
-                ...makeCodeData.project.header,
-                name,
-              }
-            : undefined,
-        },
-      },
-      id
-    );
+    const renamedMakeCodeData = {
+      ...makeCodeData,
+      project: renameMakecodeProject(makeCodeData.project, name),
+    };
+    await makeCodeStore.put(renamedMakeCodeData, id);
     const projectDataStore = tx.objectStore(DatabaseStore.PROJECT_DATA);
     const projectData = assertData(await projectDataStore.get(id));
     await projectDataStore.put(
@@ -944,15 +935,7 @@ export class IdbDatabase implements Database {
     await makeCodeStore.add(
       {
         ...makeCodeData,
-        project: {
-          ...makeCodeData.project,
-          header: makeCodeData.project.header
-            ? {
-                ...makeCodeData.project.header,
-                name,
-              }
-            : undefined,
-        },
+        project: renameMakecodeProject(makeCodeData.project, name),
       },
       id
     );

--- a/src/store.ts
+++ b/src/store.ts
@@ -48,6 +48,7 @@ import {
   DataWindow,
   legacyDataWindow,
   migrateLegacyActionDataAndAssignNewIds,
+  renameProject,
   untitledProjectName,
 } from "./project-utils";
 import { defaultSettings, Settings } from "./settings";
@@ -1954,29 +1955,6 @@ const getActionsFromProject = (project: MakeCodeProject): ActionData[] => {
   return migrateLegacyActionDataAndAssignNewIds(
     dataset.data as OldActionData[] | ActionData[]
   );
-};
-
-const renameProject = (
-  project: MakeCodeProject,
-  name: string
-): MakeCodeProject => {
-  const pxtString = project.text?.[filenames.pxtJson];
-  const pxt = JSON.parse(pxtString ?? "{}") as Record<string, unknown>;
-
-  return {
-    ...project,
-    header: {
-      ...project.header!,
-      name,
-    },
-    text: {
-      ...project.text,
-      [filenames.pxtJson]: JSON.stringify({
-        ...pxt,
-        name,
-      }),
-    },
-  };
 };
 
 const getHint = (


### PR DESCRIPTION
Extract renameProject to project-utils so it can be shared between store and storage. The shared version updates both header.name and pxt.json name, and handles missing headers gracefully.

This is @glastonbridge's work from #805 but subset to just the beta parts. I'll subsequently rebase that PR.

CC @glastonbridge for info but @microbit-grace please can you review?