### PR TITLE
Set VITE_STAGE in app CI builds so external links use correct URLs

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -57,6 +57,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - run: node ./bin/print-apps-ci-env.cjs >> $GITHUB_ENV
       - run: npm run build:apps
 
       - run: npx cap sync android

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: node ./bin/print-ci-env.cjs >> $GITHUB_ENV
+      - run: node ./bin/print-web-ci-env.cjs >> $GITHUB_ENV
       - run: npm run ci
       - name: Run Playwright tests
         if: env.STAGE == 'REVIEW' || env.STAGE == 'STAGING' || env.STAGE == 'BETA'

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -60,6 +60,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - run: node ./bin/print-apps-ci-env.cjs >> $GITHUB_ENV
       - run: npm run build:apps
 
       - run: npx cap sync ios

--- a/bin/ci-stage.cjs
+++ b/bin/ci-stage.cjs
@@ -1,0 +1,22 @@
+/**
+ * (c) 2026, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+// Determines the CI stage from GITHUB_REF.
+// Used by print-web-ci-env.cjs and print-apps-ci-env.cjs.
+
+const ref = process.env.GITHUB_REF;
+let stage;
+if (ref === "refs/heads/beta") {
+  stage = "BETA";
+} else if (ref === "refs/heads/main") {
+  stage = "STAGING";
+} else if (ref.startsWith("refs/tags/v")) {
+  stage = "PRODUCTION";
+} else {
+  stage = "REVIEW";
+}
+
+module.exports = { stage };

--- a/bin/print-apps-ci-env.cjs
+++ b/bin/print-apps-ci-env.cjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+/**
+ * (c) 2026, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+// Prints STAGE and VITE_STAGE for CI builds.
+// Used by app builds that don't need the deployment config from print-web-ci-env.cjs.
+
+const { stage } = require("./ci-stage.cjs");
+
+console.log(`STAGE=${stage}`);
+console.log(`VITE_STAGE=${stage}`);

--- a/bin/print-web-ci-env.cjs
+++ b/bin/print-web-ci-env.cjs
@@ -1,16 +1,6 @@
 #!/usr/bin/env node
 
-const ref = process.env.GITHUB_REF;
-let stage;
-if (ref === "refs/heads/beta") {
-  stage = "BETA";
-} else if (ref === "refs/heads/main") {
-  stage = "STAGING";
-} else if (ref.startsWith("refs/tags/v")) {
-  stage = "PRODUCTION";
-} else {
-  stage = "REVIEW";
-}
+const { stage } = require("./ci-stage.cjs");
 
 process.env.STAGE = stage;
 // STAGE must be defined before this is imported


### PR DESCRIPTION
App builds (iOS/Android) were missing VITE_STAGE, causing the stage to default to "local" and external links to point to staging URLs even in tagged releases. Extract stage logic into shared ci-stage.cjs and add print-apps-ci-env.cjs for app workflows.