### PR TITLE
Bucket non-English languages as 'partially supported' on native

### DIFF
--- a/src/components/LanguageDialog.tsx
+++ b/src/components/LanguageDialog.tsx
@@ -36,7 +36,8 @@ import {
 import { FormattedMessage, IntlShape, useIntl } from "react-intl";
 import { deployment, useDeployment } from "../deployment";
 import { flags } from "../flags";
-import { allLanguages, Language } from "../settings";
+import { isNativePlatform } from "../platform";
+import { allLanguages, Language, nativeLanguageIds } from "../settings";
 import { useStore } from "../store";
 import ModalFooterContent from "./ModalFooterContent";
 
@@ -61,6 +62,10 @@ export const LanguageDialog = ({
       onClose();
     },
     [onClose, setLanguage]
+  );
+  const fullySupportedLanguages = allLanguages.filter(fullySupported);
+  const partiallySupportedLanguages = allLanguages.filter(
+    (l) => !fullySupported(l)
   );
   return (
     <Modal
@@ -87,15 +92,13 @@ export const LanguageDialog = ({
                 <FormattedMessage id="language-fully-supported-heading" />
               </Text>
               <SimpleGrid width="100%" columns={[1, 2, 3]} spacing={4}>
-                {allLanguages
-                  .filter((l) => l.makeCode && uiSupported(l))
-                  .map((language) => (
-                    <LanguageCard
-                      key={language.id}
-                      language={language}
-                      onChooseLanguage={handleChooseLanguage}
-                    />
-                  ))}
+                {fullySupportedLanguages.map((language) => (
+                  <LanguageCard
+                    key={language.id}
+                    language={language}
+                    onChooseLanguage={handleChooseLanguage}
+                  />
+                ))}
               </SimpleGrid>
               <Text
                 marginTop="1em"
@@ -108,15 +111,13 @@ export const LanguageDialog = ({
                 <FormattedMessage id="language-partially-supported-heading" />
               </Text>
               <SimpleGrid width="100%" columns={[1, 2, 3]} spacing={4}>
-                {allLanguages
-                  .filter((l) => !(l.makeCode && uiSupported(l)))
-                  .map((language) => (
-                    <LanguageCard
-                      key={language.id}
-                      language={language}
-                      onChooseLanguage={handleChooseLanguage}
-                    />
-                  ))}
+                {partiallySupportedLanguages.map((language) => (
+                  <LanguageCard
+                    key={language.id}
+                    language={language}
+                    onChooseLanguage={handleChooseLanguage}
+                  />
+                ))}
               </SimpleGrid>
             </VStack>
           </ModalBody>
@@ -232,9 +233,15 @@ const LanguageCard = ({ language, onChooseLanguage }: LanguageCardProps) => {
   );
 };
 
-const uiSupported = (language: Language): boolean =>
-  language.ui === true ||
-  (language.ui === "preview" && flags.translationPreview);
+const uiSupported = (language: Language): boolean => {
+  if (isNativePlatform() && !nativeLanguageIds.includes(language.id)) {
+    return false;
+  }
+  return (
+    language.ui === true ||
+    (language.ui === "preview" && flags.translationPreview)
+  );
+};
 
 const fullySupported = (language: Language): boolean => {
   return uiSupported(language) === true && language.makeCode;

--- a/src/settings.tsx
+++ b/src/settings.tsx
@@ -278,6 +278,14 @@ export const allLanguages: Language[] = [
 export const getMakeCodeLang = (languageId: string): string =>
   allLanguages.find((l) => l.id === languageId)?.makeCode ? languageId : "en";
 
+/**
+ * Languages with UI translations covering the native (iOS/Android) app's
+ * additional strings. Other languages still appear in the picker on native,
+ * but as 'partially supported' — missing strings fall back to English. Add
+ * ids here as translations land.
+ */
+export const nativeLanguageIds = ["en", "en-US"];
+
 const supportedLanguageIds = allLanguages.map((l) => l.id);
 const defaultLanguageId = allLanguages[0].id;
 


### PR DESCRIPTION
The native (iOS/Android) app builds include strings (e.g. for
Bluetooth/permissions flows) that have not yet been translated. Until
those translations land, treat non-English languages as 'partially
supported' on native so users still see them in the picker but with the
existing missing-coverage tooltip explaining the situation. Strings
without a translation fall back to source English via formatjs.
    
Review and merge https://github.com/microbit-foundation/ml-trainer/pull/641 first.