### PR TITLE
Made close buttons bigger, LED icon buttons interactive.

### DIFF
--- a/src/components/ActionDataSamplesCard.tsx
+++ b/src/components/ActionDataSamplesCard.tsx
@@ -40,6 +40,15 @@ const flash = keyframes({
   "100%": {},
 });
 
+const bigHitArea = {
+  position: "absolute",
+  top: -2,
+  right: -2,
+  bottom: -2,
+  left: -2,
+  content: '""',
+};
+
 interface ActionDataSamplesCardProps {
   preview?: boolean;
   value: ActionData;
@@ -106,6 +115,7 @@ const ActionDataSamplesCard = ({
               borderColor="blackAlpha.500"
               boxShadow="sm"
               onClick={() => deleteActionRecording(value.id, recording.id)}
+              _after={bigHitArea}
             />
             <DataSample
               recording={recording}
@@ -358,6 +368,7 @@ const DataSample = ({
             }
           )}
           onClick={handleDelete}
+          _after={bigHitArea}
         />
       )}
       {hasGraph && (

--- a/src/components/ActionNameCard.tsx
+++ b/src/components/ActionNameCard.tsx
@@ -60,6 +60,7 @@ const ActionNameCard = ({
   const setHint = useStore((s) => s.setHint);
   const { icon, id } = value;
   const [localName, setLocalName] = useState<string>(value.name);
+
   useEffect(() => {
     // Occurs when the name is updated in another tab.
     setLocalName(value.name);
@@ -161,6 +162,14 @@ const ActionNameCard = ({
             { id: "delete-action-aria" },
             { action: localName }
           )}
+          _after={{
+            position: "absolute",
+            top: -2,
+            right: -2,
+            bottom: -2,
+            left: -2,
+            content: '""',
+          }}
         />
       )}
       <CardBody p={0} alignContent="center">
@@ -173,14 +182,15 @@ const ActionNameCard = ({
                 colorScheme="brand2"
                 initiallyOn={false}
               />
-            ) : (
-              <LedIconSvg icon={icon} />
-            )}
-            {viewMode === ActionCardNameViewMode.Editable && (
+            ) : viewMode === ActionCardNameViewMode.Editable ? (
               <LedIconPicker
                 actionName={value.name}
                 onIconSelected={handleIconSelected}
-              />
+              >
+                <LedIconSvg icon={icon} />
+              </LedIconPicker>
+            ) : (
+              <LedIconSvg icon={icon} />
             )}
           </HStack>
           <Input

--- a/src/components/LedIconPicker.tsx
+++ b/src/components/LedIconPicker.tsx
@@ -5,6 +5,7 @@
  */
 import {
   Grid,
+  HStack,
   IconButton,
   Popover,
   PopoverArrow,
@@ -22,9 +23,14 @@ import LedIconSvg from "./icons/LedIconSvg";
 interface LedIconPicker {
   actionName: string;
   onIconSelected: (icon: MakeCodeIcon) => void;
+  children: React.ReactElement;
 }
 
-const LedIconPicker = ({ actionName, onIconSelected }: LedIconPicker) => {
+const LedIconPicker = ({
+  actionName,
+  onIconSelected,
+  children,
+}: LedIconPicker) => {
   const intl = useIntl();
   const handleClick = useCallback(
     (icon: MakeCodeIcon, callback: () => void) => {
@@ -39,23 +45,26 @@ const LedIconPicker = ({ actionName, onIconSelected }: LedIconPicker) => {
       {({ onClose }) => (
         <>
           <PopoverTrigger>
-            <IconButton
-              variant="ghost"
-              color="blackAlpha.700"
-              aria-label={
-                actionName
-                  ? intl.formatMessage(
-                      { id: "select-icon-action-aria" },
-                      { action: actionName }
-                    )
-                  : intl.formatMessage({
-                      id: "select-icon-action-untitled-aria",
-                    })
-              }
-              size="sm"
-            >
-              <RiArrowDropDownFill size={32} />
-            </IconButton>
+            <HStack cursor="pointer">
+              {children}
+              <IconButton
+                variant="ghost"
+                color="blackAlpha.700"
+                aria-label={
+                  actionName
+                    ? intl.formatMessage(
+                        { id: "select-icon-action-aria" },
+                        { action: actionName }
+                      )
+                    : intl.formatMessage({
+                        id: "select-icon-action-untitled-aria",
+                      })
+                }
+                size="sm"
+              >
+                <RiArrowDropDownFill size={32} />
+              </IconButton>
+            </HStack>
           </PopoverTrigger>
           <Portal>
             <PopoverContent w="100%" height="300px" overflowY="auto">

--- a/src/components/LedIconPicker.tsx
+++ b/src/components/LedIconPicker.tsx
@@ -13,6 +13,7 @@ import {
   PopoverContent,
   PopoverTrigger,
   Portal,
+  VisuallyHidden,
 } from "@chakra-ui/react";
 import { memo, useCallback } from "react";
 import { RiArrowDropDownFill } from "react-icons/ri";
@@ -44,22 +45,33 @@ const LedIconPicker = ({
     <Popover placement="right-start" isLazy lazyBehavior="keepMounted">
       {({ onClose }) => (
         <>
+          <VisuallyHidden>
+            {/* For the icon to be read out by screen reader. */}
+            {children}
+          </VisuallyHidden>
           <PopoverTrigger>
-            <HStack cursor="pointer">
+            <HStack
+              as="button"
+              borderRadius={2}
+              aria-label={
+                actionName
+                  ? intl.formatMessage(
+                      { id: "select-icon-action-aria" },
+                      { action: actionName }
+                    )
+                  : intl.formatMessage({
+                      id: "select-icon-action-untitled-aria",
+                    })
+              }
+              _focusVisible={{ boxShadow: "outline", outline: "none" }}
+              cursor="pointer"
+            >
               {children}
               <IconButton
+                as="div"
                 variant="ghost"
                 color="blackAlpha.700"
-                aria-label={
-                  actionName
-                    ? intl.formatMessage(
-                        { id: "select-icon-action-aria" },
-                        { action: actionName }
-                      )
-                    : intl.formatMessage({
-                        id: "select-icon-action-untitled-aria",
-                      })
-                }
+                aria-label=""
                 size="sm"
               >
                 <RiArrowDropDownFill size={32} />


### PR DESCRIPTION
Added a conservative amount of hidden hit area to help with clicking close buttons, tested on mobile and it makes a difference.

Also associate the LED Icon SVG with the LED Icon picker in the ActionNameCard so that it can be clicked as a single unit. This is significant on mobile where it is intuitive to tap the LED Icon to change it, but the dropdown icon still gives the affordance that it is something that can be changed.

<img width="408" height="157" alt="image" src="https://github.com/user-attachments/assets/bab04265-e92d-42cd-a3eb-1deee59383c7" />

<img width="323" height="103" alt="image" src="https://github.com/user-attachments/assets/c1ac5748-d803-441c-b769-2ae73d7badcf" />

<img width="334" height="171" alt="image" src="https://github.com/user-attachments/assets/e04afe9a-c054-49e5-8647-2ebb9be67973" />

Addresses #856 #560 