### PR TITLE
[WIP] Hide simulator when editor is hidden to mute it

### DIFF
--- a/src/hooks/project-hooks.tsx
+++ b/src/hooks/project-hooks.tsx
@@ -16,6 +16,7 @@ import {
   RefObject,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useRef,
 } from "react";
@@ -306,12 +307,40 @@ export const ProjectProvider = ({
       setProjectEdited,
     ]
   );
+
+  const hideSimulatorPromiseRef = useRef<Promise<void> | null>(null);
+
+  const hideSimulator = useCallback(async () => {
+    hideSimulatorPromiseRef.current =
+      driverRef.current?.hideSimulator() ?? null;
+    await hideSimulatorPromiseRef.current;
+  }, [driverRef]);
+
+  const initAsyncCalled = useRef(false);
+  useEffect(() => {
+    const initAsync = async () => {
+      // Hide simulator when not on code page to avoid it from making noise
+      // when editor is not visible. Hiding it prevents it from loading.
+      if (window.location.pathname !== createCodePageUrl()) {
+        initAsyncCalled.current = true;
+        await doAfterEditorUpdate(() => Promise.resolve());
+        await hideSimulator();
+      }
+    };
+    if (!initAsyncCalled.current) {
+      void initAsync();
+    }
+    return;
+  }, [doAfterEditorUpdate, driverRef, hideSimulator]);
+
   const browserNavigationToEditor = useCallback(async () => {
     try {
       setProjectEdited();
-      await doAfterEditorUpdate(() => {
-        return Promise.resolve();
-      });
+      await doAfterEditorUpdate(() => Promise.resolve());
+      
+      // Wait for simulator to finish hiding before showing simulator.
+      await hideSimulatorPromiseRef.current;
+      await driverRef.current?.showSimulator();
       return true;
     } catch (e) {
       if (e instanceof CodeEditorError) {
@@ -323,7 +352,7 @@ export const ProjectProvider = ({
       logging.error(e);
       return false;
     }
-  }, [doAfterEditorUpdate, logging, setProjectEdited]);
+  }, [doAfterEditorUpdate, driverRef, logging, setProjectEdited]);
   const resetProject = useStore((s) => s.resetProject);
   const loadDataset = useStore((s) => s.loadDataset);
   const loadFile = useCallback(
@@ -473,7 +502,8 @@ export const ProjectProvider = ({
       focusVisible: openedViaKeyboardRef.current,
     };
     navigate(createTestingModelPageUrl(), { state });
-  }, [navigate]);
+    void hideSimulator();
+  }, [hideSimulator, navigate]);
   const onSave = saveHex;
   const downloadActions = useDownloadActions();
   const onDownload = useCallback(

--- a/src/hooks/project-hooks.tsx
+++ b/src/hooks/project-hooks.tsx
@@ -337,7 +337,7 @@ export const ProjectProvider = ({
     try {
       setProjectEdited();
       await doAfterEditorUpdate(() => Promise.resolve());
-      
+
       // Wait for simulator to finish hiding before showing simulator.
       await hideSimulatorPromiseRef.current;
       await driverRef.current?.showSimulator();

--- a/src/hooks/project-hooks.tsx
+++ b/src/hooks/project-hooks.tsx
@@ -16,7 +16,6 @@ import {
   RefObject,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
   useRef,
 } from "react";
@@ -61,6 +60,7 @@ export type LoadAction = "replaceProject" | "replaceActions";
 interface ProjectContext {
   browserNavigationToEditor(): Promise<boolean>;
   openEditor(focusVisible?: boolean): Promise<void>;
+  hideSimulator(): Promise<void>;
   project: MakeCodeProject;
   projectEdited: boolean;
   resetProject: () => void;
@@ -311,30 +311,11 @@ export const ProjectProvider = ({
   const hideSimulatorPromiseRef = useRef<Promise<void> | null>(null);
 
   const hideSimulator = useCallback(async () => {
+    await doAfterEditorUpdate(() => Promise.resolve());
     hideSimulatorPromiseRef.current =
       driverRef.current?.hideSimulator() ?? null;
     await hideSimulatorPromiseRef.current;
-  }, [driverRef]);
-
-  const initAsyncCalled = useRef(false);
-  useEffect(() => {
-    const initAsync = async () => {
-      // Hide simulator to avoid it from making noise when editor is not visible. 
-      // Hiding it prevents it from loading.
-      if (
-        window.location.pathname === createDataSamplesPageUrl() ||
-        window.location.pathname === createTestingModelPageUrl()
-      ) {
-        initAsyncCalled.current = true;
-        await doAfterEditorUpdate(() => Promise.resolve());
-        await hideSimulator();
-      }
-    };
-    if (!initAsyncCalled.current) {
-      void initAsync();
-    }
-    return;
-  }, [doAfterEditorUpdate, driverRef, hideSimulator]);
+  }, [doAfterEditorUpdate, driverRef]);
 
   const browserNavigationToEditor = useCallback(async () => {
     try {
@@ -505,8 +486,7 @@ export const ProjectProvider = ({
       focusVisible: openedViaKeyboardRef.current,
     };
     navigate(createTestingModelPageUrl(), { state });
-    void hideSimulator();
-  }, [hideSimulator, navigate]);
+  }, [navigate]);
   const onSave = saveHex;
   const downloadActions = useDownloadActions();
   const onDownload = useCallback(
@@ -526,6 +506,7 @@ export const ProjectProvider = ({
       loadFile,
       openEditor,
       browserNavigationToEditor,
+      hideSimulator,
       project,
       projectEdited,
       resetProject,
@@ -544,6 +525,7 @@ export const ProjectProvider = ({
       loadFile,
       openEditor,
       browserNavigationToEditor,
+      hideSimulator,
       project,
       projectEdited,
       resetProject,

--- a/src/hooks/project-hooks.tsx
+++ b/src/hooks/project-hooks.tsx
@@ -319,9 +319,12 @@ export const ProjectProvider = ({
   const initAsyncCalled = useRef(false);
   useEffect(() => {
     const initAsync = async () => {
-      // Hide simulator when not on code page to avoid it from making noise
-      // when editor is not visible. Hiding it prevents it from loading.
-      if (window.location.pathname !== createCodePageUrl()) {
+      // Hide simulator to avoid it from making noise when editor is not visible. 
+      // Hiding it prevents it from loading.
+      if (
+        window.location.pathname === createDataSamplesPageUrl() ||
+        window.location.pathname === createTestingModelPageUrl()
+      ) {
         initAsyncCalled.current = true;
         await doAfterEditorUpdate(() => Promise.resolve());
         await hideSimulator();

--- a/src/pages/DataSamplesPage.tsx
+++ b/src/pages/DataSamplesPage.tsx
@@ -57,7 +57,7 @@ const DataSamplesPage = () => {
   const [selectedActionIdx, setSelectedActionIdx] = useState<number>(0);
   const navigate = useNavigate();
   const { hideSimulator } = useProject();
-
+  const initAsyncCalled = useRef(false);
   useEffect(() => {
     if (!projectSessionStorage.getProjectId() || !projectId) {
       return navigate(createHomePageUrl());
@@ -65,7 +65,10 @@ const DataSamplesPage = () => {
     // Hide simulator to avoid it from making noise. Editing data samples can
     // cause the model to get invalidated and for the simulator to restart.
     // Hiding it prevents it from loading and restarting.
-    void hideSimulator();
+    if (!initAsyncCalled.current) {
+      initAsyncCalled.current = true;
+      void hideSimulator();
+    }
   }, [navigate, projectId, hideSimulator]);
 
   const trainModelFlowStart = useStore((s) => s.trainModelFlowStart);

--- a/src/pages/DataSamplesPage.tsx
+++ b/src/pages/DataSamplesPage.tsx
@@ -47,6 +47,7 @@ import {
 } from "../store";
 import { tourElClassname } from "../tours";
 import { createHomePageUrl, createTestingModelPageUrl } from "../urls";
+import { useProject } from "../hooks/project-hooks";
 
 const DataSamplesPage = () => {
   const actions = useStore((s) => s.actions);
@@ -55,12 +56,17 @@ const DataSamplesPage = () => {
   const projectId = useStore((s) => s.id);
   const [selectedActionIdx, setSelectedActionIdx] = useState<number>(0);
   const navigate = useNavigate();
+  const { hideSimulator } = useProject();
 
   useEffect(() => {
     if (!projectSessionStorage.getProjectId() || !projectId) {
       return navigate(createHomePageUrl());
     }
-  }, [navigate, projectId]);
+    // Hide simulator to avoid it from making noise. Editing data samples can
+    // cause the model to get invalidated and for the simulator to restart.
+    // Hiding it prevents it from loading and restarting.
+    void hideSimulator();
+  }, [navigate, projectId, hideSimulator]);
 
   const trainModelFlowStart = useStore((s) => s.trainModelFlowStart);
 

--- a/src/pages/TestingModelPage.tsx
+++ b/src/pages/TestingModelPage.tsx
@@ -55,6 +55,7 @@ const TestingModelPage = () => {
     navigate(createDataSamplesPageUrl());
   }, [navigate]);
 
+  const { hideSimulator } = useProject();
   useEffect(() => {
     if (!projectSessionStorage.getProjectId()) {
       return navigate(createHomePageUrl());
@@ -62,6 +63,8 @@ const TestingModelPage = () => {
     if (!model) {
       return navigateToDataSamples();
     }
+    // Hide simulator to avoid it from making noise.
+    void hideSimulator();
     startPredicting(bufferedData);
 
     return () => {
@@ -69,6 +72,7 @@ const TestingModelPage = () => {
     };
   }, [
     bufferedData,
+    hideSimulator,
     model,
     navigate,
     navigateToDataSamples,

--- a/src/pages/TestingModelPage.tsx
+++ b/src/pages/TestingModelPage.tsx
@@ -56,6 +56,7 @@ const TestingModelPage = () => {
   }, [navigate]);
 
   const { hideSimulator } = useProject();
+  const initAsyncCalled = useRef(false);
   useEffect(() => {
     if (!projectSessionStorage.getProjectId()) {
       return navigate(createHomePageUrl());
@@ -63,8 +64,11 @@ const TestingModelPage = () => {
     if (!model) {
       return navigateToDataSamples();
     }
-    // Hide simulator to avoid it from making noise.
-    void hideSimulator();
+    if (!initAsyncCalled.current) {
+      initAsyncCalled.current = true;
+      // Hide simulator to avoid it from making noise.
+      void hideSimulator();
+    }
     startPredicting(bufferedData);
 
     return () => {


### PR DESCRIPTION
- Hides simulator when on data samples / testing model pages.
- Shows simulator when on code page.

Fixes https://github.com/microbit-foundation/ml-trainer/issues/772