### PR TITLE
Use beta MakeCode for editor

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -28,6 +28,7 @@ const Editor = forwardRef<MakeCodeFrameDriver, EditorProps>(function Editor(
   return (
     <MakeCodeFrame
       ref={ref}
+      baseUrl="https://makecode.microbit.org/beta"
       queryParams={{ hidelanguage: "1", keyboardcontrols: "1" }}
       controllerId={controllerId}
       controller={2}

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -28,13 +28,12 @@ const Editor = forwardRef<MakeCodeFrameDriver, EditorProps>(function Editor(
   return (
     <MakeCodeFrame
       ref={ref}
-      baseUrl="https://makecode.microbit.org/beta"
       queryParams={{ hidelanguage: "1", keyboardcontrols: "1" }}
       controllerId={controllerId}
       controller={2}
       lang={getMakeCodeLang(languageId)}
       loading="eager"
-      version={getEditorVersionOverride()}
+      version={getEditorVersionOverride() ?? "beta"}
       {...editorCallbacks}
       {...props}
     />


### PR DESCRIPTION
Beta MakeCode includes fix for [this issue]( https://redirect.github.com/microsoft/pxt-microbit/issues/6081), which we've seen more of when testing apps. It surfaces in errors [like this](https://github.com/microbit-foundation/ml-trainer/issues/765). Until the fix reaches live MakeCode, we may need to use beta MakeCode for now.