### PR TITLE
Pause the labels when pausing the graph

### DIFF
--- a/src/components/LiveGraph.tsx
+++ b/src/components/LiveGraph.tsx
@@ -182,7 +182,7 @@ const LiveGraph = ({ paused }: LiveGraphProps) => {
         id="smoothie-chart"
         width={width - 30}
       />
-      {isConnected && <LiveGraphLabels />}
+      {isConnected && <LiveGraphLabels paused={paused} />}
     </HStack>
   );
 };

--- a/src/components/LiveGraphLabels.tsx
+++ b/src/components/LiveGraphLabels.tsx
@@ -14,7 +14,11 @@ import { getLabelHeights } from "../live-graph-label-config";
 import { smoothenDataPoint } from "./LiveGraph";
 import { useSettings } from "../store";
 
-const LiveGraphLabels = () => {
+interface LiveGraphLabelsProps {
+  paused?: boolean;
+}
+
+const LiveGraphLabels = ({ paused }: LiveGraphLabelsProps) => {
   const [{ graphColorScheme }] = useSettings();
   const colors = useGraphColors(graphColorScheme);
   const connectActions = useConnectActions();
@@ -76,11 +80,14 @@ const LiveGraphLabels = () => {
         }
       });
     };
+    if (paused) {
+      return;
+    }
     connectActions.addAccelerometerListener(listener);
     return () => {
       connectActions.removeAccelerometerListener(listener);
     };
-  }, [connectActions, labelConfig]);
+  }, [connectActions, labelConfig, paused]);
 
   return (
     <Box w={10} h={40} position="relative">


### PR DESCRIPTION
We pause when training, but didn't spot that the labels still move.

It's a shame they're rendered separately at all, I'll revisit my PR to replace the graph + labels with a single canvas rendering later but this is safer for beta.