### PR TITLE
Fix /new redirect not working when deployed with a base URL

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,6 +65,7 @@ import {
   createDataSamplesPageUrl,
   createHomePageUrl,
   createImportPageUrl,
+  createLegacyNewPageUrl,
   createOpenSharedProjectPageUrl,
   createProjectsPageUrl,
   createTestingModelPageUrl,
@@ -304,7 +305,7 @@ const createRouter = () => {
           errorElement: <NotFound />,
         },
         {
-          path: "/new",
+          path: createLegacyNewPageUrl(),
           element: <Navigate to={createHomePageUrl()} replace />,
         },
         {

--- a/src/urls.ts
+++ b/src/urls.ts
@@ -11,6 +11,8 @@ if (!basepath.endsWith("/")) {
 
 export const createHomePageUrl = () => `${basepath}`;
 
+export const createLegacyNewPageUrl = () => `${basepath}new`;
+
 export const createProjectsPageUrl = () => `${basepath}projects`;
 
 export const createImportPageUrl = () => `${basepath}import`;


### PR DESCRIPTION
The redirect path was hardcoded as "/new" instead of using the basepath prefix, so it didn't match when deployed at e.g. /v/beta/new.