### PR TITLE
Replace native Bluetooth "What you need" dialog with battery pack dialog

### DIFF
--- a/lang/ui.ca.json
+++ b/lang/ui.ca.json
@@ -371,13 +371,13 @@
     "defaultMessage": "If needed, change the pattern below to match.",
     "description": "Native Bluetooth pattern dialog subtitle"
   },
-  "connect-native-start-heading": {
-    "defaultMessage": "What you need to connect",
-    "description": "Connection dialog heading"
+  "connect-native-start-battery-check": {
+    "defaultMessage": "Connect the battery pack, then check the light on the back of the micro:bit is on.",
+    "description": "Instruction to check the micro:bit is powered on via the battery pack"
   },
-  "connect-native-start-requirements1": {
-    "defaultMessage": "micro:bit with battery pack",
-    "description": "Label for image of a micro:bit and battery pack"
+  "connect-native-start-heading": {
+    "defaultMessage": "Connect micro:bit battery pack",
+    "description": "Connection dialog heading"
   },
   "connect-or-import": {
     "defaultMessage": "<link1>Connecta una micro:bit de recollida de dades</link1> o <link2>importa mostres de dades</link2>",

--- a/lang/ui.en.json
+++ b/lang/ui.en.json
@@ -371,13 +371,13 @@
     "defaultMessage": "If needed, change the pattern below to match.",
     "description": "Native Bluetooth pattern dialog subtitle"
   },
-  "connect-native-start-heading": {
-    "defaultMessage": "What you need to connect",
-    "description": "Connection dialog heading"
+  "connect-native-start-battery-check": {
+    "defaultMessage": "Connect the battery pack, then check the light on the back of the micro:bit is on.",
+    "description": "Instruction to check the micro:bit is powered on via the battery pack"
   },
-  "connect-native-start-requirements1": {
-    "defaultMessage": "micro:bit with battery pack",
-    "description": "Label for image of a micro:bit and battery pack"
+  "connect-native-start-heading": {
+    "defaultMessage": "Connect micro:bit battery pack",
+    "description": "Connection dialog heading"
   },
   "connect-or-import": {
     "defaultMessage": "<link1>Connect a data collection micro:bit</link1> or <link2>import data samples</link2>",

--- a/lang/ui.es-es.json
+++ b/lang/ui.es-es.json
@@ -371,13 +371,13 @@
     "defaultMessage": "If needed, change the pattern below to match.",
     "description": "Native Bluetooth pattern dialog subtitle"
   },
-  "connect-native-start-heading": {
-    "defaultMessage": "What you need to connect",
-    "description": "Connection dialog heading"
+  "connect-native-start-battery-check": {
+    "defaultMessage": "Connect the battery pack, then check the light on the back of the micro:bit is on.",
+    "description": "Instruction to check the micro:bit is powered on via the battery pack"
   },
-  "connect-native-start-requirements1": {
-    "defaultMessage": "micro:bit with battery pack",
-    "description": "Label for image of a micro:bit and battery pack"
+  "connect-native-start-heading": {
+    "defaultMessage": "Connect micro:bit battery pack",
+    "description": "Connection dialog heading"
   },
   "connect-or-import": {
     "defaultMessage": "<link1>Conecta una colección de datos de micro:bit</link1> o <link2>importa muestras de datos</link2>",

--- a/lang/ui.fr.json
+++ b/lang/ui.fr.json
@@ -371,13 +371,13 @@
     "defaultMessage": "If needed, change the pattern below to match.",
     "description": "Native Bluetooth pattern dialog subtitle"
   },
-  "connect-native-start-heading": {
-    "defaultMessage": "What you need to connect",
-    "description": "Connection dialog heading"
+  "connect-native-start-battery-check": {
+    "defaultMessage": "Connect the battery pack, then check the light on the back of the micro:bit is on.",
+    "description": "Instruction to check the micro:bit is powered on via the battery pack"
   },
-  "connect-native-start-requirements1": {
-    "defaultMessage": "micro:bit with battery pack",
-    "description": "Label for image of a micro:bit and battery pack"
+  "connect-native-start-heading": {
+    "defaultMessage": "Connect micro:bit battery pack",
+    "description": "Connection dialog heading"
   },
   "connect-or-import": {
     "defaultMessage": "<link1>Connecter un micro:bit de collecte de données</link1> ou <link2>importer des échantillons de données</link2>",

--- a/lang/ui.ja.json
+++ b/lang/ui.ja.json
@@ -371,13 +371,13 @@
     "defaultMessage": "If needed, change the pattern below to match.",
     "description": "Native Bluetooth pattern dialog subtitle"
   },
-  "connect-native-start-heading": {
-    "defaultMessage": "What you need to connect",
-    "description": "Connection dialog heading"
+  "connect-native-start-battery-check": {
+    "defaultMessage": "Connect the battery pack, then check the light on the back of the micro:bit is on.",
+    "description": "Instruction to check the micro:bit is powered on via the battery pack"
   },
-  "connect-native-start-requirements1": {
-    "defaultMessage": "micro:bit with battery pack",
-    "description": "Label for image of a micro:bit and battery pack"
+  "connect-native-start-heading": {
+    "defaultMessage": "Connect micro:bit battery pack",
+    "description": "Connection dialog heading"
   },
   "connect-or-import": {
     "defaultMessage": "<link1>データ収集用micro:bitを接続</link1> または <link2>データサンプルのインポート</link2>",

--- a/lang/ui.ko.json
+++ b/lang/ui.ko.json
@@ -371,13 +371,13 @@
     "defaultMessage": "If needed, change the pattern below to match.",
     "description": "Native Bluetooth pattern dialog subtitle"
   },
-  "connect-native-start-heading": {
-    "defaultMessage": "What you need to connect",
-    "description": "Connection dialog heading"
+  "connect-native-start-battery-check": {
+    "defaultMessage": "Connect the battery pack, then check the light on the back of the micro:bit is on.",
+    "description": "Instruction to check the micro:bit is powered on via the battery pack"
   },
-  "connect-native-start-requirements1": {
-    "defaultMessage": "micro:bit with battery pack",
-    "description": "Label for image of a micro:bit and battery pack"
+  "connect-native-start-heading": {
+    "defaultMessage": "Connect micro:bit battery pack",
+    "description": "Connection dialog heading"
   },
   "connect-or-import": {
     "defaultMessage": "<link1>데이터 수집 micro:bit에 연결하기</link1> 또는  <link2>데이터 샘플 가져오기</link2>를 하세요.",

--- a/lang/ui.lol.json
+++ b/lang/ui.lol.json
@@ -371,13 +371,13 @@
     "defaultMessage": "If needed, change the pattern below to match.",
     "description": "Native Bluetooth pattern dialog subtitle"
   },
-  "connect-native-start-heading": {
-    "defaultMessage": "What you need to connect",
-    "description": "Connection dialog heading"
+  "connect-native-start-battery-check": {
+    "defaultMessage": "Connect the battery pack, then check the light on the back of the micro:bit is on.",
+    "description": "Instruction to check the micro:bit is powered on via the battery pack"
   },
-  "connect-native-start-requirements1": {
-    "defaultMessage": "micro:bit with battery pack",
-    "description": "Label for image of a micro:bit and battery pack"
+  "connect-native-start-heading": {
+    "defaultMessage": "Connect micro:bit battery pack",
+    "description": "Connection dialog heading"
   },
   "connect-or-import": {
     "defaultMessage": "crwdns362772:0crwdne362772:0",

--- a/lang/ui.nl.json
+++ b/lang/ui.nl.json
@@ -371,13 +371,13 @@
     "defaultMessage": "If needed, change the pattern below to match.",
     "description": "Native Bluetooth pattern dialog subtitle"
   },
-  "connect-native-start-heading": {
-    "defaultMessage": "What you need to connect",
-    "description": "Connection dialog heading"
+  "connect-native-start-battery-check": {
+    "defaultMessage": "Connect the battery pack, then check the light on the back of the micro:bit is on.",
+    "description": "Instruction to check the micro:bit is powered on via the battery pack"
   },
-  "connect-native-start-requirements1": {
-    "defaultMessage": "micro:bit with battery pack",
-    "description": "Label for image of a micro:bit and battery pack"
+  "connect-native-start-heading": {
+    "defaultMessage": "Connect micro:bit battery pack",
+    "description": "Connection dialog heading"
   },
   "connect-or-import": {
     "defaultMessage": "<link1>Verbind een micro:bit die gegevens verzamelt</link1> of <link2>importeer data samples</link2>",

--- a/lang/ui.pl.json
+++ b/lang/ui.pl.json
@@ -371,13 +371,13 @@
     "defaultMessage": "If needed, change the pattern below to match.",
     "description": "Native Bluetooth pattern dialog subtitle"
   },
-  "connect-native-start-heading": {
-    "defaultMessage": "What you need to connect",
-    "description": "Connection dialog heading"
+  "connect-native-start-battery-check": {
+    "defaultMessage": "Connect the battery pack, then check the light on the back of the micro:bit is on.",
+    "description": "Instruction to check the micro:bit is powered on via the battery pack"
   },
-  "connect-native-start-requirements1": {
-    "defaultMessage": "micro:bit with battery pack",
-    "description": "Label for image of a micro:bit and battery pack"
+  "connect-native-start-heading": {
+    "defaultMessage": "Connect micro:bit battery pack",
+    "description": "Connection dialog heading"
   },
   "connect-or-import": {
     "defaultMessage": "<link1>Podłącz micro:bit zbierający dane</link1> lub <link2>importuj próbki danych</link2>",

--- a/lang/ui.pt-br.json
+++ b/lang/ui.pt-br.json
@@ -371,13 +371,13 @@
     "defaultMessage": "If needed, change the pattern below to match.",
     "description": "Native Bluetooth pattern dialog subtitle"
   },
-  "connect-native-start-heading": {
-    "defaultMessage": "What you need to connect",
-    "description": "Connection dialog heading"
+  "connect-native-start-battery-check": {
+    "defaultMessage": "Connect the battery pack, then check the light on the back of the micro:bit is on.",
+    "description": "Instruction to check the micro:bit is powered on via the battery pack"
   },
-  "connect-native-start-requirements1": {
-    "defaultMessage": "micro:bit with battery pack",
-    "description": "Label for image of a micro:bit and battery pack"
+  "connect-native-start-heading": {
+    "defaultMessage": "Connect micro:bit battery pack",
+    "description": "Connection dialog heading"
   },
   "connect-or-import": {
     "defaultMessage": "<link1>Conecte um micro:bit de coleta de dados</link1> ou <link2>importe as amostras de dados</link2>",

--- a/lang/ui.zh-tw.json
+++ b/lang/ui.zh-tw.json
@@ -371,13 +371,13 @@
     "defaultMessage": "If needed, change the pattern below to match.",
     "description": "Native Bluetooth pattern dialog subtitle"
   },
-  "connect-native-start-heading": {
-    "defaultMessage": "What you need to connect",
-    "description": "Connection dialog heading"
+  "connect-native-start-battery-check": {
+    "defaultMessage": "Connect the battery pack, then check the light on the back of the micro:bit is on.",
+    "description": "Instruction to check the micro:bit is powered on via the battery pack"
   },
-  "connect-native-start-requirements1": {
-    "defaultMessage": "micro:bit with battery pack",
-    "description": "Label for image of a micro:bit and battery pack"
+  "connect-native-start-heading": {
+    "defaultMessage": "Connect micro:bit battery pack",
+    "description": "Connection dialog heading"
   },
   "connect-or-import": {
     "defaultMessage": "<link1>連線數據收集用的 micro:bit</link1> 或<link2>匯入數據樣本</link2>",

--- a/src/components/DataConnectionDialogs.tsx
+++ b/src/components/DataConnectionDialogs.tsx
@@ -7,9 +7,13 @@ import {
   DataConnectionStep,
   DataConnectionType,
   isDataConnectionDialogOpen,
+  useDataConnectionActions,
 } from "../data-connection-flow";
+import { DataConnectionState } from "../data-connection-flow/data-connection-types";
+import { bluetoothUniversalHex } from "../device/get-hex-file";
+import { isAndroid } from "../platform";
 import { useStore } from "../store";
-import { useDataConnectionActions } from "../data-connection-flow";
+import BluetoothConnectingDialog from "./BluetoothConnectingDialog";
 import PermissionErrorDialog from "./BluetoothPermissionErrorDialog";
 import BrokenFirmwareDialog from "./BrokenFirmwareDialog";
 import ConnectBatteryDialog from "./ConnectBatteryDialog";
@@ -25,8 +29,11 @@ import DownloadProgressDialog, {
 import EnterBluetoothPatternDialog from "./EnterBluetoothPatternDialog";
 import LoadingDialog from "./LoadingDialog";
 import ManualFlashingDialog from "./ManualFlashingDialog";
+import NativeBluetoothConnectBatteryDialog from "./NativeBluetoothConnectBatteryDialog";
 import NativeBluetoothErrorDialog from "./NativeBluetoothErrorDialog";
+import NativeBluetoothPairingLostDialog from "./NativeBluetoothPairingLostDialog";
 import ResetToBluetoothModeDialog from "./ResetToBluetoothModeDialog";
+import ResetToBluetoothModeTroubleshootDialog from "./ResetToBluetoothModeTroubleshootDialog";
 import SelectMicrobitBluetoothDialog from "./SelectMicrobitBluetoothDialog";
 import SelectMicrobitUsbDialog, {
   getHeadingId as getSelectMicrobitUsbHeadingId,
@@ -35,12 +42,6 @@ import TryAgainDialog from "./TryAgainDialog";
 import UnsupportedMicrobitDialog from "./UnsupportedMicrobitDialog";
 import WebUsbBluetoothUnsupportedDialog from "./WebUsbBluetoothUnsupportedDialog";
 import WhatYouWillNeedDialog from "./WhatYouWillNeedDialog";
-import { bluetoothUniversalHex } from "../device/get-hex-file";
-import { isAndroid } from "../platform";
-import { DataConnectionState } from "../data-connection-flow/data-connection-types";
-import NativeBluetoothPairingLostDialog from "./NativeBluetoothPairingLostDialog";
-import ResetToBluetoothModeTroubleshootDialog from "./ResetToBluetoothModeTroubleshootDialog";
-import BluetoothConnectingDialog from "./BluetoothConnectingDialog";
 
 const getDeviceType = (state: DataConnectionState): ConnectionErrorDeviceType =>
   state.type === DataConnectionType.Radio
@@ -62,9 +63,18 @@ const DataConnectionDialogs = () => {
   switch (state.step) {
     case DataConnectionStep.StartOver:
     case DataConnectionStep.Start: {
+      if (state.type === DataConnectionType.NativeBluetooth) {
+        return (
+          <NativeBluetoothConnectBatteryDialog
+            {...dialogCommonProps}
+            onNextClick={actions.onNextClick}
+            reconnect={state.step === DataConnectionStep.StartOver}
+          />
+        );
+      }
       return (
         <WhatYouWillNeedDialog
-          type={state.type}
+          type={state.type === DataConnectionType.Radio ? "radio" : "bluetooth"}
           {...dialogCommonProps}
           onLinkClick={
             actions.canSwitchFlowType() ? actions.switchFlowType : undefined

--- a/src/components/NativeBluetoothConnectBatteryDialog.tsx
+++ b/src/components/NativeBluetoothConnectBatteryDialog.tsx
@@ -1,0 +1,52 @@
+/**
+ * (c) 2026, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { Image, Text, VStack } from "@chakra-ui/react";
+import { FormattedMessage } from "react-intl";
+import microbitWithBatteryPack from "../images/microbit-with-battery-pack.svg";
+import ConnectContainerDialog, {
+  ConnectContainerDialogProps,
+} from "./ConnectContainerDialog";
+
+export interface NativeBluetoothConnectBatteryDialogProps
+  extends Omit<ConnectContainerDialogProps, "children" | "headingId"> {
+  reconnect: boolean;
+}
+
+const NativeBluetoothConnectBatteryDialog = ({
+  reconnect,
+  ...props
+}: NativeBluetoothConnectBatteryDialogProps) => {
+  return (
+    <ConnectContainerDialog
+      {...props}
+      headingId={
+        reconnect
+          ? "reconnect-failed-native-heading"
+          : "connect-native-start-heading"
+      }
+    >
+      <VStack gap={5} width="100%">
+        {reconnect && (
+          <Text width="100%">
+            <FormattedMessage id="reconnect-failed-subtitle" />
+          </Text>
+        )}
+        <Text width="100%">
+          <FormattedMessage id="connect-native-start-battery-check" />
+        </Text>
+        <Image
+          src={microbitWithBatteryPack}
+          alt=""
+          width="22rem"
+          aspectRatio={250 / 148}
+          my={3.5}
+        />
+      </VStack>
+    </ConnectContainerDialog>
+  );
+};
+
+export default NativeBluetoothConnectBatteryDialog;

--- a/src/components/WhatYouWillNeedDialog.tsx
+++ b/src/components/WhatYouWillNeedDialog.tsx
@@ -7,8 +7,6 @@ import { Button, Grid, GridItem, Image, Text, VStack } from "@chakra-ui/react";
 import { FormattedMessage } from "react-intl";
 import batteryPackImage from "../images/stylised-battery-pack.svg";
 import microbitImage from "../images/stylised-microbit-black.svg";
-import microbitWithBatteryPack from "../images/microbit-with-battery-pack.svg";
-import bluetoothSymbol from "../images/bluetooth-symbol.svg";
 import twoMicrobitsImage from "../images/stylised-two-microbits-black.svg";
 import usbCableImage from "../images/stylised-usb-cable.svg";
 import computerImage from "../images/stylised_computer.svg";
@@ -18,20 +16,9 @@ import ConnectContainerDialog, {
 } from "./ConnectContainerDialog";
 import ExternalLink from "./ExternalLink";
 import { useDeployment } from "../deployment";
-import { DataConnectionType } from "../data-connection-flow";
 
-const itemsConfig: Record<
-  DataConnectionType,
-  Array<{
-    imgSrc: string;
-    titleId: string;
-    subtitleId?: string;
-    width?: string;
-    height?: string;
-    mobileMaxHeight?: string;
-  }>
-> = {
-  [DataConnectionType.Radio]: [
+const itemsConfig = {
+  radio: [
     {
       imgSrc: twoMicrobitsImage,
       titleId: "connect-radio-start-requirements1",
@@ -52,7 +39,7 @@ const itemsConfig: Record<
       subtitleId: "connect-with-batteries",
     },
   ],
-  [DataConnectionType.WebBluetooth]: [
+  bluetooth: [
     {
       imgSrc: microbitImage,
       titleId: "connect-bluetooth-start-requirements1",
@@ -72,21 +59,6 @@ const itemsConfig: Record<
       subtitleId: "connect-with-batteries",
     },
   ],
-  [DataConnectionType.NativeBluetooth]: [
-    {
-      imgSrc: microbitWithBatteryPack,
-      titleId: "connect-native-start-requirements1",
-      width: "250px",
-      height: "148px",
-    },
-    {
-      imgSrc: bluetoothSymbol,
-      titleId: "connect-bluetooth-enabled",
-      width: "148px",
-      height: "148px",
-      mobileMaxHeight: "50vw",
-    },
-  ],
 };
 
 export interface WhatYouWillNeedDialogProps
@@ -95,7 +67,7 @@ export interface WhatYouWillNeedDialogProps
     "children" | "onBack" | "headingId"
   > {
   reconnect: boolean;
-  type: DataConnectionType;
+  type: "radio" | "bluetooth";
   onLinkClick: (() => void) | undefined;
 }
 
@@ -106,26 +78,22 @@ const WhatYouWillNeedDialog = ({
   ...props
 }: WhatYouWillNeedDialogProps) => {
   const { supportLinks } = useDeployment();
-  const simpleType: string = {
-    [DataConnectionType.NativeBluetooth]: "native",
-    [DataConnectionType.Radio]: "radio",
-    [DataConnectionType.WebBluetooth]: "bluetooth",
-  }[type];
-  const otherSimpleType = simpleType === "radio" ? "bluetooth" : "radio";
   return (
     <ConnectContainerDialog
       {...props}
       headingId={
         reconnect
-          ? `reconnect-failed-${simpleType}-heading`
-          : `connect-${simpleType}-start-heading`
+          ? `reconnect-failed-${type}-heading`
+          : `connect-${type}-start-heading`
       }
       footerLeft={
         <VStack alignItems="start">
           {onLinkClick && (
             <Button onClick={onLinkClick} variant="link" size="lg">
               <FormattedMessage
-                id={`connect-${simpleType}-start-switch-${otherSimpleType}`}
+                id={`connect-${type}-start-switch-${
+                  type === "bluetooth" ? "radio" : "bluetooth"
+                }`}
               />
             </Button>
           )}
@@ -145,46 +113,34 @@ const WhatYouWillNeedDialog = ({
       )}
       <Grid
         width="100%"
-        templateColumns={{
-          base: itemsConfig[type].length > 2 ? "1fr 1fr" : "1fr",
-          md: `repeat(${itemsConfig[type].length}, 1fr)`,
-        }}
-        gap={{ base: 6, md: 16 }}
-        p={{ base: "15px", md: "30px" }}
+        templateColumns={`repeat(${itemsConfig[type].length}, 1fr)`}
+        gap={16}
+        p="30px"
       >
-        {itemsConfig[type].map(
-          ({ imgSrc, width, height, mobileMaxHeight, titleId, subtitleId }) => {
-            const defaultMobileMaxHeight =
-              itemsConfig[type].length > 2 ? "25vw" : undefined;
-            return (
-              <GridItem key={titleId}>
-                <VStack gap={{ base: 3, md: 5 }}>
-                  <Image
-                    src={imgSrc}
-                    alt=""
-                    objectFit="contain"
-                    width={{ base: "100%", md: width ?? "107px" }}
-                    height={{ base: "auto", md: height ?? "107px" }}
-                    maxHeight={{
-                      base: mobileMaxHeight ?? defaultMobileMaxHeight,
-                      md: "none",
-                    }}
-                  />
-                  <VStack textAlign="center">
-                    <Text fontWeight="bold">
-                      <FormattedMessage id={titleId} />
+        {itemsConfig[type].map(({ imgSrc, titleId, subtitleId }) => {
+          return (
+            <GridItem key={titleId}>
+              <VStack gap={5}>
+                <Image
+                  src={imgSrc}
+                  alt=""
+                  objectFit="contain"
+                  boxSize="107px"
+                />
+                <VStack textAlign="center">
+                  <Text fontWeight="bold">
+                    <FormattedMessage id={titleId} />
+                  </Text>
+                  {subtitleId && (
+                    <Text>
+                      <FormattedMessage id={subtitleId} />
                     </Text>
-                    {subtitleId && (
-                      <Text>
-                        <FormattedMessage id={subtitleId} />
-                      </Text>
-                    )}
-                  </VStack>
+                  )}
                 </VStack>
-              </GridItem>
-            );
-          }
-        )}
+              </VStack>
+            </GridItem>
+          );
+        })}
       </Grid>
     </ConnectContainerDialog>
   );

--- a/src/e2e/app/connection-dialogs.ts
+++ b/src/e2e/app/connection-dialogs.ts
@@ -28,7 +28,7 @@ export const dialogTitles: {
     connectBluetooth: "Connect to micro:bit using Web Bluetooth",
   },
   nativeBluetooth: {
-    whatYouNeed: "What you need to connect",
+    connectBattery: "Connect micro:bit battery pack",
     resetToBluetooth: "Reset to Bluetooth mode",
     copyPattern: "Copy pattern",
     confirmPattern: "Confirm this pattern matches your micro:bit",

--- a/src/e2e/native-bluetooth.spec.ts
+++ b/src/e2e/native-bluetooth.spec.ts
@@ -47,7 +47,7 @@ test.describe("native bluetooth", () => {
 
     // 1. What you need
     await connectionDialogs.waitForText(
-      connectionDialogs.types.nativeBluetooth.whatYouNeed
+      connectionDialogs.types.nativeBluetooth.connectBattery
     );
     await captureDialog(page, "connection-01-what-you-need");
 
@@ -123,7 +123,7 @@ test.describe("native bluetooth", () => {
 
     const connectionDialogs2 = await dataSamplesPage.connect();
     await connectionDialogs2.waitForText(
-      connectionDialogs2.types.nativeBluetooth.whatYouNeed
+      connectionDialogs2.types.nativeBluetooth.connectBattery
     );
     await connectionDialogs2.clickNext();
     await connectionDialogs2.waitForText(
@@ -154,7 +154,7 @@ test.describe("native bluetooth", () => {
     await connectionDialogs.setBluetoothAvailability("disabled");
 
     await connectionDialogs.waitForText(
-      connectionDialogs.types.nativeBluetooth.whatYouNeed
+      connectionDialogs.types.nativeBluetooth.connectBattery
     );
     await connectionDialogs.clickNext();
 
@@ -183,7 +183,7 @@ test.describe("native bluetooth", () => {
     await connectionDialogs.setBluetoothAvailability("permission-denied");
 
     await connectionDialogs.waitForText(
-      connectionDialogs.types.nativeBluetooth.whatYouNeed
+      connectionDialogs.types.nativeBluetooth.connectBattery
     );
     await connectionDialogs.clickNext();
 
@@ -209,7 +209,7 @@ test.describe("native bluetooth", () => {
     await connectionDialogs.setBluetoothAvailability("disabled");
 
     await connectionDialogs.waitForText(
-      connectionDialogs.types.nativeBluetooth.whatYouNeed
+      connectionDialogs.types.nativeBluetooth.connectBattery
     );
     await connectionDialogs.clickNext();
     await connectionDialogs.expectBluetoothDisabledDialog();
@@ -235,7 +235,7 @@ test.describe("native bluetooth", () => {
     ]);
 
     await connectionDialogs.waitForText(
-      connectionDialogs.types.nativeBluetooth.whatYouNeed
+      connectionDialogs.types.nativeBluetooth.connectBattery
     );
     await connectionDialogs.clickNext();
     await connectionDialogs.waitForText(
@@ -264,7 +264,7 @@ test.describe("native bluetooth", () => {
 
     // Complete the connection flow
     await connectionDialogs.waitForText(
-      connectionDialogs.types.nativeBluetooth.whatYouNeed
+      connectionDialogs.types.nativeBluetooth.connectBattery
     );
     await connectionDialogs.clickNext();
     await connectionDialogs.waitForText(
@@ -313,7 +313,7 @@ test.describe("native bluetooth", () => {
     ]);
 
     await connectionDialogs.waitForText(
-      connectionDialogs.types.nativeBluetooth.whatYouNeed
+      connectionDialogs.types.nativeBluetooth.connectBattery
     );
     await connectionDialogs.clickNext();
     await connectionDialogs.waitForText(

--- a/src/messages/ui.ca.json
+++ b/src/messages/ui.ca.json
@@ -685,16 +685,16 @@
       "value": "If needed, change the pattern below to match."
     }
   ],
+  "connect-native-start-battery-check": [
+    {
+      "type": 0,
+      "value": "Connect the battery pack, then check the light on the back of the micro:bit is on."
+    }
+  ],
   "connect-native-start-heading": [
     {
       "type": 0,
-      "value": "What you need to connect"
-    }
-  ],
-  "connect-native-start-requirements1": [
-    {
-      "type": 0,
-      "value": "micro:bit with battery pack"
+      "value": "Connect micro:bit battery pack"
     }
   ],
   "connect-or-import": [

--- a/src/messages/ui.en.json
+++ b/src/messages/ui.en.json
@@ -685,16 +685,16 @@
       "value": "If needed, change the pattern below to match."
     }
   ],
+  "connect-native-start-battery-check": [
+    {
+      "type": 0,
+      "value": "Connect the battery pack, then check the light on the back of the micro:bit is on."
+    }
+  ],
   "connect-native-start-heading": [
     {
       "type": 0,
-      "value": "What you need to connect"
-    }
-  ],
-  "connect-native-start-requirements1": [
-    {
-      "type": 0,
-      "value": "micro:bit with battery pack"
+      "value": "Connect micro:bit battery pack"
     }
   ],
   "connect-or-import": [

--- a/src/messages/ui.es-es.json
+++ b/src/messages/ui.es-es.json
@@ -685,16 +685,16 @@
       "value": "If needed, change the pattern below to match."
     }
   ],
+  "connect-native-start-battery-check": [
+    {
+      "type": 0,
+      "value": "Connect the battery pack, then check the light on the back of the micro:bit is on."
+    }
+  ],
   "connect-native-start-heading": [
     {
       "type": 0,
-      "value": "What you need to connect"
-    }
-  ],
-  "connect-native-start-requirements1": [
-    {
-      "type": 0,
-      "value": "micro:bit with battery pack"
+      "value": "Connect micro:bit battery pack"
     }
   ],
   "connect-or-import": [

--- a/src/messages/ui.fr.json
+++ b/src/messages/ui.fr.json
@@ -685,16 +685,16 @@
       "value": "If needed, change the pattern below to match."
     }
   ],
+  "connect-native-start-battery-check": [
+    {
+      "type": 0,
+      "value": "Connect the battery pack, then check the light on the back of the micro:bit is on."
+    }
+  ],
   "connect-native-start-heading": [
     {
       "type": 0,
-      "value": "What you need to connect"
-    }
-  ],
-  "connect-native-start-requirements1": [
-    {
-      "type": 0,
-      "value": "micro:bit with battery pack"
+      "value": "Connect micro:bit battery pack"
     }
   ],
   "connect-or-import": [

--- a/src/messages/ui.ja.json
+++ b/src/messages/ui.ja.json
@@ -677,16 +677,16 @@
       "value": "If needed, change the pattern below to match."
     }
   ],
+  "connect-native-start-battery-check": [
+    {
+      "type": 0,
+      "value": "Connect the battery pack, then check the light on the back of the micro:bit is on."
+    }
+  ],
   "connect-native-start-heading": [
     {
       "type": 0,
-      "value": "What you need to connect"
-    }
-  ],
-  "connect-native-start-requirements1": [
-    {
-      "type": 0,
-      "value": "micro:bit with battery pack"
+      "value": "Connect micro:bit battery pack"
     }
   ],
   "connect-or-import": [

--- a/src/messages/ui.ko.json
+++ b/src/messages/ui.ko.json
@@ -677,16 +677,16 @@
       "value": "If needed, change the pattern below to match."
     }
   ],
+  "connect-native-start-battery-check": [
+    {
+      "type": 0,
+      "value": "Connect the battery pack, then check the light on the back of the micro:bit is on."
+    }
+  ],
   "connect-native-start-heading": [
     {
       "type": 0,
-      "value": "What you need to connect"
-    }
-  ],
-  "connect-native-start-requirements1": [
-    {
-      "type": 0,
-      "value": "micro:bit with battery pack"
+      "value": "Connect micro:bit battery pack"
     }
   ],
   "connect-or-import": [

--- a/src/messages/ui.lol.json
+++ b/src/messages/ui.lol.json
@@ -675,16 +675,16 @@
       "value": "If needed, change the pattern below to match."
     }
   ],
+  "connect-native-start-battery-check": [
+    {
+      "type": 0,
+      "value": "Connect the battery pack, then check the light on the back of the micro:bit is on."
+    }
+  ],
   "connect-native-start-heading": [
     {
       "type": 0,
-      "value": "What you need to connect"
-    }
-  ],
-  "connect-native-start-requirements1": [
-    {
-      "type": 0,
-      "value": "micro:bit with battery pack"
+      "value": "Connect micro:bit battery pack"
     }
   ],
   "connect-or-import": [

--- a/src/messages/ui.nl.json
+++ b/src/messages/ui.nl.json
@@ -685,16 +685,16 @@
       "value": "If needed, change the pattern below to match."
     }
   ],
+  "connect-native-start-battery-check": [
+    {
+      "type": 0,
+      "value": "Connect the battery pack, then check the light on the back of the micro:bit is on."
+    }
+  ],
   "connect-native-start-heading": [
     {
       "type": 0,
-      "value": "What you need to connect"
-    }
-  ],
-  "connect-native-start-requirements1": [
-    {
-      "type": 0,
-      "value": "micro:bit with battery pack"
+      "value": "Connect micro:bit battery pack"
     }
   ],
   "connect-or-import": [

--- a/src/messages/ui.pl.json
+++ b/src/messages/ui.pl.json
@@ -685,16 +685,16 @@
       "value": "If needed, change the pattern below to match."
     }
   ],
+  "connect-native-start-battery-check": [
+    {
+      "type": 0,
+      "value": "Connect the battery pack, then check the light on the back of the micro:bit is on."
+    }
+  ],
   "connect-native-start-heading": [
     {
       "type": 0,
-      "value": "What you need to connect"
-    }
-  ],
-  "connect-native-start-requirements1": [
-    {
-      "type": 0,
-      "value": "micro:bit with battery pack"
+      "value": "Connect micro:bit battery pack"
     }
   ],
   "connect-or-import": [

--- a/src/messages/ui.pt-br.json
+++ b/src/messages/ui.pt-br.json
@@ -685,16 +685,16 @@
       "value": "If needed, change the pattern below to match."
     }
   ],
+  "connect-native-start-battery-check": [
+    {
+      "type": 0,
+      "value": "Connect the battery pack, then check the light on the back of the micro:bit is on."
+    }
+  ],
   "connect-native-start-heading": [
     {
       "type": 0,
-      "value": "What you need to connect"
-    }
-  ],
-  "connect-native-start-requirements1": [
-    {
-      "type": 0,
-      "value": "micro:bit with battery pack"
+      "value": "Connect micro:bit battery pack"
     }
   ],
   "connect-or-import": [

--- a/src/messages/ui.zh-tw.json
+++ b/src/messages/ui.zh-tw.json
@@ -685,16 +685,16 @@
       "value": "If needed, change the pattern below to match."
     }
   ],
+  "connect-native-start-battery-check": [
+    {
+      "type": 0,
+      "value": "Connect the battery pack, then check the light on the back of the micro:bit is on."
+    }
+  ],
   "connect-native-start-heading": [
     {
       "type": 0,
-      "value": "What you need to connect"
-    }
-  ],
-  "connect-native-start-requirements1": [
-    {
-      "type": 0,
-      "value": "micro:bit with battery pack"
+      "value": "Connect micro:bit battery pack"
     }
   ],
   "connect-or-import": [


### PR DESCRIPTION
The first step of the native Bluetooth connection flow now shows a simpler dialog focused on connecting the battery pack, rather than the generic "What you will need" checklist. The Bluetooth explanation is removed from this step as subsequent steps handle permissions.