### PR TITLE
Fix web language regressions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ When documenting properties/fields use the following style of comment:
 To add or amend UI strings:
 
 1. Edit `lang/ui.en.json`
-2. Run `find lang -type f -not -name ui.en.json | while read n; do git checkout beta -- $n; done  && npm run i18n:compile` to update `src/messages/` via formatjs and ensure that outdated text of new message is not preserved in translation bundles as we iterate on the text.
+2. Run `find lang -type f -not -name ui.en.json | while read n; do git checkout main -- $n; done  && npm run i18n:compile` to update `src/messages/` via formatjs and ensure that outdated text of new message is not preserved in translation bundles as we iterate on the text.
 
 ## Vitest
 

--- a/lang/ui.ca.json
+++ b/lang/ui.ca.json
@@ -787,10 +787,6 @@
     "defaultMessage": "Finding micro:bit…",
     "description": "Progress text during device discovery stage of flashing"
   },
-  "downloading-stage-flashing": {
-    "defaultMessage": "Please wait. Downloading program to micro:bit.",
-    "description": "Progress text during actual flashing stage"
-  },
   "downloading-stage-flashing-native": {
     "defaultMessage": "Please do not interact with the micro:bit before the download is complete.",
     "description": "Progress text during native flashing stage"
@@ -798,6 +794,10 @@
   "downloading-stage-resetting-device": {
     "defaultMessage": "Waiting for micro:bit to reboot...",
     "description": "Progress text when rebooting micro:bit before flashing"
+  },
+  "downloading-subtitle": {
+    "defaultMessage": "Si us plau, espera. Transferint el programa a la micro:bit.",
+    "description": "Progress text"
   },
   "duplicate-project-action": {
     "defaultMessage": "Duplica",

--- a/lang/ui.ca.json
+++ b/lang/ui.ca.json
@@ -543,6 +543,10 @@
     "defaultMessage": "S'està connectant...",
     "description": "Text shown while waiting for bluetooth/radio connection"
   },
+  "connecting-data-collection-microbit-heading": {
+    "defaultMessage": "Connecting to data collection micro:bit",
+    "description": "Connection dialogs"
+  },
   "continue-makecode-action": {
     "defaultMessage": "Continua amb MakeCode",
     "description": "Continue to MakeCode editor button text"

--- a/lang/ui.en.json
+++ b/lang/ui.en.json
@@ -276,7 +276,7 @@
     "description": "Label indicating Bluetooth needs to be enabled"
   },
   "connect-bluetooth-heading": {
-    "defaultMessage": "Connecting to data collection micro:bit",
+    "defaultMessage": "Connect using Web Bluetooth",
     "description": "Connection dialogs"
   },
   "connect-bluetooth-invalid-pattern": {
@@ -542,6 +542,10 @@
   "connecting": {
     "defaultMessage": "Connecting…",
     "description": "Text shown while waiting for bluetooth/radio connection"
+  },
+  "connecting-data-collection-microbit-heading": {
+    "defaultMessage": "Connecting to data collection micro:bit",
+    "description": "Connection dialogs"
   },
   "continue-makecode-action": {
     "defaultMessage": "Continue to MakeCode",

--- a/lang/ui.en.json
+++ b/lang/ui.en.json
@@ -787,10 +787,6 @@
     "defaultMessage": "Finding micro:bit…",
     "description": "Progress text during device discovery stage of flashing"
   },
-  "downloading-stage-flashing": {
-    "defaultMessage": "Please wait. Downloading program to micro:bit.",
-    "description": "Progress text during actual flashing stage"
-  },
   "downloading-stage-flashing-native": {
     "defaultMessage": "Please do not interact with the micro:bit before the download is complete.",
     "description": "Progress text during native flashing stage"
@@ -798,6 +794,10 @@
   "downloading-stage-resetting-device": {
     "defaultMessage": "Waiting for micro:bit to reboot...",
     "description": "Progress text when rebooting micro:bit before flashing"
+  },
+  "downloading-subtitle": {
+    "defaultMessage": "Please wait. Downloading program to micro:bit.",
+    "description": "Progress text during actual flashing stage"
   },
   "duplicate-project-action": {
     "defaultMessage": "Duplicate",

--- a/lang/ui.es-es.json
+++ b/lang/ui.es-es.json
@@ -543,6 +543,10 @@
     "defaultMessage": "Conectando...",
     "description": "Text shown while waiting for bluetooth/radio connection"
   },
+  "connecting-data-collection-microbit-heading": {
+    "defaultMessage": "Connecting to data collection micro:bit",
+    "description": "Connection dialogs"
+  },
   "continue-makecode-action": {
     "defaultMessage": "Continuar a MakeCode",
     "description": "Continue to MakeCode editor button text"

--- a/lang/ui.es-es.json
+++ b/lang/ui.es-es.json
@@ -787,10 +787,6 @@
     "defaultMessage": "Finding micro:bit…",
     "description": "Progress text during device discovery stage of flashing"
   },
-  "downloading-stage-flashing": {
-    "defaultMessage": "Please wait. Downloading program to micro:bit.",
-    "description": "Progress text during actual flashing stage"
-  },
   "downloading-stage-flashing-native": {
     "defaultMessage": "Please do not interact with the micro:bit before the download is complete.",
     "description": "Progress text during native flashing stage"
@@ -798,6 +794,10 @@
   "downloading-stage-resetting-device": {
     "defaultMessage": "Waiting for micro:bit to reboot...",
     "description": "Progress text when rebooting micro:bit before flashing"
+  },
+  "downloading-subtitle": {
+    "defaultMessage": "Espera, por favor. Descargando el programa al micro:bit.",
+    "description": "Progress text"
   },
   "duplicate-project-action": {
     "defaultMessage": "Duplicado",

--- a/lang/ui.fr.json
+++ b/lang/ui.fr.json
@@ -787,10 +787,6 @@
     "defaultMessage": "Finding micro:bit…",
     "description": "Progress text during device discovery stage of flashing"
   },
-  "downloading-stage-flashing": {
-    "defaultMessage": "Please wait. Downloading program to micro:bit.",
-    "description": "Progress text during actual flashing stage"
-  },
   "downloading-stage-flashing-native": {
     "defaultMessage": "Please do not interact with the micro:bit before the download is complete.",
     "description": "Progress text during native flashing stage"
@@ -798,6 +794,10 @@
   "downloading-stage-resetting-device": {
     "defaultMessage": "Waiting for micro:bit to reboot...",
     "description": "Progress text when rebooting micro:bit before flashing"
+  },
+  "downloading-subtitle": {
+    "defaultMessage": "Veuillez patienter. Téléchargement du programme sur le micro:bit.",
+    "description": "Progress text"
   },
   "duplicate-project-action": {
     "defaultMessage": "Dupliquer",

--- a/lang/ui.fr.json
+++ b/lang/ui.fr.json
@@ -543,6 +543,10 @@
     "defaultMessage": "Connexion…",
     "description": "Text shown while waiting for bluetooth/radio connection"
   },
+  "connecting-data-collection-microbit-heading": {
+    "defaultMessage": "Connecting to data collection micro:bit",
+    "description": "Connection dialogs"
+  },
   "continue-makecode-action": {
     "defaultMessage": "Continuer vers MakeCode",
     "description": "Continue to MakeCode editor button text"

--- a/lang/ui.ja.json
+++ b/lang/ui.ja.json
@@ -543,6 +543,10 @@
     "defaultMessage": "接続中...",
     "description": "Text shown while waiting for bluetooth/radio connection"
   },
+  "connecting-data-collection-microbit-heading": {
+    "defaultMessage": "Connecting to data collection micro:bit",
+    "description": "Connection dialogs"
+  },
   "continue-makecode-action": {
     "defaultMessage": "MakeCodeに進む",
     "description": "Continue to MakeCode editor button text"

--- a/lang/ui.ja.json
+++ b/lang/ui.ja.json
@@ -787,10 +787,6 @@
     "defaultMessage": "Finding micro:bit…",
     "description": "Progress text during device discovery stage of flashing"
   },
-  "downloading-stage-flashing": {
-    "defaultMessage": "Please wait. Downloading program to micro:bit.",
-    "description": "Progress text during actual flashing stage"
-  },
   "downloading-stage-flashing-native": {
     "defaultMessage": "Please do not interact with the micro:bit before the download is complete.",
     "description": "Progress text during native flashing stage"
@@ -798,6 +794,10 @@
   "downloading-stage-resetting-device": {
     "defaultMessage": "Waiting for micro:bit to reboot...",
     "description": "Progress text when rebooting micro:bit before flashing"
+  },
+  "downloading-subtitle": {
+    "defaultMessage": "しばらくお待ちください。micro:bitにプログラムをダウンロードしています。",
+    "description": "Progress text"
   },
   "duplicate-project-action": {
     "defaultMessage": "複製",

--- a/lang/ui.ko.json
+++ b/lang/ui.ko.json
@@ -543,6 +543,10 @@
     "defaultMessage": "연결 중…",
     "description": "Text shown while waiting for bluetooth/radio connection"
   },
+  "connecting-data-collection-microbit-heading": {
+    "defaultMessage": "Connecting to data collection micro:bit",
+    "description": "Connection dialogs"
+  },
   "continue-makecode-action": {
     "defaultMessage": "MakeCode로 계속 진행하기",
     "description": "Continue to MakeCode editor button text"

--- a/lang/ui.ko.json
+++ b/lang/ui.ko.json
@@ -787,10 +787,6 @@
     "defaultMessage": "Finding micro:bit…",
     "description": "Progress text during device discovery stage of flashing"
   },
-  "downloading-stage-flashing": {
-    "defaultMessage": "Please wait. Downloading program to micro:bit.",
-    "description": "Progress text during actual flashing stage"
-  },
   "downloading-stage-flashing-native": {
     "defaultMessage": "Please do not interact with the micro:bit before the download is complete.",
     "description": "Progress text during native flashing stage"
@@ -798,6 +794,10 @@
   "downloading-stage-resetting-device": {
     "defaultMessage": "Waiting for micro:bit to reboot...",
     "description": "Progress text when rebooting micro:bit before flashing"
+  },
+  "downloading-subtitle": {
+    "defaultMessage": "잠시만 기다리세요. micro:bit에 프로그램을 다운로드하는 중입니다.",
+    "description": "Progress text"
   },
   "duplicate-project-action": {
     "defaultMessage": "복제",

--- a/lang/ui.lol.json
+++ b/lang/ui.lol.json
@@ -543,6 +543,10 @@
     "defaultMessage": "crwdns362836:0crwdne362836:0",
     "description": "Text shown while waiting for bluetooth/radio connection"
   },
+  "connecting-data-collection-microbit-heading": {
+    "defaultMessage": "Connecting to data collection micro:bit",
+    "description": "Connection dialogs"
+  },
   "continue-makecode-action": {
     "defaultMessage": "crwdns362838:0crwdne362838:0",
     "description": "Continue to MakeCode editor button text"

--- a/lang/ui.lol.json
+++ b/lang/ui.lol.json
@@ -787,10 +787,6 @@
     "defaultMessage": "Finding micro:bit…",
     "description": "Progress text during device discovery stage of flashing"
   },
-  "downloading-stage-flashing": {
-    "defaultMessage": "Please wait. Downloading program to micro:bit.",
-    "description": "Progress text during actual flashing stage"
-  },
   "downloading-stage-flashing-native": {
     "defaultMessage": "Please do not interact with the micro:bit before the download is complete.",
     "description": "Progress text during native flashing stage"
@@ -798,6 +794,10 @@
   "downloading-stage-resetting-device": {
     "defaultMessage": "Waiting for micro:bit to reboot...",
     "description": "Progress text when rebooting micro:bit before flashing"
+  },
+  "downloading-subtitle": {
+    "defaultMessage": "crwdns362932:0crwdne362932:0",
+    "description": "Progress text"
   },
   "duplicate-project-action": {
     "defaultMessage": "crwdns369323:0crwdne369323:0",

--- a/lang/ui.nl.json
+++ b/lang/ui.nl.json
@@ -543,6 +543,10 @@
     "defaultMessage": "Verbinden…",
     "description": "Text shown while waiting for bluetooth/radio connection"
   },
+  "connecting-data-collection-microbit-heading": {
+    "defaultMessage": "Connecting to data collection micro:bit",
+    "description": "Connection dialogs"
+  },
   "continue-makecode-action": {
     "defaultMessage": "Doorgaan naar MakeCode",
     "description": "Continue to MakeCode editor button text"

--- a/lang/ui.nl.json
+++ b/lang/ui.nl.json
@@ -787,10 +787,6 @@
     "defaultMessage": "Finding micro:bit…",
     "description": "Progress text during device discovery stage of flashing"
   },
-  "downloading-stage-flashing": {
-    "defaultMessage": "Please wait. Downloading program to micro:bit.",
-    "description": "Progress text during actual flashing stage"
-  },
   "downloading-stage-flashing-native": {
     "defaultMessage": "Please do not interact with the micro:bit before the download is complete.",
     "description": "Progress text during native flashing stage"
@@ -798,6 +794,10 @@
   "downloading-stage-resetting-device": {
     "defaultMessage": "Waiting for micro:bit to reboot...",
     "description": "Progress text when rebooting micro:bit before flashing"
+  },
+  "downloading-subtitle": {
+    "defaultMessage": "Even geduld. Programma is aan het downloaden naar de micro:bit.",
+    "description": "Progress text"
   },
   "duplicate-project-action": {
     "defaultMessage": "Kopiëren",

--- a/lang/ui.pl.json
+++ b/lang/ui.pl.json
@@ -543,6 +543,10 @@
     "defaultMessage": "Łączenie...",
     "description": "Text shown while waiting for bluetooth/radio connection"
   },
+  "connecting-data-collection-microbit-heading": {
+    "defaultMessage": "Connecting to data collection micro:bit",
+    "description": "Connection dialogs"
+  },
   "continue-makecode-action": {
     "defaultMessage": "Przejdź do MakeCode",
     "description": "Continue to MakeCode editor button text"

--- a/lang/ui.pl.json
+++ b/lang/ui.pl.json
@@ -787,10 +787,6 @@
     "defaultMessage": "Finding micro:bit…",
     "description": "Progress text during device discovery stage of flashing"
   },
-  "downloading-stage-flashing": {
-    "defaultMessage": "Please wait. Downloading program to micro:bit.",
-    "description": "Progress text during actual flashing stage"
-  },
   "downloading-stage-flashing-native": {
     "defaultMessage": "Please do not interact with the micro:bit before the download is complete.",
     "description": "Progress text during native flashing stage"
@@ -798,6 +794,10 @@
   "downloading-stage-resetting-device": {
     "defaultMessage": "Waiting for micro:bit to reboot...",
     "description": "Progress text when rebooting micro:bit before flashing"
+  },
+  "downloading-subtitle": {
+    "defaultMessage": "Proszę czekać. Pobieranie programu na micro:bita.",
+    "description": "Progress text"
   },
   "duplicate-project-action": {
     "defaultMessage": "Duplikuj",

--- a/lang/ui.pt-br.json
+++ b/lang/ui.pt-br.json
@@ -543,6 +543,10 @@
     "defaultMessage": "Conectando…",
     "description": "Text shown while waiting for bluetooth/radio connection"
   },
+  "connecting-data-collection-microbit-heading": {
+    "defaultMessage": "Connecting to data collection micro:bit",
+    "description": "Connection dialogs"
+  },
   "continue-makecode-action": {
     "defaultMessage": "Continuar no MakeCode",
     "description": "Continue to MakeCode editor button text"

--- a/lang/ui.pt-br.json
+++ b/lang/ui.pt-br.json
@@ -787,10 +787,6 @@
     "defaultMessage": "Finding micro:bit…",
     "description": "Progress text during device discovery stage of flashing"
   },
-  "downloading-stage-flashing": {
-    "defaultMessage": "Please wait. Downloading program to micro:bit.",
-    "description": "Progress text during actual flashing stage"
-  },
   "downloading-stage-flashing-native": {
     "defaultMessage": "Please do not interact with the micro:bit before the download is complete.",
     "description": "Progress text during native flashing stage"
@@ -798,6 +794,10 @@
   "downloading-stage-resetting-device": {
     "defaultMessage": "Waiting for micro:bit to reboot...",
     "description": "Progress text when rebooting micro:bit before flashing"
+  },
+  "downloading-subtitle": {
+    "defaultMessage": "Por favor, aguarde. Baixando o programa para o micro:bit.",
+    "description": "Progress text"
   },
   "duplicate-project-action": {
     "defaultMessage": "Duplicar",

--- a/lang/ui.zh-tw.json
+++ b/lang/ui.zh-tw.json
@@ -543,6 +543,10 @@
     "defaultMessage": "正在連線…",
     "description": "Text shown while waiting for bluetooth/radio connection"
   },
+  "connecting-data-collection-microbit-heading": {
+    "defaultMessage": "Connecting to data collection micro:bit",
+    "description": "Connection dialogs"
+  },
   "continue-makecode-action": {
     "defaultMessage": "繼續前往 MakeCode",
     "description": "Continue to MakeCode editor button text"

--- a/lang/ui.zh-tw.json
+++ b/lang/ui.zh-tw.json
@@ -787,10 +787,6 @@
     "defaultMessage": "Finding micro:bit…",
     "description": "Progress text during device discovery stage of flashing"
   },
-  "downloading-stage-flashing": {
-    "defaultMessage": "Please wait. Downloading program to micro:bit.",
-    "description": "Progress text during actual flashing stage"
-  },
   "downloading-stage-flashing-native": {
     "defaultMessage": "Please do not interact with the micro:bit before the download is complete.",
     "description": "Progress text during native flashing stage"
@@ -798,6 +794,10 @@
   "downloading-stage-resetting-device": {
     "defaultMessage": "Waiting for micro:bit to reboot...",
     "description": "Progress text when rebooting micro:bit before flashing"
+  },
+  "downloading-subtitle": {
+    "defaultMessage": "請稍等。正在將程式下載至 micro:bit。",
+    "description": "Progress text"
   },
   "duplicate-project-action": {
     "defaultMessage": "複製",

--- a/src/components/BluetoothConnectingDialog.tsx
+++ b/src/components/BluetoothConnectingDialog.tsx
@@ -18,6 +18,7 @@ import { FormattedMessage } from "react-intl";
 import { isNativePlatform } from "../platform";
 import ChooseDeviceOverlay from "./ChooseDeviceOverlay";
 import LoadingAnimation from "./LoadingAnimation";
+import { getLegacyTextIdIfNeeded } from "../get-legacy-text-id";
 
 export interface BluetoothConnectingDialogProps {
   isOpen: boolean;
@@ -55,12 +56,22 @@ const BluetoothConnectingDialog = ({
       <ModalOverlay>
         <ModalContent>
           <ModalHeader>
-            <FormattedMessage id="connect-bluetooth-heading" />
+            <FormattedMessage
+              id={getLegacyTextIdIfNeeded({
+                legacyId: "connect-bluetooth-heading",
+                id: "connecting-data-collection-microbit-heading",
+              })}
+            />
           </ModalHeader>
           <ModalBody>
             <VStack width="100%" gap={5} alignItems="center">
               <Text textAlign="center">
-                <FormattedMessage id="downloading-stage-connecting" />
+                <FormattedMessage
+                  id={getLegacyTextIdIfNeeded({
+                    legacyId: "connecting",
+                    id: "downloading-stage-connecting",
+                  })}
+                />
               </Text>
               <LoadingAnimation />
             </VStack>

--- a/src/components/DownloadProgressDialog.tsx
+++ b/src/components/DownloadProgressDialog.tsx
@@ -23,6 +23,7 @@ import { isNativePlatform } from "../platform";
 import ChooseDeviceOverlay from "./ChooseDeviceOverlay";
 import LoadingAnimation from "./LoadingAnimation";
 import BluetoothPatternInput from "./BluetoothPatternInput";
+import { getLegacyTextIdIfNeeded } from "../get-legacy-text-id";
 
 export interface DownloadProgressDialogProps {
   isOpen: boolean;
@@ -62,7 +63,10 @@ const getSubtitleId = (
     case ProgressStage.ResettingDevice:
       return "downloading-stage-resetting-device";
     case ProgressStage.Connecting:
-      return "downloading-stage-connecting";
+      return getLegacyTextIdIfNeeded({
+        legacyId: "connecting",
+        id: "downloading-stage-connecting",
+      });
     case ProgressStage.PartialFlashing:
     case ProgressStage.FullFlashing:
       return isNativePlatform()

--- a/src/components/DownloadProgressDialog.tsx
+++ b/src/components/DownloadProgressDialog.tsx
@@ -71,7 +71,7 @@ const getSubtitleId = (
     case ProgressStage.FullFlashing:
       return isNativePlatform()
         ? "downloading-stage-flashing-native"
-        : "downloading-stage-flashing";
+        : "downloading-subtitle";
     default:
       throw new Error(stage);
   }

--- a/src/components/TryAgainDialog.tsx
+++ b/src/components/TryAgainDialog.tsx
@@ -20,6 +20,7 @@ import {
 import { FormattedMessage } from "react-intl";
 import { DataConnectionStep } from "../data-connection-flow";
 import { useDeployment } from "../deployment";
+import { getLegacyTextIdIfNeeded } from "../get-legacy-text-id";
 
 const OneLineContent = ({ textId }: { textId: string }) => {
   return (
@@ -86,7 +87,10 @@ const configs: Record<
     children: <OneLineContent textId="webusb-retry-no-select" />,
   },
   [DataConnectionStep.TryAgainBluetoothSelectMicrobit]: {
-    headingId: "connect-bluetooth-heading",
+    headingId: getLegacyTextIdIfNeeded({
+      legacyId: "connect-bluetooth-heading",
+      id: "connecting-data-collection-microbit-heading",
+    }),
     children: (
       <OneLineContent textId="connect-bluetooth-cancelled-connection" />
     ),

--- a/src/get-legacy-text-id.ts
+++ b/src/get-legacy-text-id.ts
@@ -1,4 +1,4 @@
-import { Capacitor } from "@capacitor/core";
+import { isNativePlatform } from "./platform";
 
 // Temporary helper to avoiding untranslated text on web platform.
 export const getLegacyTextIdIfNeeded = ({
@@ -8,5 +8,5 @@ export const getLegacyTextIdIfNeeded = ({
   legacyId: string;
   id: string;
 }) => {
-  return Capacitor.getPlatform() === "web" ? legacyId : id;
+  return isNativePlatform() ? id : legacyId;
 };

--- a/src/get-legacy-text-id.ts
+++ b/src/get-legacy-text-id.ts
@@ -1,0 +1,12 @@
+import { Capacitor } from "@capacitor/core";
+
+// Temporary helper to avoiding untranslated text on web platform.
+export const getLegacyTextIdIfNeeded = ({
+  legacyId,
+  id,
+}: {
+  legacyId: string;
+  id: string;
+}) => {
+  return Capacitor.getPlatform() === "web" ? legacyId : id;
+};

--- a/src/messages/ui.ca.json
+++ b/src/messages/ui.ca.json
@@ -1449,12 +1449,6 @@
       "value": "Finding micro:bit…"
     }
   ],
-  "downloading-stage-flashing": [
-    {
-      "type": 0,
-      "value": "Please wait. Downloading program to micro:bit."
-    }
-  ],
   "downloading-stage-flashing-native": [
     {
       "type": 0,
@@ -1465,6 +1459,12 @@
     {
       "type": 0,
       "value": "Waiting for micro:bit to reboot..."
+    }
+  ],
+  "downloading-subtitle": [
+    {
+      "type": 0,
+      "value": "Si us plau, espera. Transferint el programa a la micro:bit."
     }
   ],
   "duplicate-project-action": [

--- a/src/messages/ui.ca.json
+++ b/src/messages/ui.ca.json
@@ -987,6 +987,12 @@
       "value": "S'està connectant..."
     }
   ],
+  "connecting-data-collection-microbit-heading": [
+    {
+      "type": 0,
+      "value": "Connecting to data collection micro:bit"
+    }
+  ],
   "continue-makecode-action": [
     {
       "type": 0,

--- a/src/messages/ui.en.json
+++ b/src/messages/ui.en.json
@@ -1453,12 +1453,6 @@
       "value": "Finding micro:bit…"
     }
   ],
-  "downloading-stage-flashing": [
-    {
-      "type": 0,
-      "value": "Please wait. Downloading program to micro:bit."
-    }
-  ],
   "downloading-stage-flashing-native": [
     {
       "type": 0,
@@ -1469,6 +1463,12 @@
     {
       "type": 0,
       "value": "Waiting for micro:bit to reboot..."
+    }
+  ],
+  "downloading-subtitle": [
+    {
+      "type": 0,
+      "value": "Please wait. Downloading program to micro:bit."
     }
   ],
   "duplicate-project-action": [

--- a/src/messages/ui.en.json
+++ b/src/messages/ui.en.json
@@ -544,7 +544,7 @@
   "connect-bluetooth-heading": [
     {
       "type": 0,
-      "value": "Connecting to data collection micro:bit"
+      "value": "Connect using Web Bluetooth"
     }
   ],
   "connect-bluetooth-invalid-pattern": [
@@ -989,6 +989,12 @@
     {
       "type": 0,
       "value": "Connecting…"
+    }
+  ],
+  "connecting-data-collection-microbit-heading": [
+    {
+      "type": 0,
+      "value": "Connecting to data collection micro:bit"
     }
   ],
   "continue-makecode-action": [

--- a/src/messages/ui.es-es.json
+++ b/src/messages/ui.es-es.json
@@ -991,6 +991,12 @@
       "value": "Conectando..."
     }
   ],
+  "connecting-data-collection-microbit-heading": [
+    {
+      "type": 0,
+      "value": "Connecting to data collection micro:bit"
+    }
+  ],
   "continue-makecode-action": [
     {
       "type": 0,

--- a/src/messages/ui.es-es.json
+++ b/src/messages/ui.es-es.json
@@ -1461,12 +1461,6 @@
       "value": "Finding micro:bit…"
     }
   ],
-  "downloading-stage-flashing": [
-    {
-      "type": 0,
-      "value": "Please wait. Downloading program to micro:bit."
-    }
-  ],
   "downloading-stage-flashing-native": [
     {
       "type": 0,
@@ -1477,6 +1471,12 @@
     {
       "type": 0,
       "value": "Waiting for micro:bit to reboot..."
+    }
+  ],
+  "downloading-subtitle": [
+    {
+      "type": 0,
+      "value": "Espera, por favor. Descargando el programa al micro:bit."
     }
   ],
   "duplicate-project-action": [

--- a/src/messages/ui.fr.json
+++ b/src/messages/ui.fr.json
@@ -1457,12 +1457,6 @@
       "value": "Finding micro:bit…"
     }
   ],
-  "downloading-stage-flashing": [
-    {
-      "type": 0,
-      "value": "Please wait. Downloading program to micro:bit."
-    }
-  ],
   "downloading-stage-flashing-native": [
     {
       "type": 0,
@@ -1473,6 +1467,12 @@
     {
       "type": 0,
       "value": "Waiting for micro:bit to reboot..."
+    }
+  ],
+  "downloading-subtitle": [
+    {
+      "type": 0,
+      "value": "Veuillez patienter. Téléchargement du programme sur le micro:bit."
     }
   ],
   "duplicate-project-action": [

--- a/src/messages/ui.fr.json
+++ b/src/messages/ui.fr.json
@@ -991,6 +991,12 @@
       "value": "Connexion…"
     }
   ],
+  "connecting-data-collection-microbit-heading": [
+    {
+      "type": 0,
+      "value": "Connecting to data collection micro:bit"
+    }
+  ],
   "continue-makecode-action": [
     {
       "type": 0,

--- a/src/messages/ui.ja.json
+++ b/src/messages/ui.ja.json
@@ -1421,12 +1421,6 @@
       "value": "Finding micro:bit…"
     }
   ],
-  "downloading-stage-flashing": [
-    {
-      "type": 0,
-      "value": "Please wait. Downloading program to micro:bit."
-    }
-  ],
   "downloading-stage-flashing-native": [
     {
       "type": 0,
@@ -1437,6 +1431,12 @@
     {
       "type": 0,
       "value": "Waiting for micro:bit to reboot..."
+    }
+  ],
+  "downloading-subtitle": [
+    {
+      "type": 0,
+      "value": "しばらくお待ちください。micro:bitにプログラムをダウンロードしています。"
     }
   ],
   "duplicate-project-action": [

--- a/src/messages/ui.ja.json
+++ b/src/messages/ui.ja.json
@@ -975,6 +975,12 @@
       "value": "接続中..."
     }
   ],
+  "connecting-data-collection-microbit-heading": [
+    {
+      "type": 0,
+      "value": "Connecting to data collection micro:bit"
+    }
+  ],
   "continue-makecode-action": [
     {
       "type": 0,

--- a/src/messages/ui.ko.json
+++ b/src/messages/ui.ko.json
@@ -971,6 +971,12 @@
       "value": "연결 중…"
     }
   ],
+  "connecting-data-collection-microbit-heading": [
+    {
+      "type": 0,
+      "value": "Connecting to data collection micro:bit"
+    }
+  ],
   "continue-makecode-action": [
     {
       "type": 0,

--- a/src/messages/ui.ko.json
+++ b/src/messages/ui.ko.json
@@ -1417,12 +1417,6 @@
       "value": "Finding micro:bit…"
     }
   ],
-  "downloading-stage-flashing": [
-    {
-      "type": 0,
-      "value": "Please wait. Downloading program to micro:bit."
-    }
-  ],
   "downloading-stage-flashing-native": [
     {
       "type": 0,
@@ -1433,6 +1427,12 @@
     {
       "type": 0,
       "value": "Waiting for micro:bit to reboot..."
+    }
+  ],
+  "downloading-subtitle": [
+    {
+      "type": 0,
+      "value": "잠시만 기다리세요. micro:bit에 프로그램을 다운로드하는 중입니다."
     }
   ],
   "duplicate-project-action": [

--- a/src/messages/ui.lol.json
+++ b/src/messages/ui.lol.json
@@ -1433,12 +1433,6 @@
       "value": "Finding micro:bit…"
     }
   ],
-  "downloading-stage-flashing": [
-    {
-      "type": 0,
-      "value": "Please wait. Downloading program to micro:bit."
-    }
-  ],
   "downloading-stage-flashing-native": [
     {
       "type": 0,
@@ -1449,6 +1443,12 @@
     {
       "type": 0,
       "value": "Waiting for micro:bit to reboot..."
+    }
+  ],
+  "downloading-subtitle": [
+    {
+      "type": 0,
+      "value": "crwdns362932:0crwdne362932:0"
     }
   ],
   "duplicate-project-action": [

--- a/src/messages/ui.lol.json
+++ b/src/messages/ui.lol.json
@@ -979,6 +979,12 @@
       "value": "crwdns362836:0crwdne362836:0"
     }
   ],
+  "connecting-data-collection-microbit-heading": [
+    {
+      "type": 0,
+      "value": "Connecting to data collection micro:bit"
+    }
+  ],
   "continue-makecode-action": [
     {
       "type": 0,

--- a/src/messages/ui.nl.json
+++ b/src/messages/ui.nl.json
@@ -1453,12 +1453,6 @@
       "value": "Finding micro:bit…"
     }
   ],
-  "downloading-stage-flashing": [
-    {
-      "type": 0,
-      "value": "Please wait. Downloading program to micro:bit."
-    }
-  ],
   "downloading-stage-flashing-native": [
     {
       "type": 0,
@@ -1469,6 +1463,12 @@
     {
       "type": 0,
       "value": "Waiting for micro:bit to reboot..."
+    }
+  ],
+  "downloading-subtitle": [
+    {
+      "type": 0,
+      "value": "Even geduld. Programma is aan het downloaden naar de micro:bit."
     }
   ],
   "duplicate-project-action": [

--- a/src/messages/ui.nl.json
+++ b/src/messages/ui.nl.json
@@ -991,6 +991,12 @@
       "value": "Verbinden…"
     }
   ],
+  "connecting-data-collection-microbit-heading": [
+    {
+      "type": 0,
+      "value": "Connecting to data collection micro:bit"
+    }
+  ],
   "continue-makecode-action": [
     {
       "type": 0,

--- a/src/messages/ui.pl.json
+++ b/src/messages/ui.pl.json
@@ -991,6 +991,12 @@
       "value": "Łączenie..."
     }
   ],
+  "connecting-data-collection-microbit-heading": [
+    {
+      "type": 0,
+      "value": "Connecting to data collection micro:bit"
+    }
+  ],
   "continue-makecode-action": [
     {
       "type": 0,

--- a/src/messages/ui.pl.json
+++ b/src/messages/ui.pl.json
@@ -1457,12 +1457,6 @@
       "value": "Finding micro:bit…"
     }
   ],
-  "downloading-stage-flashing": [
-    {
-      "type": 0,
-      "value": "Please wait. Downloading program to micro:bit."
-    }
-  ],
   "downloading-stage-flashing-native": [
     {
       "type": 0,
@@ -1473,6 +1467,12 @@
     {
       "type": 0,
       "value": "Waiting for micro:bit to reboot..."
+    }
+  ],
+  "downloading-subtitle": [
+    {
+      "type": 0,
+      "value": "Proszę czekać. Pobieranie programu na micro:bita."
     }
   ],
   "duplicate-project-action": [

--- a/src/messages/ui.pt-br.json
+++ b/src/messages/ui.pt-br.json
@@ -991,6 +991,12 @@
       "value": "Conectando…"
     }
   ],
+  "connecting-data-collection-microbit-heading": [
+    {
+      "type": 0,
+      "value": "Connecting to data collection micro:bit"
+    }
+  ],
   "continue-makecode-action": [
     {
       "type": 0,

--- a/src/messages/ui.pt-br.json
+++ b/src/messages/ui.pt-br.json
@@ -1453,12 +1453,6 @@
       "value": "Finding micro:bit…"
     }
   ],
-  "downloading-stage-flashing": [
-    {
-      "type": 0,
-      "value": "Please wait. Downloading program to micro:bit."
-    }
-  ],
   "downloading-stage-flashing-native": [
     {
       "type": 0,
@@ -1469,6 +1463,12 @@
     {
       "type": 0,
       "value": "Waiting for micro:bit to reboot..."
+    }
+  ],
+  "downloading-subtitle": [
+    {
+      "type": 0,
+      "value": "Por favor, aguarde. Baixando o programa para o micro:bit."
     }
   ],
   "duplicate-project-action": [

--- a/src/messages/ui.zh-tw.json
+++ b/src/messages/ui.zh-tw.json
@@ -1461,12 +1461,6 @@
       "value": "Finding micro:bit…"
     }
   ],
-  "downloading-stage-flashing": [
-    {
-      "type": 0,
-      "value": "Please wait. Downloading program to micro:bit."
-    }
-  ],
   "downloading-stage-flashing-native": [
     {
       "type": 0,
@@ -1477,6 +1471,12 @@
     {
       "type": 0,
       "value": "Waiting for micro:bit to reboot..."
+    }
+  ],
+  "downloading-subtitle": [
+    {
+      "type": 0,
+      "value": "請稍等。正在將程式下載至 micro:bit。"
     }
   ],
   "duplicate-project-action": [

--- a/src/messages/ui.zh-tw.json
+++ b/src/messages/ui.zh-tw.json
@@ -999,6 +999,12 @@
       "value": "正在連線…"
     }
   ],
+  "connecting-data-collection-microbit-heading": [
+    {
+      "type": 0,
+      "value": "Connecting to data collection micro:bit"
+    }
+  ],
   "continue-makecode-action": [
     {
       "type": 0,


### PR DESCRIPTION
- Temporarily use legacy text id for web platforms to avoid language regressions.
  - legacy id: "connecting" , new id: "downloading-stage-connecting"
  - legacy id: "connect-bluetooth-heading", new id: "connecting-data-collection-microbit-heading"
- Revert text id change "downloading-stage-flashing” -> "downloading-subtitle”
- Update AGENTS.md to use `main` instead of `beta`