### PR TITLE
Adapt data samples and testing model grid for narrow screens

### DIFF
--- a/src/components/ActionDataSamplesCard.tsx
+++ b/src/components/ActionDataSamplesCard.tsx
@@ -21,7 +21,7 @@ import {
   Text,
   VStack,
 } from "@chakra-ui/react";
-import { ReactNode, useCallback } from "react";
+import { forwardRef, ReactNode, useCallback, useRef } from "react";
 import { RiHashtag, RiTimerLine } from "react-icons/ri";
 import { FormattedMessage, useIntl } from "react-intl";
 import { DataSamplesView, ActionData, RecordingData } from "../model";
@@ -81,32 +81,33 @@ const ActionDataSamplesCard = ({
           </DataSamplesRowCard>
         )}
         {value.recordings.map((recording, idx) => (
-          <DataSamplesRowCard
+          <GraphAndDataFeaturesDataSampleCard
             onSelectRow={onSelectRow}
             selected={selected}
             key={recording.id}
+            closeButton={
+              <CloseButton
+                aria-label={intl.formatMessage(
+                  {
+                    id: "delete-recording-aria",
+                  },
+                  {
+                    sample: value.recordings.length - idx,
+                    numSamples: value.recordings.length,
+                    action: value.name,
+                  }
+                )}
+                position="absolute"
+                top={-2}
+                right={-2}
+                rounded="full"
+                bgColor="white"
+                borderColor="blackAlpha.500"
+                boxShadow="sm"
+                onClick={() => deleteActionRecording(value.id, recording.id)}
+              />
+            }
           >
-            <CloseButton
-              aria-label={intl.formatMessage(
-                {
-                  id: "delete-recording-aria",
-                },
-                {
-                  sample: value.recordings.length - idx,
-                  numSamples: value.recordings.length,
-                  action: value.name,
-                }
-              )}
-              position="absolute"
-              top={-2}
-              right={-2}
-              rounded="full"
-              bgColor="white"
-              zIndex={1}
-              borderColor="blackAlpha.500"
-              boxShadow="sm"
-              onClick={() => deleteActionRecording(value.id, recording.id)}
-            />
             <DataSample
               recording={recording}
               numRecordings={value.recordings.length}
@@ -119,7 +120,7 @@ const ActionDataSamplesCard = ({
               view={view}
               hasClose={false}
             />
-          </DataSamplesRowCard>
+          </GraphAndDataFeaturesDataSampleCard>
         ))}
       </HStack>
     );
@@ -163,36 +164,57 @@ const ActionDataSamplesCard = ({
   );
 };
 
+interface GraphAndDataFeaturesDataSampleCardProps
+  extends DataSamplesRowCardProps {
+  children: ReactNode;
+  closeButton: ReactNode;
+}
+
+const GraphAndDataFeaturesDataSampleCard = ({
+  children,
+  closeButton,
+  ...props
+}: GraphAndDataFeaturesDataSampleCardProps) => {
+  const ref = useRef<HTMLDivElement>(null);
+  return (
+    <DataSamplesRowCard {...props} ref={ref}>
+      <Portal containerRef={ref}>{closeButton}</Portal>
+      {children}
+    </DataSamplesRowCard>
+  );
+};
+
 interface DataSamplesRowCardProps extends CardProps {
   selected: boolean;
   onSelectRow?: () => void;
   children: ReactNode;
 }
 
-const DataSamplesRowCard = ({
-  selected,
-  onSelectRow,
-  children,
-  ...rest
-}: DataSamplesRowCardProps) => {
-  return (
-    <Card
-      onClick={onSelectRow}
-      p={2}
-      h="120px"
-      display="flex"
-      flexDirection="row"
-      width="fit-content"
-      borderColor={selected ? "brand.500" : "transparent"}
-      borderWidth={1}
-      {...rest}
-    >
-      <CardBody display="flex" flexDirection="row" p={1} gap={3}>
-        {children}
-      </CardBody>
-    </Card>
-  );
-};
+const DataSamplesRowCard = forwardRef<HTMLDivElement, DataSamplesRowCardProps>(
+  function DataSamplesRowCard(
+    { selected, onSelectRow, children, ...rest }: DataSamplesRowCardProps,
+    ref
+  ) {
+    return (
+      <Card
+        ref={ref}
+        onClick={onSelectRow}
+        p={2}
+        h="120px"
+        display="flex"
+        flexDirection="row"
+        width="fit-content"
+        borderColor={selected ? "brand.500" : "transparent"}
+        borderWidth={1}
+        {...rest}
+      >
+        <CardBody display="flex" flexDirection="row" p={1} gap={3}>
+          {children}
+        </CardBody>
+      </Card>
+    );
+  }
+);
 
 interface RecordingAreaProps extends BoxProps {
   action: ActionData;
@@ -328,6 +350,7 @@ const DataSample = ({
   view: DataSamplesView;
   hasClose?: boolean;
 }) => {
+  const ref = useRef<HTMLDivElement>(null);
   const hasGraph =
     view === DataSamplesView.Graph ||
     view === DataSamplesView.GraphAndDataFeatures;
@@ -339,26 +362,27 @@ const DataSample = ({
     onDelete(actionId, recording.id);
   }, [actionId, onDelete, recording.id]);
   return (
-    <HStack key={recording.id} position="relative">
+    <HStack key={recording.id} position="relative" ref={ref}>
       {hasClose && (
-        <CloseButton
-          position="absolute"
-          top={0}
-          right={0}
-          zIndex={1}
-          size="sm"
-          aria-label={intl.formatMessage(
-            {
-              id: "delete-recording-aria",
-            },
-            {
-              sample: numRecordings - recordingIndex,
-              numSamples: numRecordings,
-              action: actionName,
-            }
-          )}
-          onClick={handleDelete}
-        />
+        <Portal containerRef={ref}>
+          <CloseButton
+            position="absolute"
+            top={0}
+            right={2}
+            size="sm"
+            aria-label={intl.formatMessage(
+              {
+                id: "delete-recording-aria",
+              },
+              {
+                sample: numRecordings - recordingIndex,
+                numSamples: numRecordings,
+                action: actionName,
+              }
+            )}
+            onClick={handleDelete}
+          />
+        </Portal>
       )}
       {hasGraph && (
         <RecordingGraph

--- a/src/components/CodeViewCard.tsx
+++ b/src/components/CodeViewCard.tsx
@@ -54,7 +54,6 @@ const CodeViewCard = ({ project, parentRef }: CodeViewCardProps) => {
       alignSelf="start"
       display="flex"
       flexDirection="column"
-      py={2}
       h="full"
       w="full"
       borderColor="brand.500"

--- a/src/components/CodeViewCard.tsx
+++ b/src/components/CodeViewCard.tsx
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { Box, Card, SkeletonText, VStack } from "@chakra-ui/react";
+import { Box, Card, CardProps, SkeletonText, VStack } from "@chakra-ui/react";
 import {
   BlockLayout,
   MakeCodeBlocksRendering,
@@ -12,12 +12,12 @@ import {
 import { memo, useLayoutEffect, useRef, useState } from "react";
 import { tourElClassname } from "../tours";
 
-interface CodeViewCardProps {
+interface CodeViewCardProps extends CardProps {
   project: MakeCodeProject;
   parentRef: React.RefObject<HTMLDivElement>;
 }
 
-const CodeViewCard = ({ project, parentRef }: CodeViewCardProps) => {
+const CodeViewCard = ({ project, parentRef, ...props }: CodeViewCardProps) => {
   // This is used to set the tour cutout as the card can be taller than
   // the parent in a scrollable area.
   const [observableHeight, setObservableHeight] = useState<number | string>(
@@ -66,6 +66,7 @@ const CodeViewCard = ({ project, parentRef }: CodeViewCardProps) => {
         p={5}
         objectFit="contain"
         position="relative"
+        {...props}
       >
         <Box
           position="absolute"

--- a/src/components/CodeViewDefaultBlockCard.tsx
+++ b/src/components/CodeViewDefaultBlockCard.tsx
@@ -3,18 +3,19 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { Card } from "@chakra-ui/react";
+import { Card, CardProps } from "@chakra-ui/react";
 import { memo } from "react";
 import { ActionData } from "../model";
 import { tourElClassname } from "../tours";
 import CodeViewDefaultBlock from "./CodeViewDefaultBlock";
 
-interface CodeViewDefaultBlockCardProps {
+interface CodeViewDefaultBlockCardProps extends CardProps {
   action: ActionData;
 }
 
 const CodeViewDefaultBlockCard = ({
   action,
+  ...props
 }: CodeViewDefaultBlockCardProps) => {
   return (
     <Card
@@ -22,10 +23,10 @@ const CodeViewDefaultBlockCard = ({
       h="120px"
       display="flex"
       borderColor="brand.500"
-      minW="400px"
       width="fit-content"
       justifyContent="center"
       className={tourElClassname.makeCodeCodeView}
+      {...props}
     >
       <CodeViewDefaultBlock actionName={action.name} icon={action.icon} />
     </Card>

--- a/src/components/CodeViewDefaultBlockCard.tsx
+++ b/src/components/CodeViewDefaultBlockCard.tsx
@@ -23,7 +23,7 @@ const CodeViewDefaultBlockCard = ({
       h="120px"
       display="flex"
       borderColor="brand.500"
-      width="fit-content"
+      maxW="100%"
       justifyContent="center"
       className={tourElClassname.makeCodeCodeView}
       {...props}

--- a/src/components/DataSamplesTable.tsx
+++ b/src/components/DataSamplesTable.tsx
@@ -4,7 +4,7 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { Grid, GridProps, HStack, Text } from "@chakra-ui/react";
+import { Grid, GridProps, Text } from "@chakra-ui/react";
 import { ButtonData } from "@microbit/microbit-connection";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -36,20 +36,8 @@ const gridCommonProps: Partial<GridProps> = {
 };
 
 const headings: GridColumnHeadingItemProps[] = [
-  {
-    titleId: "action-label",
-    descriptionId: "action-tooltip",
-  },
-  {
-    titleId: "data-samples-label",
-    descriptionId: "data-samples-tooltip",
-    itemsRight: (
-      <HStack>
-        <ShowGraphsCheckbox />
-        <DataSamplesMenu />
-      </HStack>
-    ),
-  },
+  { titleId: "action-label", descriptionId: "action-tooltip" },
+  { titleId: "data-samples-label", descriptionId: "data-samples-tooltip" },
 ];
 
 interface DataSamplesTableProps {
@@ -249,6 +237,13 @@ const DataSamplesTable = ({
         top={0}
         {...gridCommonProps}
         headings={headings}
+        w={gridRef.current?.clientWidth}
+        rightItems={
+          <>
+            <ShowGraphsCheckbox />
+            <DataSamplesMenu />
+          </>
+        }
       />
       <Grid
         {...gridCommonProps}
@@ -256,7 +251,6 @@ const DataSamplesTable = ({
         pb={gridPadding > 0 ? `${gridPadding}px` : 2}
         alignItems="start"
         autoRows="max-content"
-        overflow="auto"
         flexGrow={1}
         h={0}
         ref={(node) => {

--- a/src/components/DataSamplesTable.tsx
+++ b/src/components/DataSamplesTable.tsx
@@ -233,8 +233,6 @@ const DataSamplesTable = ({
         </>
       )}
       <HeadingGrid
-        position="sticky"
-        top={0}
         {...gridCommonProps}
         headings={headings}
         w={gridRef.current?.clientWidth}

--- a/src/components/DataSamplesTable.tsx
+++ b/src/components/DataSamplesTable.tsx
@@ -241,10 +241,7 @@ const DataSamplesTable = ({
           />
         </>
       )}
-      <HeadingGrid
-        {...gridCommonProps}
-        headings={headings}
-      />
+      <HeadingGrid {...gridCommonProps} headings={headings} />
       <Grid
         {...gridCommonProps}
         py={2}

--- a/src/components/DataSamplesTable.tsx
+++ b/src/components/DataSamplesTable.tsx
@@ -244,7 +244,6 @@ const DataSamplesTable = ({
       <HeadingGrid
         {...gridCommonProps}
         headings={headings}
-        w={gridRef.current?.clientWidth}
       />
       <Grid
         {...gridCommonProps}

--- a/src/components/DataSamplesTable.tsx
+++ b/src/components/DataSamplesTable.tsx
@@ -4,7 +4,7 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { Grid, GridProps, Text } from "@chakra-ui/react";
+import { Grid, GridProps, HStack, Text } from "@chakra-ui/react";
 import { ButtonData } from "@microbit/microbit-connection";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -37,7 +37,16 @@ const gridCommonProps: Partial<GridProps> = {
 
 const headings: GridColumnHeadingItemProps[] = [
   { titleId: "action-label", descriptionId: "action-tooltip" },
-  { titleId: "data-samples-label", descriptionId: "data-samples-tooltip" },
+  {
+    titleId: "data-samples-label",
+    descriptionId: "data-samples-tooltip",
+    itemsRight: (
+      <HStack position="sticky" right={0} backgroundColor="whitesmoke" pl={2}>
+        <ShowGraphsCheckbox />
+        <DataSamplesMenu />
+      </HStack>
+    ),
+  },
 ];
 
 interface DataSamplesTableProps {
@@ -236,12 +245,6 @@ const DataSamplesTable = ({
         {...gridCommonProps}
         headings={headings}
         w={gridRef.current?.clientWidth}
-        rightItems={
-          <>
-            <ShowGraphsCheckbox />
-            <DataSamplesMenu />
-          </>
-        }
       />
       <Grid
         {...gridCommonProps}

--- a/src/components/DataSamplesTable.tsx
+++ b/src/components/DataSamplesTable.tsx
@@ -249,7 +249,7 @@ const DataSamplesTable = ({
         alignItems="start"
         autoRows="max-content"
         flexGrow={1}
-        h={0}
+        h="fit-content"
         ref={(node) => {
           arrowNavRef(node);
           gridRef.current = node;

--- a/src/components/HeadingGrid.tsx
+++ b/src/components/HeadingGrid.tsx
@@ -10,7 +10,7 @@ import { ReactNode } from "react";
 
 interface HeadingGridProps extends GridProps {
   headings: GridColumnHeadingItemProps[];
-  rightItems: ReactNode;
+  rightItems?: ReactNode;
 }
 export const headingGridCommonProps: GridProps = {
   height: "3.25rem",
@@ -37,15 +37,17 @@ const HeadingGrid = ({ headings, rightItems, ...props }: HeadingGridProps) => {
           <GridColumnHeadingItem {...props} key={idx} />
         ))}
       </Grid>
-      <HStack
-        position="absolute"
-        right={0}
-        pl={2}
-        backgroundColor="whitesmoke"
-        {...headingGridCommonProps}
-      >
-        {rightItems}
-      </HStack>
+      {rightItems && (
+        <HStack
+          position="absolute"
+          right={0}
+          pl={2}
+          backgroundColor="whitesmoke"
+          {...headingGridCommonProps}
+        >
+          {rightItems}
+        </HStack>
+      )}
     </>
   );
 };

--- a/src/components/HeadingGrid.tsx
+++ b/src/components/HeadingGrid.tsx
@@ -10,22 +10,43 @@ import { ReactNode } from "react";
 
 interface HeadingGridProps extends GridProps {
   headings: GridColumnHeadingItemProps[];
+  rightItems: ReactNode;
 }
-
-const HeadingGrid = ({ headings, ...props }: HeadingGridProps) => {
+export const headingGridCommonProps: GridProps = {
+  height: "3.25rem",
+  borderBottomWidth: 3,
+  borderColor: "gray.200",
+  zIndex: 1,
+};
+const HeadingGrid = ({ headings, rightItems, ...props }: HeadingGridProps) => {
   return (
-    <Grid
-      flexShrink={0}
-      h="3.25rem"
-      alignItems="center"
-      borderBottomWidth={3}
-      borderColor="gray.200"
-      {...props}
-    >
-      {headings.map((props, idx) => (
-        <GridColumnHeadingItem {...props} key={idx} />
-      ))}
-    </Grid>
+    <>
+      <HStack
+        position="absolute"
+        w="100%"
+        backgroundColor="whitesmoke"
+        {...headingGridCommonProps}
+      />
+      <Grid
+        flexShrink={0}
+        alignItems="center"
+        {...headingGridCommonProps}
+        {...props}
+      >
+        {headings.map((props, idx) => (
+          <GridColumnHeadingItem {...props} key={idx} />
+        ))}
+      </Grid>
+      <HStack
+        position="absolute"
+        right={0}
+        pl={2}
+        backgroundColor="whitesmoke"
+        {...headingGridCommonProps}
+      >
+        {rightItems}
+      </HStack>
+    </>
   );
 };
 

--- a/src/components/HeadingGrid.tsx
+++ b/src/components/HeadingGrid.tsx
@@ -30,6 +30,8 @@ const HeadingGrid = ({ headings, rightItems, ...props }: HeadingGridProps) => {
       <Grid
         flexShrink={0}
         alignItems="center"
+        position="sticky"
+        top={0}
         {...headingGridCommonProps}
         {...props}
       >

--- a/src/components/HeadingGrid.tsx
+++ b/src/components/HeadingGrid.tsx
@@ -10,47 +10,25 @@ import { ReactNode } from "react";
 
 interface HeadingGridProps extends GridProps {
   headings: GridColumnHeadingItemProps[];
-  rightItems?: ReactNode;
 }
-export const headingGridCommonProps: GridProps = {
-  height: "3.25rem",
-  borderBottomWidth: 3,
-  borderColor: "gray.200",
-  zIndex: 1,
-};
-const HeadingGrid = ({ headings, rightItems, ...props }: HeadingGridProps) => {
+const HeadingGrid = ({ headings, ...props }: HeadingGridProps) => {
   return (
-    <>
-      <HStack
-        position="absolute"
-        w="100%"
-        backgroundColor="whitesmoke"
-        {...headingGridCommonProps}
-      />
-      <Grid
-        flexShrink={0}
-        alignItems="center"
-        position="sticky"
-        top={0}
-        {...headingGridCommonProps}
-        {...props}
-      >
-        {headings.map((props, idx) => (
-          <GridColumnHeadingItem {...props} key={idx} />
-        ))}
-      </Grid>
-      {rightItems && (
-        <HStack
-          position="absolute"
-          right={0}
-          pl={2}
-          backgroundColor="whitesmoke"
-          {...headingGridCommonProps}
-        >
-          {rightItems}
-        </HStack>
-      )}
-    </>
+    <Grid
+      flexShrink={0}
+      alignItems="center"
+      position="sticky"
+      top={0}
+      height="3.25rem"
+      borderBottomWidth={3}
+      borderColor="gray.200"
+      zIndex={1}
+      backgroundColor="whitesmoke"
+      {...props}
+    >
+      {headings.map((props, idx) => (
+        <GridColumnHeadingItem {...props} key={idx} />
+      ))}
+    </Grid>
   );
 };
 

--- a/src/components/TestingModelTable.tsx
+++ b/src/components/TestingModelTable.tsx
@@ -4,15 +4,7 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import {
-  Box,
-  Grid,
-  GridItem,
-  GridProps,
-  HStack,
-  Icon,
-  VStack,
-} from "@chakra-ui/react";
+import { Box, Grid, GridItem, GridProps, Icon, VStack } from "@chakra-ui/react";
 import { MakeCodeRenderBlocksProvider } from "@microbit/makecode-embed/react";
 import { useRef } from "react";
 import { RiArrowRightLine } from "react-icons/ri";
@@ -28,8 +20,10 @@ import CodeViewCard from "./CodeViewCard";
 import CodeViewDefaultBlockCard from "./CodeViewDefaultBlockCard";
 import HeadingGrid from "./HeadingGrid";
 
+const blockCardMinWidth = "400px";
+
 const gridCommonProps: Partial<GridProps> = {
-  gridTemplateColumns: "290px 360px 40px auto",
+  gridTemplateColumns: "290px 360px 40px minmax(400px, 1fr)",
   gap: 3,
   w: "100%",
 };
@@ -70,69 +64,81 @@ const TestingModelTable = () => {
         justifyContent="start"
         flexGrow={1}
         alignItems="start"
-        overflow="auto"
         flexShrink={1}
         ref={scrollableAreaRef}
       >
-        <HStack gap={0} h="min-content" w="full">
-          <Grid
-            {...gridCommonProps}
-            {...(projectEdited ? { w: "fit-content", pr: 0 } : {})}
-            py={2}
-            autoRows="max-content"
-            h="fit-content"
-            alignSelf="start"
-          >
-            {actions.map((action) => {
-              const { requiredConfidence: threshold } = action;
-              return (
-                <Box
-                  key={action.id}
-                  role="region"
-                  aria-label={intl.formatMessage(
-                    {
-                      id: "action-region",
-                    },
-                    { action: action.name }
-                  )}
-                  display="contents"
-                >
-                  <GridItem>
-                    <ActionNameCard
-                      value={action}
-                      viewMode={ActionCardNameViewMode.ReadOnly}
-                      disabled={!isConnected}
+        <Grid
+          {...gridCommonProps}
+          py={2}
+          autoRows="max-content"
+          h="fit-content"
+          alignSelf="start"
+        >
+          {actions.map((action, actionIdx) => {
+            const { requiredConfidence: threshold } = action;
+            return (
+              <Box
+                key={action.id}
+                role="region"
+                aria-label={intl.formatMessage(
+                  {
+                    id: "action-region",
+                  },
+                  { action: action.name }
+                )}
+                display="contents"
+              >
+                <GridItem>
+                  <ActionNameCard
+                    value={action}
+                    viewMode={ActionCardNameViewMode.ReadOnly}
+                    disabled={!isConnected}
+                  />
+                </GridItem>
+                <GridItem>
+                  <ActionCertaintyCard
+                    actionName={action.name}
+                    actionId={action.id}
+                    onThresholdChange={(val) =>
+                      setRequiredConfidence(action.id, val)
+                    }
+                    requiredConfidence={
+                      threshold ?? mlSettings.defaultRequiredConfidence
+                    }
+                    disabled={!isConnected}
+                  />
+                </GridItem>
+                <VStack justifyContent="center" h="full">
+                  <Icon as={RiArrowRightLine} boxSize={10} color="gray.600" />
+                </VStack>
+                {!projectEdited && (
+                  <GridItem position="relative">
+                    <CodeViewDefaultBlockCard
+                      action={action}
+                      minW={blockCardMinWidth}
+                      position="absolute"
                     />
                   </GridItem>
-                  <GridItem>
-                    <ActionCertaintyCard
-                      actionName={action.name}
-                      actionId={action.id}
-                      onThresholdChange={(val) =>
-                        setRequiredConfidence(action.id, val)
-                      }
-                      requiredConfidence={
-                        threshold ?? mlSettings.defaultRequiredConfidence
-                      }
-                      disabled={!isConnected}
+                )}
+
+                {projectEdited && actionIdx === 0 && (
+                  <GridItem
+                    rowSpan={actions.length}
+                    minW={0}
+                    h="100%"
+                    maxW="100%"
+                    position="relative"
+                  >
+                    <CodeViewCard
+                      parentRef={scrollableAreaRef}
+                      project={project}
                     />
                   </GridItem>
-                  <VStack justifyContent="center" h="full">
-                    <Icon as={RiArrowRightLine} boxSize={10} color="gray.600" />
-                  </VStack>
-                  <GridItem>
-                    {!projectEdited && (
-                      <CodeViewDefaultBlockCard action={action} />
-                    )}
-                  </GridItem>
-                </Box>
-              );
-            })}
-          </Grid>
-          {projectEdited && (
-            <CodeViewCard parentRef={scrollableAreaRef} project={project} />
-          )}
-        </HStack>
+                )}
+              </Box>
+            );
+          })}
+        </Grid>
       </VStack>
     </MakeCodeRenderBlocksProvider>
   );

--- a/src/components/TestingModelTable.tsx
+++ b/src/components/TestingModelTable.tsx
@@ -4,9 +4,17 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { Box, Grid, GridItem, GridProps, Icon, VStack } from "@chakra-ui/react";
+import {
+  Box,
+  Flex,
+  Grid,
+  GridItem,
+  GridProps,
+  Icon,
+  VStack,
+} from "@chakra-ui/react";
 import { MakeCodeRenderBlocksProvider } from "@microbit/makecode-embed/react";
-import { useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { RiArrowRightLine } from "react-icons/ri";
 import { useIntl } from "react-intl";
 import { useDataConnected } from "../data-connection-flow";
@@ -56,95 +64,126 @@ const TestingModelTable = () => {
   const gridAreaRef = useRef<HTMLDivElement>(null);
   const intl = useIntl();
 
+  const scrollableAreaRef = useRef<HTMLDivElement>(null);
+  const [scrollbarWidth, setScrollbarWidth] = useState<number>(0);
+  useEffect(() => {
+    const scrollEl = scrollableAreaRef.current;
+    if (!scrollEl) {
+      return;
+    }
+    const measure = () => {
+      const hasScrollbar = scrollEl.scrollHeight > scrollEl.clientHeight;
+      const scrollbarWidth = scrollEl.offsetWidth - scrollEl.clientWidth;
+      setScrollbarWidth(hasScrollbar ? scrollbarWidth : 0);
+    };
+
+    measure(); // run on mount.
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, []);
+
   return (
     <MakeCodeRenderBlocksProvider key={makeCodeLang} lang={makeCodeLang}>
-      <HeadingGrid {...gridCommonProps} px={5} headings={headings} />
-      <VStack
-        w="100vw"
-        h={0}
-        justifyContent="start"
+      <Flex
         flexGrow={1}
-        alignItems="start"
-        flexShrink={1}
-        ref={gridAreaRef}
+        flexDir="column"
+        overflow="auto"
+        ref={scrollableAreaRef}
       >
-        <Grid
-          {...gridCommonProps}
-          py={2}
-          px={5}
-          autoRows="max-content"
-          h="fit-content"
-          alignSelf="start"
-        >
-          {actions.map((action, actionIdx) => {
-            const { requiredConfidence: threshold } = action;
-            return (
-              <Box
-                key={action.id}
-                role="region"
-                aria-label={intl.formatMessage(
-                  {
-                    id: "action-region",
-                  },
-                  { action: action.name }
-                )}
-                display="contents"
-              >
-                <GridItem>
-                  <ActionNameCard
-                    value={action}
-                    viewMode={ActionCardNameViewMode.ReadOnly}
-                    disabled={!isConnected}
-                  />
-                </GridItem>
-                <GridItem>
-                  <ActionCertaintyCard
-                    actionName={action.name}
-                    actionId={action.id}
-                    onThresholdChange={(val) =>
-                      setRequiredConfidence(action.id, val)
-                    }
-                    requiredConfidence={
-                      threshold ?? mlSettings.defaultRequiredConfidence
-                    }
-                    disabled={!isConnected}
-                  />
-                </GridItem>
-                <VStack justifyContent="center" h="full">
-                  <Icon as={RiArrowRightLine} boxSize={10} color="gray.600" />
-                </VStack>
-                {!projectEdited && (
-                  <GridItem position="relative">
-                    <CodeViewDefaultBlockCard
-                      action={action}
-                      minW={blockCardMinWidth}
-                      position="absolute"
-                    />
-                  </GridItem>
-                )}
-
-                {projectEdited && actionIdx === 0 && (
-                  <GridItem
-                    // Extra row to extend beyond the grid.
-                    rowSpan={actions.length + 1}
-                    minW={0}
-                    h="100%"
-                    maxW="100%"
-                    position="relative"
+        <Flex flexGrow={1} flexDir="column" w="max-content">
+          <HeadingGrid {...gridCommonProps} px={5} headings={headings} />
+          <VStack
+            w={`calc(100vw - ${scrollbarWidth}px)`}
+            h={0}
+            justifyContent="start"
+            flexGrow={1}
+            alignItems="start"
+            flexShrink={1}
+            ref={gridAreaRef}
+          >
+            <Grid
+              {...gridCommonProps}
+              py={2}
+              px={5}
+              autoRows="max-content"
+              h="fit-content"
+              alignSelf="start"
+            >
+              {actions.map((action, actionIdx) => {
+                const { requiredConfidence: threshold } = action;
+                return (
+                  <Box
+                    key={action.id}
+                    role="region"
+                    aria-label={intl.formatMessage(
+                      {
+                        id: "action-region",
+                      },
+                      { action: action.name }
+                    )}
+                    display="contents"
                   >
-                    <CodeViewCard
-                      parentRef={gridAreaRef}
-                      project={project}
-                      // To remove extra gap for extra row.
-                      mb={gap}
-                    />
-                  </GridItem>
-                )}
-              </Box>
-            );
-          })}
-        </Grid>
-      </VStack>
+                    <GridItem>
+                      <ActionNameCard
+                        value={action}
+                        viewMode={ActionCardNameViewMode.ReadOnly}
+                        disabled={!isConnected}
+                      />
+                    </GridItem>
+                    <GridItem>
+                      <ActionCertaintyCard
+                        actionName={action.name}
+                        actionId={action.id}
+                        onThresholdChange={(val) =>
+                          setRequiredConfidence(action.id, val)
+                        }
+                        requiredConfidence={
+                          threshold ?? mlSettings.defaultRequiredConfidence
+                        }
+                        disabled={!isConnected}
+                      />
+                    </GridItem>
+                    <VStack justifyContent="center" h="full">
+                      <Icon
+                        as={RiArrowRightLine}
+                        boxSize={10}
+                        color="gray.600"
+                      />
+                    </VStack>
+                    {!projectEdited && (
+                      <GridItem position="relative">
+                        <CodeViewDefaultBlockCard
+                          action={action}
+                          minW={blockCardMinWidth}
+                          position="absolute"
+                        />
+                      </GridItem>
+                    )}
+
+                    {projectEdited && actionIdx === 0 && (
+                      <GridItem
+                        // Extra row to extend beyond the grid.
+                        rowSpan={actions.length + 1}
+                        minW={0}
+                        h="100%"
+                        maxW="100%"
+                        position="relative"
+                      >
+                        <CodeViewCard
+                          parentRef={gridAreaRef}
+                          project={project}
+                          // To remove extra gap for extra row.
+                          mb={gap}
+                        />
+                      </GridItem>
+                    )}
+                  </Box>
+                );
+              })}
+            </Grid>
+          </VStack>
+        </Flex>
+      </Flex>
     </MakeCodeRenderBlocksProvider>
   );
 };

--- a/src/components/TestingModelTable.tsx
+++ b/src/components/TestingModelTable.tsx
@@ -151,10 +151,9 @@ const TestingModelTable = () => {
                       />
                     </VStack>
                     {!projectEdited && (
-                      <GridItem position="relative">
+                      <GridItem position="relative" w="100%">
                         <CodeViewDefaultBlockCard
                           action={action}
-                          minW={blockCardMinWidth}
                           position="absolute"
                         />
                       </GridItem>

--- a/src/components/TestingModelTable.tsx
+++ b/src/components/TestingModelTable.tsx
@@ -24,7 +24,7 @@ const blockCardMinWidth = "400px";
 const gap = 3;
 
 const gridCommonProps: Partial<GridProps> = {
-  gridTemplateColumns: "290px 360px 40px minmax(400px, 1fr)",
+  gridTemplateColumns: `290px 360px 40px minmax(${blockCardMinWidth}, 1fr)`,
   gap,
   w: "100%",
 };
@@ -53,24 +53,25 @@ const TestingModelTable = () => {
   const isConnected = useDataConnected();
   const [{ languageId }] = useSettings();
   const makeCodeLang = getMakeCodeLang(languageId);
-  const scrollableAreaRef = useRef<HTMLDivElement>(null);
+  const gridAreaRef = useRef<HTMLDivElement>(null);
   const intl = useIntl();
+
   return (
     <MakeCodeRenderBlocksProvider key={makeCodeLang} lang={makeCodeLang}>
       <HeadingGrid {...gridCommonProps} px={5} headings={headings} />
       <VStack
-        px={5}
-        w="full"
+        w="100vw"
         h={0}
         justifyContent="start"
         flexGrow={1}
         alignItems="start"
         flexShrink={1}
-        ref={scrollableAreaRef}
+        ref={gridAreaRef}
       >
         <Grid
           {...gridCommonProps}
           py={2}
+          px={5}
           autoRows="max-content"
           h="fit-content"
           alignSelf="start"
@@ -132,7 +133,7 @@ const TestingModelTable = () => {
                     position="relative"
                   >
                     <CodeViewCard
-                      parentRef={scrollableAreaRef}
+                      parentRef={gridAreaRef}
                       project={project}
                       // To remove extra gap for extra row.
                       mb={gap}

--- a/src/components/TestingModelTable.tsx
+++ b/src/components/TestingModelTable.tsx
@@ -14,7 +14,7 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { MakeCodeRenderBlocksProvider } from "@microbit/makecode-embed/react";
-import { useEffect, useRef, useState } from "react";
+import { useRef } from "react";
 import { RiArrowRightLine } from "react-icons/ri";
 import { useIntl } from "react-intl";
 import { useDataConnected } from "../data-connection-flow";
@@ -27,6 +27,7 @@ import ActionNameCard, { ActionCardNameViewMode } from "./ActionNameCard";
 import CodeViewCard from "./CodeViewCard";
 import CodeViewDefaultBlockCard from "./CodeViewDefaultBlockCard";
 import HeadingGrid from "./HeadingGrid";
+import { useResizeObserverContentRect } from "../hooks/use-resize-observer";
 
 const blockCardMinWidth = "400px";
 const gap = 3;
@@ -65,22 +66,11 @@ const TestingModelTable = () => {
   const intl = useIntl();
 
   const scrollableAreaRef = useRef<HTMLDivElement>(null);
-  const [scrollbarWidth, setScrollbarWidth] = useState<number>(0);
-  useEffect(() => {
-    const scrollEl = scrollableAreaRef.current;
-    if (!scrollEl) {
-      return;
-    }
-    const measure = () => {
-      const hasScrollbar = scrollEl.scrollHeight > scrollEl.clientHeight;
-      const scrollbarWidth = scrollEl.offsetWidth - scrollEl.clientWidth;
-      setScrollbarWidth(hasScrollbar ? scrollbarWidth : 0);
-    };
-
-    measure(); // run on mount.
-    window.addEventListener("resize", measure);
-    return () => window.removeEventListener("resize", measure);
-  }, []);
+  const contentRect = useResizeObserverContentRect(scrollableAreaRef);
+  const scrollbarWidth = scrollableAreaRef.current
+    ? scrollableAreaRef.current.offsetWidth -
+      (contentRect?.width ?? scrollableAreaRef.current.offsetWidth)
+    : 0;
 
   return (
     <MakeCodeRenderBlocksProvider key={makeCodeLang} lang={makeCodeLang}>

--- a/src/components/TestingModelTable.tsx
+++ b/src/components/TestingModelTable.tsx
@@ -21,10 +21,11 @@ import CodeViewDefaultBlockCard from "./CodeViewDefaultBlockCard";
 import HeadingGrid from "./HeadingGrid";
 
 const blockCardMinWidth = "400px";
+const gap = 3;
 
 const gridCommonProps: Partial<GridProps> = {
   gridTemplateColumns: "290px 360px 40px minmax(400px, 1fr)",
-  gap: 3,
+  gap,
   w: "100%",
 };
 
@@ -123,7 +124,8 @@ const TestingModelTable = () => {
 
                 {projectEdited && actionIdx === 0 && (
                   <GridItem
-                    rowSpan={actions.length}
+                    // Extra row to extend beyond the grid.
+                    rowSpan={actions.length + 1}
                     minW={0}
                     h="100%"
                     maxW="100%"
@@ -132,6 +134,8 @@ const TestingModelTable = () => {
                     <CodeViewCard
                       parentRef={scrollableAreaRef}
                       project={project}
+                      // To remove extra gap for extra row.
+                      mb={gap}
                     />
                   </GridItem>
                 )}

--- a/src/hooks/use-resize-observer.ts
+++ b/src/hooks/use-resize-observer.ts
@@ -1,0 +1,30 @@
+/**
+ * (c) 2026, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { RefObject, useEffect, useState } from "react";
+
+export const useResizeObserverContentRect = (
+  ref: RefObject<HTMLElement>
+): DOMRectReadOnly | undefined => {
+  const [contentRect, setContentRect] = useState<DOMRectReadOnly | undefined>(
+    undefined
+  );
+  useEffect(() => {
+    const resizeObserver = new ResizeObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.contentRect) {
+          setContentRect(entry.contentRect);
+        }
+      });
+    });
+    if (ref.current) {
+      resizeObserver.observe(ref.current);
+    }
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [ref]);
+  return contentRect;
+};

--- a/src/pages/DataSamplesPage.tsx
+++ b/src/pages/DataSamplesPage.tsx
@@ -288,7 +288,13 @@ const DataSamplesPage = () => {
         }
         backLabelId="home-action"
       >
-        <Flex as="main" flexGrow={1} flexDir="column" ref={pageRef}>
+        <Flex
+          as="main"
+          flexGrow={1}
+          flexDir="column"
+          ref={pageRef}
+          w="max-content"
+        >
           <DataSamplesTable
             selectedActionIdx={selectedActionIdx}
             setSelectedActionIdx={setSelectedActionIdx}

--- a/src/pages/DataSamplesPage.tsx
+++ b/src/pages/DataSamplesPage.tsx
@@ -294,6 +294,7 @@ const DataSamplesPage = () => {
           flexDir="column"
           ref={pageRef}
           w="max-content"
+          minWidth="100%"
         >
           <DataSamplesTable
             selectedActionIdx={selectedActionIdx}

--- a/src/pages/TestingModelPage.tsx
+++ b/src/pages/TestingModelPage.tsx
@@ -200,7 +200,7 @@ const TestingModelPage = () => {
         onNextLoading={editorLoading}
       />
       <Flex as="main" flexGrow={1} flexDir="column">
-            <TestingModelTable />
+        <TestingModelTable />
       </Flex>
     </DefaultPageLayout>
   ) : (

--- a/src/pages/TestingModelPage.tsx
+++ b/src/pages/TestingModelPage.tsx
@@ -199,7 +199,7 @@ const TestingModelPage = () => {
         stage="openEditor"
         onNextLoading={editorLoading}
       />
-      <Flex as="main" flexGrow={1} flexDir="column">
+      <Flex as="main" flexGrow={1} flexDir="column" w="max-content">
         <TestingModelTable />
       </Flex>
     </DefaultPageLayout>

--- a/src/pages/TestingModelPage.tsx
+++ b/src/pages/TestingModelPage.tsx
@@ -199,8 +199,8 @@ const TestingModelPage = () => {
         stage="openEditor"
         onNextLoading={editorLoading}
       />
-      <Flex as="main" flexGrow={1} flexDir="column" w="max-content">
-        <TestingModelTable />
+      <Flex as="main" flexGrow={1} flexDir="column">
+            <TestingModelTable />
       </Flex>
     </DefaultPageLayout>
   ) : (

--- a/src/pages/TourOverlay.tsx
+++ b/src/pages/TourOverlay.tsx
@@ -70,6 +70,8 @@ interface Rect {
 const useRects = (ref: RefObject<HTMLElement | undefined>): Rect[] => {
   const [rects, setRects] = useState<Rect[]>([]);
   useLayoutEffect(() => {
+    // Scroll ref element into view before calculating rect.
+    ref.current?.scrollIntoView({ behavior: "instant", inline: "nearest" });
     const resizeObserver = new ResizeObserver(() => {
       if (ref.current) {
         setRects([


### PR DESCRIPTION
Fixes https://github.com/microbit-foundation/ml-trainer/issues/853

- Horizontally scroll column headings with the content, but stick them on the top when vertically scrolled. 
- Add min width for testing model page code card area so that the code inside is visible.
- Ensure there's a gap around the grid content and the scroll area in smaller screen sizes.
- Used portal for close buttons in data samples to simplify use of z-index. 
- Minor improvement in scrolling into view ref element during tour.


