### PR TITLE
Add error handling for IndexedDB storage failures

### DIFF
--- a/lang/ui.ca.json
+++ b/lang/ui.ca.json
@@ -1651,6 +1651,18 @@
     "defaultMessage": "Atura l'enregistrament",
     "description": "Button label to stop recording movement data while recording multiple samples"
   },
+  "storage-error-other": {
+    "defaultMessage": "Failed to save your project to browser storage",
+    "description": "Toast shown when a storage write fails for an unknown reason"
+  },
+  "storage-error-quota-description": {
+    "defaultMessage": "Your project edit may not be saved.",
+    "description": "Toast description when browser storage quota is exceeded"
+  },
+  "storage-error-quota-title": {
+    "defaultMessage": "Browser storage full",
+    "description": "Toast title when browser storage quota is exceeded"
+  },
   "support-request": {
     "defaultMessage": "Si us plau, considera<link>fer una sol·licitud d'assistència</link>.",
     "description": "Support request link text"

--- a/lang/ui.en.json
+++ b/lang/ui.en.json
@@ -1651,6 +1651,18 @@
     "defaultMessage": "Stop recording",
     "description": "Button label to stop recording movement data while recording multiple samples"
   },
+  "storage-error-other": {
+    "defaultMessage": "Failed to save your project to browser storage",
+    "description": "Toast shown when a storage write fails for an unknown reason"
+  },
+  "storage-error-quota-description": {
+    "defaultMessage": "Your project edit may not be saved.",
+    "description": "Toast description when browser storage quota is exceeded"
+  },
+  "storage-error-quota-title": {
+    "defaultMessage": "Browser storage full",
+    "description": "Toast title when browser storage quota is exceeded"
+  },
   "support-request": {
     "defaultMessage": "Please consider <link>raising a support request</link>.",
     "description": "Support request link text"

--- a/lang/ui.es-es.json
+++ b/lang/ui.es-es.json
@@ -1651,6 +1651,18 @@
     "defaultMessage": "Detener la grabación",
     "description": "Button label to stop recording movement data while recording multiple samples"
   },
+  "storage-error-other": {
+    "defaultMessage": "Failed to save your project to browser storage",
+    "description": "Toast shown when a storage write fails for an unknown reason"
+  },
+  "storage-error-quota-description": {
+    "defaultMessage": "Your project edit may not be saved.",
+    "description": "Toast description when browser storage quota is exceeded"
+  },
+  "storage-error-quota-title": {
+    "defaultMessage": "Browser storage full",
+    "description": "Toast title when browser storage quota is exceeded"
+  },
   "support-request": {
     "defaultMessage": "Por favor considere <link>una solicitud de soporte</link>.",
     "description": "Support request link text"

--- a/lang/ui.fr.json
+++ b/lang/ui.fr.json
@@ -1651,6 +1651,18 @@
     "defaultMessage": "Arrêter l'enregistrement",
     "description": "Button label to stop recording movement data while recording multiple samples"
   },
+  "storage-error-other": {
+    "defaultMessage": "Failed to save your project to browser storage",
+    "description": "Toast shown when a storage write fails for an unknown reason"
+  },
+  "storage-error-quota-description": {
+    "defaultMessage": "Your project edit may not be saved.",
+    "description": "Toast description when browser storage quota is exceeded"
+  },
+  "storage-error-quota-title": {
+    "defaultMessage": "Browser storage full",
+    "description": "Toast title when browser storage quota is exceeded"
+  },
   "support-request": {
     "defaultMessage": "Veuillez <link>formuler une demande de support</link>.",
     "description": "Support request link text"

--- a/lang/ui.ja.json
+++ b/lang/ui.ja.json
@@ -1651,6 +1651,18 @@
     "defaultMessage": "記録の停止",
     "description": "Button label to stop recording movement data while recording multiple samples"
   },
+  "storage-error-other": {
+    "defaultMessage": "Failed to save your project to browser storage",
+    "description": "Toast shown when a storage write fails for an unknown reason"
+  },
+  "storage-error-quota-description": {
+    "defaultMessage": "Your project edit may not be saved.",
+    "description": "Toast description when browser storage quota is exceeded"
+  },
+  "storage-error-quota-title": {
+    "defaultMessage": "Browser storage full",
+    "description": "Toast title when browser storage quota is exceeded"
+  },
   "support-request": {
     "defaultMessage": "<link>サポートリクエストの提出</link> を検討してください。",
     "description": "Support request link text"

--- a/lang/ui.ko.json
+++ b/lang/ui.ko.json
@@ -1651,6 +1651,18 @@
     "defaultMessage": "기록 중단",
     "description": "Button label to stop recording movement data while recording multiple samples"
   },
+  "storage-error-other": {
+    "defaultMessage": "Failed to save your project to browser storage",
+    "description": "Toast shown when a storage write fails for an unknown reason"
+  },
+  "storage-error-quota-description": {
+    "defaultMessage": "Your project edit may not be saved.",
+    "description": "Toast description when browser storage quota is exceeded"
+  },
+  "storage-error-quota-title": {
+    "defaultMessage": "Browser storage full",
+    "description": "Toast title when browser storage quota is exceeded"
+  },
   "support-request": {
     "defaultMessage": "<link>지원 요청</link>을 생각해 보세요.",
     "description": "Support request link text"

--- a/lang/ui.lol.json
+++ b/lang/ui.lol.json
@@ -1651,6 +1651,18 @@
     "defaultMessage": "crwdns363360:0crwdne363360:0",
     "description": "Button label to stop recording movement data while recording multiple samples"
   },
+  "storage-error-other": {
+    "defaultMessage": "Failed to save your project to browser storage",
+    "description": "Toast shown when a storage write fails for an unknown reason"
+  },
+  "storage-error-quota-description": {
+    "defaultMessage": "Your project edit may not be saved.",
+    "description": "Toast description when browser storage quota is exceeded"
+  },
+  "storage-error-quota-title": {
+    "defaultMessage": "Browser storage full",
+    "description": "Toast title when browser storage quota is exceeded"
+  },
   "support-request": {
     "defaultMessage": "crwdns363362:0crwdne363362:0",
     "description": "Support request link text"

--- a/lang/ui.nl.json
+++ b/lang/ui.nl.json
@@ -1651,6 +1651,18 @@
     "defaultMessage": "Stop met opnemen",
     "description": "Button label to stop recording movement data while recording multiple samples"
   },
+  "storage-error-other": {
+    "defaultMessage": "Failed to save your project to browser storage",
+    "description": "Toast shown when a storage write fails for an unknown reason"
+  },
+  "storage-error-quota-description": {
+    "defaultMessage": "Your project edit may not be saved.",
+    "description": "Toast description when browser storage quota is exceeded"
+  },
+  "storage-error-quota-title": {
+    "defaultMessage": "Browser storage full",
+    "description": "Toast title when browser storage quota is exceeded"
+  },
   "support-request": {
     "defaultMessage": "Overweeg <link>een ondersteuningsverzoek</link> in te dienen.",
     "description": "Support request link text"

--- a/lang/ui.pl.json
+++ b/lang/ui.pl.json
@@ -1651,6 +1651,18 @@
     "defaultMessage": "Zatrzymaj nagrywanie",
     "description": "Button label to stop recording movement data while recording multiple samples"
   },
+  "storage-error-other": {
+    "defaultMessage": "Failed to save your project to browser storage",
+    "description": "Toast shown when a storage write fails for an unknown reason"
+  },
+  "storage-error-quota-description": {
+    "defaultMessage": "Your project edit may not be saved.",
+    "description": "Toast description when browser storage quota is exceeded"
+  },
+  "storage-error-quota-title": {
+    "defaultMessage": "Browser storage full",
+    "description": "Toast title when browser storage quota is exceeded"
+  },
   "support-request": {
     "defaultMessage": "Rozważ <link>złożenie prośby o pomoc</link>.",
     "description": "Support request link text"

--- a/lang/ui.pt-br.json
+++ b/lang/ui.pt-br.json
@@ -1651,6 +1651,18 @@
     "defaultMessage": "Parar a gravação",
     "description": "Button label to stop recording movement data while recording multiple samples"
   },
+  "storage-error-other": {
+    "defaultMessage": "Failed to save your project to browser storage",
+    "description": "Toast shown when a storage write fails for an unknown reason"
+  },
+  "storage-error-quota-description": {
+    "defaultMessage": "Your project edit may not be saved.",
+    "description": "Toast description when browser storage quota is exceeded"
+  },
+  "storage-error-quota-title": {
+    "defaultMessage": "Browser storage full",
+    "description": "Toast title when browser storage quota is exceeded"
+  },
   "support-request": {
     "defaultMessage": "Por favor, considere <link>abrir uma solicitação de suporte</link>",
     "description": "Support request link text"

--- a/lang/ui.zh-tw.json
+++ b/lang/ui.zh-tw.json
@@ -1651,6 +1651,18 @@
     "defaultMessage": "停止錄製",
     "description": "Button label to stop recording movement data while recording multiple samples"
   },
+  "storage-error-other": {
+    "defaultMessage": "Failed to save your project to browser storage",
+    "description": "Toast shown when a storage write fails for an unknown reason"
+  },
+  "storage-error-quota-description": {
+    "defaultMessage": "Your project edit may not be saved.",
+    "description": "Toast description when browser storage quota is exceeded"
+  },
+  "storage-error-quota-title": {
+    "defaultMessage": "Browser storage full",
+    "description": "Toast title when browser storage quota is exceeded"
+  },
   "support-request": {
     "defaultMessage": "請考慮<link>提出支援請求</link>。",
     "description": "Support request link text"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,7 @@ import {
   getAllProjectsFromStorage,
   loadProjectAndModelFromStorage,
   loadSettingsFromStorage,
+  StorageErrorEvent,
   useStore,
 } from "./store";
 import {
@@ -162,6 +163,40 @@ const Layout = () => {
       }
     );
   }, [intl, navigate, setPostImportDialogState, toast]);
+
+  const storageError: StorageErrorEvent | undefined = useStore(
+    (s) => s.storageError
+  );
+  useEffect(() => {
+    if (!storageError) {
+      return;
+    }
+    const messages =
+      storageError.type === "quota"
+        ? {
+            title: intl.formatMessage({ id: "storage-error-quota-title" }),
+            description: intl.formatMessage({
+              id: "storage-error-quota-description",
+            }),
+          }
+        : {
+            title: intl.formatMessage({ id: "storage-error-other" }),
+          };
+    const toastOptions = {
+      id: "storage-error",
+      position: "top" as const,
+      duration: null,
+      isClosable: true,
+      variant: "toast",
+      status: "error" as const,
+      ...messages,
+    };
+    if (toast.isActive("storage-error")) {
+      toast.update("storage-error", toastOptions);
+    } else {
+      toast(toastOptions);
+    }
+  }, [intl, storageError, toast]);
 
   useEffect(() => {
     if (updateProjectTimestampUrls.includes(location.pathname) && id) {

--- a/src/e2e/storage-errors.spec.ts
+++ b/src/e2e/storage-errors.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * (c) 2026, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { expect } from "@playwright/test";
+import { test } from "./fixtures";
+
+/**
+ * Monkey-patches IDBObjectStore.prototype.put so that the next call
+ * throws, then restores the original method.
+ */
+const injectWriteError = async (
+  page: import("@playwright/test").Page,
+  errorName: string = "QuotaExceededError"
+) => {
+  await page.evaluate((errorName) => {
+    const original = IDBObjectStore.prototype.put;
+    IDBObjectStore.prototype.put = function () {
+      IDBObjectStore.prototype.put = original;
+      throw new DOMException(`Simulated ${errorName}`, errorName);
+    };
+  }, errorName);
+};
+
+test.describe("storage write errors", () => {
+  test("shows toast on QuotaExceededError and app remains usable", async ({
+    homePage,
+    dataSamplesPage,
+  }) => {
+    // Create a project so we have something to interact with.
+    await homePage.goto();
+    await homePage.newProject();
+    await dataSamplesPage.expectOnPage();
+
+    // Inject a one-shot write failure for the next put.
+    await injectWriteError(dataSamplesPage.page, "QuotaExceededError");
+
+    // Rename an action to trigger a storage write.
+    const actionInput = dataSamplesPage.page.getByRole("textbox", {
+      name: "Name of action",
+    });
+    await actionInput.first().fill("Wave");
+    // Blur to commit the rename which triggers the storage write.
+    await actionInput.first().blur();
+
+    // Toast should appear with the quota title and description.
+    await expect(
+      dataSamplesPage.page.getByText("Browser storage full")
+    ).toBeVisible();
+    await expect(
+      dataSamplesPage.page.getByText("Your project edit may not be saved.")
+    ).toBeVisible();
+
+    // App should still be usable — no error boundary.
+    await expect(
+      dataSamplesPage.page.getByText("An unexpected error occurred")
+    ).toBeHidden();
+    // Verify we can still interact with the page.
+    await expect(actionInput.first()).toBeVisible();
+  });
+
+  test("shows toast on generic write error", async ({
+    homePage,
+    dataSamplesPage,
+  }) => {
+    await homePage.goto();
+    await homePage.newProject();
+    await dataSamplesPage.expectOnPage();
+
+    await injectWriteError(dataSamplesPage.page, "UnknownError");
+
+    const actionInput = dataSamplesPage.page.getByRole("textbox", {
+      name: "Name of action",
+    });
+    await actionInput.first().fill("Wave");
+    await actionInput.first().blur();
+
+    await expect(
+      dataSamplesPage.page.getByText(
+        "Failed to save your project to browser storage"
+      )
+    ).toBeVisible();
+
+    await expect(
+      dataSamplesPage.page.getByText("An unexpected error occurred")
+    ).toBeHidden();
+  });
+});
+
+test.describe("storage read errors", () => {
+  test("shows error boundary on read failure", async ({
+    homePage,
+    dataSamplesPage,
+  }) => {
+    // Create a project first so the home page has data to load.
+    await homePage.goto();
+    await homePage.newProject();
+    await dataSamplesPage.welcomeDialog.close();
+    await dataSamplesPage.navbar.home();
+    await homePage.expectOnHomePage();
+
+    // Register an init script that monkey-patches getAll to fail once.
+    // addInitScript runs before any page script on every navigation/reload,
+    // so the patch is in place when the route loader fires.
+    await homePage.page.addInitScript(() => {
+      const original = IDBObjectStore.prototype.getAll;
+      IDBObjectStore.prototype.getAll = function () {
+        IDBObjectStore.prototype.getAll = original;
+        throw new DOMException("Simulated read error", "UnknownError");
+      };
+    });
+
+    await homePage.page.reload();
+
+    // Error boundary should render.
+    await expect(
+      homePage.page.getByText("An unexpected error occurred")
+    ).toBeVisible();
+  });
+});

--- a/src/messages/ui.ca.json
+++ b/src/messages/ui.ca.json
@@ -2929,6 +2929,24 @@
       "value": "Atura l'enregistrament"
     }
   ],
+  "storage-error-other": [
+    {
+      "type": 0,
+      "value": "Failed to save your project to browser storage"
+    }
+  ],
+  "storage-error-quota-description": [
+    {
+      "type": 0,
+      "value": "Your project edit may not be saved."
+    }
+  ],
+  "storage-error-quota-title": [
+    {
+      "type": 0,
+      "value": "Browser storage full"
+    }
+  ],
   "support-request": [
     {
       "type": 0,

--- a/src/messages/ui.en.json
+++ b/src/messages/ui.en.json
@@ -2947,6 +2947,24 @@
       "value": "Stop recording"
     }
   ],
+  "storage-error-other": [
+    {
+      "type": 0,
+      "value": "Failed to save your project to browser storage"
+    }
+  ],
+  "storage-error-quota-description": [
+    {
+      "type": 0,
+      "value": "Your project edit may not be saved."
+    }
+  ],
+  "storage-error-quota-title": [
+    {
+      "type": 0,
+      "value": "Browser storage full"
+    }
+  ],
   "support-request": [
     {
       "type": 0,

--- a/src/messages/ui.es-es.json
+++ b/src/messages/ui.es-es.json
@@ -2959,6 +2959,24 @@
       "value": "Detener la grabación"
     }
   ],
+  "storage-error-other": [
+    {
+      "type": 0,
+      "value": "Failed to save your project to browser storage"
+    }
+  ],
+  "storage-error-quota-description": [
+    {
+      "type": 0,
+      "value": "Your project edit may not be saved."
+    }
+  ],
+  "storage-error-quota-title": [
+    {
+      "type": 0,
+      "value": "Browser storage full"
+    }
+  ],
   "support-request": [
     {
       "type": 0,

--- a/src/messages/ui.fr.json
+++ b/src/messages/ui.fr.json
@@ -2951,6 +2951,24 @@
       "value": "Arrêter l'enregistrement"
     }
   ],
+  "storage-error-other": [
+    {
+      "type": 0,
+      "value": "Failed to save your project to browser storage"
+    }
+  ],
+  "storage-error-quota-description": [
+    {
+      "type": 0,
+      "value": "Your project edit may not be saved."
+    }
+  ],
+  "storage-error-quota-title": [
+    {
+      "type": 0,
+      "value": "Browser storage full"
+    }
+  ],
   "support-request": [
     {
       "type": 0,

--- a/src/messages/ui.ja.json
+++ b/src/messages/ui.ja.json
@@ -2883,6 +2883,24 @@
       "value": "記録の停止"
     }
   ],
+  "storage-error-other": [
+    {
+      "type": 0,
+      "value": "Failed to save your project to browser storage"
+    }
+  ],
+  "storage-error-quota-description": [
+    {
+      "type": 0,
+      "value": "Your project edit may not be saved."
+    }
+  ],
+  "storage-error-quota-title": [
+    {
+      "type": 0,
+      "value": "Browser storage full"
+    }
+  ],
   "support-request": [
     {
       "children": [

--- a/src/messages/ui.ko.json
+++ b/src/messages/ui.ko.json
@@ -2879,6 +2879,24 @@
       "value": "기록 중단"
     }
   ],
+  "storage-error-other": [
+    {
+      "type": 0,
+      "value": "Failed to save your project to browser storage"
+    }
+  ],
+  "storage-error-quota-description": [
+    {
+      "type": 0,
+      "value": "Your project edit may not be saved."
+    }
+  ],
+  "storage-error-quota-title": [
+    {
+      "type": 0,
+      "value": "Browser storage full"
+    }
+  ],
   "support-request": [
     {
       "children": [

--- a/src/messages/ui.lol.json
+++ b/src/messages/ui.lol.json
@@ -2861,6 +2861,24 @@
       "value": "crwdns363360:0crwdne363360:0"
     }
   ],
+  "storage-error-other": [
+    {
+      "type": 0,
+      "value": "Failed to save your project to browser storage"
+    }
+  ],
+  "storage-error-quota-description": [
+    {
+      "type": 0,
+      "value": "Your project edit may not be saved."
+    }
+  ],
+  "storage-error-quota-title": [
+    {
+      "type": 0,
+      "value": "Browser storage full"
+    }
+  ],
   "support-request": [
     {
       "type": 0,

--- a/src/messages/ui.nl.json
+++ b/src/messages/ui.nl.json
@@ -2955,6 +2955,24 @@
       "value": "Stop met opnemen"
     }
   ],
+  "storage-error-other": [
+    {
+      "type": 0,
+      "value": "Failed to save your project to browser storage"
+    }
+  ],
+  "storage-error-quota-description": [
+    {
+      "type": 0,
+      "value": "Your project edit may not be saved."
+    }
+  ],
+  "storage-error-quota-title": [
+    {
+      "type": 0,
+      "value": "Browser storage full"
+    }
+  ],
   "support-request": [
     {
       "type": 0,

--- a/src/messages/ui.pl.json
+++ b/src/messages/ui.pl.json
@@ -2955,6 +2955,24 @@
       "value": "Zatrzymaj nagrywanie"
     }
   ],
+  "storage-error-other": [
+    {
+      "type": 0,
+      "value": "Failed to save your project to browser storage"
+    }
+  ],
+  "storage-error-quota-description": [
+    {
+      "type": 0,
+      "value": "Your project edit may not be saved."
+    }
+  ],
+  "storage-error-quota-title": [
+    {
+      "type": 0,
+      "value": "Browser storage full"
+    }
+  ],
   "support-request": [
     {
       "type": 0,

--- a/src/messages/ui.pt-br.json
+++ b/src/messages/ui.pt-br.json
@@ -2951,6 +2951,24 @@
       "value": "Parar a gravação"
     }
   ],
+  "storage-error-other": [
+    {
+      "type": 0,
+      "value": "Failed to save your project to browser storage"
+    }
+  ],
+  "storage-error-quota-description": [
+    {
+      "type": 0,
+      "value": "Your project edit may not be saved."
+    }
+  ],
+  "storage-error-quota-title": [
+    {
+      "type": 0,
+      "value": "Browser storage full"
+    }
+  ],
   "support-request": [
     {
       "type": 0,

--- a/src/messages/ui.zh-tw.json
+++ b/src/messages/ui.zh-tw.json
@@ -2951,6 +2951,24 @@
       "value": "停止錄製"
     }
   ],
+  "storage-error-other": [
+    {
+      "type": 0,
+      "value": "Failed to save your project to browser storage"
+    }
+  ],
+  "storage-error-quota-description": [
+    {
+      "type": 0,
+      "value": "Your project edit may not be saved."
+    }
+  ],
+  "storage-error-quota-title": [
+    {
+      "type": 0,
+      "value": "Browser storage full"
+    }
+  ],
   "support-request": [
     {
       "type": 0,

--- a/src/store.ts
+++ b/src/store.ts
@@ -52,12 +52,7 @@ import {
   untitledProjectName,
 } from "./project-utils";
 import { defaultSettings, Settings } from "./settings";
-import {
-  Database,
-  IdbDatabase,
-  ProjectDataWithActions,
-  StorageError,
-} from "./storage";
+import { Database, IdbDatabase, ProjectDataWithActions } from "./storage";
 import { getTour as getTourSpec } from "./tours";
 import { getTotalNumSamples } from "./utils/actions";
 import { defaultIcons, MakeCodeIcon } from "./utils/icons";
@@ -121,7 +116,12 @@ const updateProject = (
   };
 };
 
+export interface StorageErrorEvent {
+  type: "quota" | "other";
+}
+
 export interface State {
+  storageError: StorageErrorEvent | undefined;
   id: string | undefined;
   actions: ActionData[];
   dataWindow: DataWindow;
@@ -318,6 +318,7 @@ const createMlStore = (logging: Logging) => {
   return create<Store>()(
     devtools(
       (set, get) => ({
+        storageError: undefined,
         id: undefined,
         timestamp: 0,
         actions: [createFirstAction()],
@@ -382,7 +383,7 @@ const createMlStore = (logging: Logging) => {
           };
           const timestamp = Date.now();
           set({ settings: updatedSettings, timestamp }, false, "setSettings");
-          await storageWithErrHandling(
+          await storageWriteWithErrHandling(
             () => storage.updateSettings(updatedSettings),
             "settings"
           );
@@ -416,7 +417,7 @@ const createMlStore = (logging: Logging) => {
             false,
             "setLanguage"
           );
-          await storageWithErrHandling(
+          await storageWriteWithErrHandling(
             () => storage.updateSettings(updatedSettings),
             "settings"
           );
@@ -447,7 +448,7 @@ const createMlStore = (logging: Logging) => {
             "newSession"
           );
           projectSessionStorage.setProjectId(id);
-          await storageWithErrHandling(() =>
+          await storageWriteWithErrHandling(() =>
             storage.newSession(
               actions,
               {
@@ -522,7 +523,7 @@ const createMlStore = (logging: Logging) => {
 
         async updateProjectUpdatedAt() {
           const { id } = get();
-          await storageWithErrHandling(() =>
+          await storageWriteWithErrHandling(() =>
             storage.updateProjectTimestamp(id, Date.now())
           );
         },
@@ -539,7 +540,7 @@ const createMlStore = (logging: Logging) => {
                 { ...duplicatedProject, name, id: newProjectId, timestamp },
               ],
             });
-            await storageWithErrHandling(() =>
+            await storageWriteWithErrHandling(() =>
               storage.duplicateProject(id, {
                 id: newProjectId,
                 name,
@@ -573,7 +574,10 @@ const createMlStore = (logging: Logging) => {
           if (id === currentProjectId) {
             projectSessionStorage.clearProjectId();
           }
-          await storageWithErrHandling(() => storage.deleteProject(id), false);
+          await storageWriteWithErrHandling(
+            () => storage.deleteProject(id),
+            false
+          );
           const message: BroadcastChannelData = {
             messageType: BroadcastChannelMessageType.DELETE_PROJECT,
             projectIds: [id],
@@ -605,7 +609,7 @@ const createMlStore = (logging: Logging) => {
           if (currentProjectId && ids.includes(currentProjectId)) {
             projectSessionStorage.clearProjectId();
           }
-          await storageWithErrHandling(
+          await storageWriteWithErrHandling(
             () => storage.deleteProjects(ids),
             false
           );
@@ -659,7 +663,7 @@ const createMlStore = (logging: Logging) => {
             timestamp,
             ...updatedProject,
           });
-          await storageWithErrHandling(() =>
+          await storageWriteWithErrHandling(() =>
             storage.addAction(
               id,
               newAction,
@@ -701,7 +705,7 @@ const createMlStore = (logging: Logging) => {
 
             ...updatedProject,
           });
-          await storageWithErrHandling(() =>
+          await storageWriteWithErrHandling(() =>
             storage.addRecording(
               id,
               recording,
@@ -740,7 +744,7 @@ const createMlStore = (logging: Logging) => {
             timestamp,
             ...updatedProject,
           });
-          await storageWithErrHandling(() =>
+          await storageWriteWithErrHandling(() =>
             storage.deleteAction(
               id,
               action,
@@ -790,7 +794,7 @@ const createMlStore = (logging: Logging) => {
             timestamp,
             ...updatedProject,
           });
-          await storageWithErrHandling(() =>
+          await storageWriteWithErrHandling(() =>
             storage.updateAction(
               id,
               updatedAction,
@@ -839,7 +843,7 @@ const createMlStore = (logging: Logging) => {
             timestamp,
             ...updatedProject,
           });
-          await storageWithErrHandling(() =>
+          await storageWriteWithErrHandling(() =>
             storage.updateActions(
               id,
               updatedActions,
@@ -876,7 +880,7 @@ const createMlStore = (logging: Logging) => {
             timestamp,
             ...updatedProject,
           });
-          await storageWithErrHandling(() =>
+          await storageWriteWithErrHandling(() =>
             storage.updateAction(
               id,
               updatedAction,
@@ -926,7 +930,7 @@ const createMlStore = (logging: Logging) => {
             timestamp,
             ...updatedProject,
           });
-          await storageWithErrHandling(() =>
+          await storageWriteWithErrHandling(() =>
             storage.deleteRecording(
               id,
               recordingId.toString(),
@@ -958,7 +962,7 @@ const createMlStore = (logging: Logging) => {
             model: undefined,
             ...updatedProject,
           });
-          await storageWithErrHandling(() =>
+          await storageWriteWithErrHandling(() =>
             storage.deleteAllActions(
               id,
               actions,
@@ -1030,7 +1034,7 @@ const createMlStore = (logging: Logging) => {
               hint: getHint(newActionsWithIcons, true),
               ...updatedProject,
             });
-            await storageWithErrHandling(() =>
+            await storageWriteWithErrHandling(() =>
               storage.replaceActions(
                 newActionsWithIcons,
                 {
@@ -1043,7 +1047,7 @@ const createMlStore = (logging: Logging) => {
                 }
               )
             );
-            await storageWithErrHandling(() =>
+            await storageWriteWithErrHandling(() =>
               storage.updateSettings(updatedSettings)
             );
           } else if (loadAction === "replaceProject") {
@@ -1059,7 +1063,7 @@ const createMlStore = (logging: Logging) => {
               ...updatedProject,
             });
             projectSessionStorage.setProjectId(newId);
-            await storageWithErrHandling(() =>
+            await storageWriteWithErrHandling(() =>
               storage.importProject(
                 newActionsWithIcons,
                 {
@@ -1072,7 +1076,7 @@ const createMlStore = (logging: Logging) => {
                 }
               )
             );
-            await storageWithErrHandling(() =>
+            await storageWriteWithErrHandling(() =>
               storage.updateSettings(updatedSettings)
             );
           }
@@ -1121,14 +1125,14 @@ const createMlStore = (logging: Logging) => {
             };
           });
           projectSessionStorage.setProjectId(id);
-          await storageWithErrHandling(() =>
+          await storageWriteWithErrHandling(() =>
             storage.importProject(
               newActions,
               { project, projectEdited },
               { timestamp, id }
             )
           );
-          await storageWithErrHandling(() =>
+          await storageWriteWithErrHandling(() =>
             storage.updateSettings(updatedSettings)
           );
         },
@@ -1203,7 +1207,7 @@ const createMlStore = (logging: Logging) => {
             false,
             actionName
           );
-          await storageWithErrHandling(() =>
+          await storageWriteWithErrHandling(() =>
             storage.updateMakeCodeProject(
               id,
               {
@@ -1254,7 +1258,7 @@ const createMlStore = (logging: Logging) => {
             false,
             "resetProject"
           );
-          await storageWithErrHandling(() =>
+          await storageWriteWithErrHandling(() =>
             storage.updateMakeCodeProject(
               id,
               {
@@ -1294,7 +1298,7 @@ const createMlStore = (logging: Logging) => {
             false,
             "setProjectName"
           );
-          await storageWithErrHandling(() =>
+          await storageWriteWithErrHandling(() =>
             storage.renameProject(id, name, timestamp)
           );
         },
@@ -1480,7 +1484,7 @@ const createMlStore = (logging: Logging) => {
           );
           if (importProject) {
             projectSessionStorage.setProjectId(newProjectId);
-            await storageWithErrHandling(() =>
+            await storageWriteWithErrHandling(() =>
               storage.importProject(
                 newActions as ActionData[],
                 {
@@ -1490,11 +1494,11 @@ const createMlStore = (logging: Logging) => {
                 { timestamp: updatedTimestamp, id: newProjectId }
               )
             );
-            await storageWithErrHandling(() =>
+            await storageWriteWithErrHandling(() =>
               storage.updateSettings(updatedSettings)
             );
           } else if (updateMakeCodeProject) {
-            await storageWithErrHandling(() =>
+            await storageWriteWithErrHandling(() =>
               storage.updateMakeCodeProject(
                 id,
                 {
@@ -1607,7 +1611,7 @@ const createMlStore = (logging: Logging) => {
               timestamp,
             };
             set(updatedState);
-            await storageWithErrHandling(
+            await storageWriteWithErrHandling(
               () => storage.updateSettings(updatedSettings),
               "settings"
             );
@@ -1647,7 +1651,7 @@ const createMlStore = (logging: Logging) => {
             settings: updatedSettings,
             timestamp,
           });
-          await storageWithErrHandling(
+          await storageWriteWithErrHandling(
             () => storage.updateSettings(updatedSettings),
             "settings"
           );
@@ -1664,7 +1668,7 @@ const createMlStore = (logging: Logging) => {
             settings: updatedSettings,
             timestamp,
           });
-          await storageWithErrHandling(
+          await storageWriteWithErrHandling(
             () => storage.updateSettings(updatedSettings),
             "settings"
           );
@@ -1678,7 +1682,7 @@ const createMlStore = (logging: Logging) => {
           set({
             settings: updatedSettings,
           });
-          await storageWithErrHandling(
+          await storageWriteWithErrHandling(
             () => storage.updateSettings(updatedSettings),
             "settings"
           );
@@ -1866,14 +1870,17 @@ useStore.subscribe(async (state, prevState) => {
   const { model: previousModel, id: prevId } = prevState;
   if (newModel !== previousModel) {
     if (!newModel && newId && newId === prevId) {
-      await storageWithErrHandling(() => storage.removeModel(newId), false);
+      await storageWriteWithErrHandling(
+        () => storage.removeModel(newId),
+        false
+      );
       const message: BroadcastChannelData = {
         messageType: BroadcastChannelMessageType.REMOVE_MODEL,
         projectIds: [newId],
       };
       broadcastChannel.postMessage(message);
     } else if (newModel) {
-      await storageWithErrHandling(
+      await storageWriteWithErrHandling(
         () => storage.saveModel(newId, newModel),
         false
       );
@@ -2016,36 +2023,59 @@ const projectInHexIsEdited = (project: MakeCodeProject): boolean => {
   return projectEdited;
 };
 
+let storageErrorReported = false;
+const setStorageError = (err: unknown) => {
+  const isQuotaError =
+    err instanceof DOMException && err.name === "QuotaExceededError";
+  if (!storageErrorReported) {
+    storageErrorReported = true;
+    deployment.logging.error(err);
+  }
+  useStore.setState({
+    storageError: { type: isQuotaError ? "quota" : "other" },
+  });
+};
+
+/**
+ * Wraps a storage operation with error handling.
+ *
+ * Write operations show a toast and swallow the error so that
+ * optimistic UI updates are not disrupted by an error boundary.
+ * Read operations re-throw so that React Router loaders / error
+ * boundaries can handle them.
+ */
 const storageWithErrHandling = async <T>(
   callback: () => Promise<T>,
   broadcastEvent: boolean | "settings" = true
 ) => {
+  const value = await callback();
+  const projectId = useStore.getState().id;
+  const settings = broadcastEvent === "settings";
+  if (broadcastEvent && (projectId || settings)) {
+    const message: BroadcastChannelData = {
+      messageType: BroadcastChannelMessageType.RELOAD_PROJECT,
+      projectIds: projectId ? [projectId] : [],
+      ...(settings && { settings: true }),
+    };
+    broadcastChannel.postMessage(message);
+  }
+  return value;
+};
+
+/**
+ * Like {@link storageWithErrHandling} but sets a storage error in the
+ * store (triggering a toast) and swallows the error. Use for
+ * fire-and-forget writes where the in-memory state has already been
+ * optimistically updated.
+ */
+const storageWriteWithErrHandling = async (
+  callback: () => Promise<void>,
+  broadcastEvent: boolean | "settings" = true
+) => {
   try {
-    const value = await callback();
-    const projectId = useStore.getState().id;
-    const settings = broadcastEvent === "settings";
-    if (broadcastEvent && (projectId || settings)) {
-      const message: BroadcastChannelData = {
-        messageType: BroadcastChannelMessageType.RELOAD_PROJECT,
-        projectIds: projectId ? [projectId] : [],
-        ...(settings && { settings: true }),
-      };
-      broadcastChannel.postMessage(message);
-    }
-    return value;
+    await storageWithErrHandling(callback, broadcastEvent);
   } catch (err) {
-    // TODO: Add sensible error handling.
-    if (err instanceof DOMException && err.name === "QuotaExceededError") {
-      console.error("Storage quota exceeded!", err);
-    } else if (err instanceof StorageError) {
-      // We have failed to load an expected value from storage.
-      console.error(err);
-    } else {
-      console.error(err);
-    }
-    // Throw for now to improve typing.
-    throw err;
-    // We can in theory set error state here with useStore.setState.
+    setStorageError(err);
   }
 };
 


### PR DESCRIPTION
Write errors (quota exceeded, unexpected failures) show a persistent toast via store state observed in Layout, keeping the app usable. Read errors propagate to the React Router error boundary. First error per session is reported to Sentry; subsequent ones are suppressed.

Includes e2e tests that monkey-patch IDBObjectStore to simulate both write and read failures.