### PR TITLE
Only reset on close if not hadSuccessfulConnection

### DIFF
--- a/src/data-connection-flow/data-connection-machine-common.ts
+++ b/src/data-connection-flow/data-connection-machine-common.ts
@@ -783,17 +783,24 @@ export const connectedState = {
 
 /**
  * Global handlers shared by all flows.
- * - close: returns to Idle and resets state
+ * - close: returns to Idle and resets state if not hadSuccessfulConnection (to preserve reconnect)
  * - disconnect: returns to Idle (preserves hadSuccessfulConnection for reconnect)
  * - reset: resets state in place (use after disconnect when micro:bit is being reused)
  */
 export const globalHandlers = {
   _global: {
     on: {
-      close: {
-        target: DataConnectionStep.Idle,
-        actions: actions.reset,
-      },
+      close: [
+        {
+          guard: guards.hadSuccessfulConnection,
+          target: DataConnectionStep.Idle,
+        },
+        {
+          guard: always,
+          target: DataConnectionStep.Idle,
+          actions: actions.reset,
+        },
+      ],
       disconnect: {
         target: DataConnectionStep.Idle,
         actions: [{ type: "disconnectData" }],

--- a/src/data-connection-flow/data-connection-machine-native-bluetooth.test.ts
+++ b/src/data-connection-flow/data-connection-machine-native-bluetooth.test.ts
@@ -464,17 +464,32 @@ describe("Data connection flow: Native Bluetooth", () => {
       DataConnectionStep.StartOver,
       DataConnectionStep.NativeBluetoothPreConnectTutorial,
       DataConnectionStep.EnterBluetoothPattern,
-      DataConnectionStep.ConnectFailed,
-      DataConnectionStep.ConnectionLost,
       DataConnectionStep.BluetoothDisabled,
       DataConnectionStep.BluetoothPermissionDenied,
       DataConnectionStep.LocationDisabled,
     ];
+    const stepsAfterSuccessfulConnection = [
+      DataConnectionStep.ConnectFailed,
+      DataConnectionStep.ConnectionLost,
+    ];
 
     stepsWithClose.forEach((step) => {
-      it(`${step} close -> None`, () => {
+      it(`${step} close -> None with reset`, () => {
         const result = transition(step, { type: "close" });
         expect(result?.step).toBe(DataConnectionStep.Idle);
+        expect(result?.actions).toContainEqual({ type: "reset" });
+      });
+    });
+
+    stepsAfterSuccessfulConnection.forEach((step) => {
+      it(`${step} close -> None`, () => {
+        const result = transition(
+          step,
+          { type: "close" },
+          { hadSuccessfulConnection: true }
+        );
+        expect(result?.step).toBe(DataConnectionStep.Idle);
+        expect(result?.actions.length).toBe(0);
       });
     });
   });

--- a/src/data-connection-flow/data-connection-machine-radio.test.ts
+++ b/src/data-connection-flow/data-connection-machine-radio.test.ts
@@ -676,14 +676,29 @@ describe("Data connection flow: Radio", () => {
         DataConnectionStep.TryAgainReplugMicrobit,
         DataConnectionStep.TryAgainCloseTabs,
         DataConnectionStep.TryAgainWebUsbSelectMicrobit,
+      ];
+      const stepsAfterSuccessfulConnection = [
         DataConnectionStep.ConnectFailed,
         DataConnectionStep.ConnectionLost,
       ];
 
       stepsWithClose.forEach((step) => {
-        it(`${step} close -> None`, () => {
+        it(`${step} close -> None with reset`, () => {
           const result = transition(step, { type: "close" });
           expect(result?.step).toBe(DataConnectionStep.Idle);
+          expect(result?.actions).toContainEqual({ type: "reset" });
+        });
+      });
+
+      stepsAfterSuccessfulConnection.forEach((step) => {
+        it(`${step} close -> None`, () => {
+          const result = transition(
+            step,
+            { type: "close" },
+            { hadSuccessfulConnection: true }
+          );
+          expect(result?.step).toBe(DataConnectionStep.Idle);
+          expect(result?.actions.length).toBe(0);
         });
       });
     });

--- a/src/data-connection-flow/data-connection-machine-web-bluetooth.test.ts
+++ b/src/data-connection-flow/data-connection-machine-web-bluetooth.test.ts
@@ -421,15 +421,30 @@ describe("Data connection flow: Web Bluetooth", () => {
       DataConnectionStep.WebBluetoothPreConnectTutorial,
       DataConnectionStep.BadFirmware,
       DataConnectionStep.TryAgainBluetoothSelectMicrobit,
+      DataConnectionStep.WebUsbBluetoothUnsupported,
+    ];
+    const stepsAfterSuccessfulConnection = [
       DataConnectionStep.ConnectFailed,
       DataConnectionStep.ConnectionLost,
-      DataConnectionStep.WebUsbBluetoothUnsupported,
     ];
 
     stepsWithClose.forEach((step) => {
-      it(`${step} close -> None`, () => {
+      it(`${step} close -> None with reset`, () => {
         const result = transition(step, { type: "close" });
         expect(result?.step).toBe(DataConnectionStep.Idle);
+        expect(result?.actions).toContainEqual({ type: "reset" });
+      });
+    });
+
+    stepsAfterSuccessfulConnection.forEach((step) => {
+      it(`${step} close -> None`, () => {
+        const result = transition(
+          step,
+          { type: "close" },
+          { hadSuccessfulConnection: true }
+        );
+        expect(result?.step).toBe(DataConnectionStep.Idle);
+        expect(result?.actions.length).toBe(0);
       });
     });
   });


### PR DESCRIPTION
Fixes part of https://github.com/microbit-foundation/ml-trainer/issues/729 to match live behaviour:

> The live behaviour is that clicking connect at the bottom of the page after dismissing the try again / reconnect dialog retries the connection to the radio link micro:bit rather than starting from scratch.

Closing Bluetooth try again/reconnect dialog also has similar issue where clicking "Connect" starts from scratch as opposed to retries connection.