### PR TITLE
Disconnect in pairing mode before downloading MakeCode project

### DIFF
--- a/src/download-flow/download-machine-native-bluetooth.test.ts
+++ b/src/download-flow/download-machine-native-bluetooth.test.ts
@@ -62,9 +62,6 @@ describe("Download flow: Native Bluetooth", () => {
       );
 
       expect(result?.step).toBe(DownloadStep.NativeBluetoothPreConnectTutorial);
-      expect(result?.actions).toContainEqual({
-        type: "disconnectDataConnection",
-      });
     });
   });
 
@@ -73,9 +70,6 @@ describe("Download flow: Native Bluetooth", () => {
       const result = transition(DownloadStep.Help, { type: "next" });
 
       expect(result?.step).toBe(DownloadStep.NativeBluetoothPreConnectTutorial);
-      expect(result?.actions).toContainEqual({
-        type: "disconnectDataConnection",
-      });
     });
 
     it("NativeBluetoothPreConnectTutorial -> BluetoothPattern", () => {
@@ -93,6 +87,9 @@ describe("Download flow: Native Bluetooth", () => {
       });
 
       expect(result?.step).toBe(DownloadStep.FlashingInProgress);
+      expect(result?.actions).toContainEqual({
+        type: "disconnectDataConnection",
+      });
       expect(result?.actions).toContainEqual({
         type: "connectFlash",
         clearDevice: true,

--- a/src/download-flow/download-machine-native-bluetooth.ts
+++ b/src/download-flow/download-machine-native-bluetooth.ts
@@ -138,7 +138,6 @@ export const nativeBluetoothFlow: DownloadFlowDefinition = {
   },
 
   [DownloadStep.NativeBluetoothPreConnectTutorial]: {
-    entry: [{ type: "disconnectDataConnection" }],
     on: {
       next: [
         {
@@ -172,7 +171,10 @@ export const nativeBluetoothFlow: DownloadFlowDefinition = {
     on: {
       next: {
         target: DownloadStep.FlashingInProgress,
-        actions: [{ type: "connectFlash", clearDevice: true }],
+        actions: [
+          { type: "disconnectDataConnection" },
+          { type: "connectFlash", clearDevice: true },
+        ],
       },
       back: { target: DownloadStep.NativeBluetoothPreConnectTutorial },
       setMicrobitName: {


### PR DESCRIPTION
Fixes https://github.com/microbit-foundation/ml-trainer/issues/845

Disconnecting when user is in pairing mode avoids the sad face from being shown on the micro:bit because the micro:bit is not in application mode. At the same time, it also avoids the connection lost dialog from popping up. 

However, it would make encountering [this issue](https://redirect.github.com/microbit-foundation/ml-trainer/issues/851) more probable. Users may enter pairing mode on the micro:bit, decide to not download the program, return to the testing model page to see the graph lines missing.