### PR TITLE
Data preview recordings flash purple on page load

### DIFF
--- a/src/pages/ImportPage.tsx
+++ b/src/pages/ImportPage.tsx
@@ -23,6 +23,7 @@ import {
 } from "../model";
 import { useStore } from "../store";
 import { createDataSamplesPageUrl, createHomePageUrl } from "../urls";
+import { migrateLegacyActionDataAndAssignNewIds } from "../project-utils";
 
 const ImportPage = () => {
   const intl = useIntl();
@@ -59,13 +60,14 @@ const ImportPage = () => {
         );
         if (project.text?.["dataset.json"]) {
           // Do this first in case it errors on parse
-          setDataset(
+          const actionData = migrateLegacyActionDataAndAssignNewIds(
             (
               JSON.parse(
                 project.text["dataset.json"]
               ) as DatasetEditorJsonFormat
             ).data
           );
+          setDataset(actionData);
         }
         setProject(project);
       } catch (e) {


### PR DESCRIPTION
The recordings flashed because they were detected as new. This was because the action data was using the legacy format, where `ID` was used instead of `id`.

Though we do migrate the data when sharing a project, it happens too late (on loading the project). This change does the migration earlier so that it is applied when previewing the data.

Fixes https://github.com/microbit-foundation/ml-trainer/issues/767
