### PR TITLE
Recover spacing between data sample and fingerprint

### DIFF
--- a/src/components/ActionDataSamplesCard.tsx
+++ b/src/components/ActionDataSamplesCard.tsx
@@ -372,7 +372,12 @@ const DataSample = ({
     onDelete(actionId, recording.id);
   }, [actionId, onDelete, recording.id]);
   return (
-    <HStack key={recording.id} position="relative" ref={ref} gap={0}>
+    <HStack
+      key={recording.id}
+      position="relative"
+      ref={ref}
+      gap={hasFingerprint && hasGraph ? 2 : 0}
+    >
       {hasClose && (
         <Portal containerRef={ref}>
           <CloseButton


### PR DESCRIPTION
Regression from https://github.com/microbit-foundation/ml-trainer/pull/740/changes/20801b669159533787c1f25848afc028f0c03eb2

**Issue**
<img width="287" height="130" alt="Screenshot 2026-04-29 at 17 23 29" src="https://github.com/user-attachments/assets/da37659d-fe71-4064-a66e-1b58c4b1a142" />

**After changes**
<img width="286" height="121" alt="Screenshot 2026-04-29 at 17 23 59" src="https://github.com/user-attachments/assets/11002c3b-f92e-436d-90b1-bfd282275160" />
