### PR TITLE
Revert beta MakeCode and use temporary version of makecode-embed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@formatjs/intl-localematcher": "^0.8.0",
         "@microbit/capacitor-community-nordic-dfu": "^7.0.0-microbit.3",
         "@microbit/capacitor-sqlite-vanilla": "^0.1.0-alpha.5",
-        "@microbit/makecode-embed": "^0.5.0",
+        "@microbit/makecode-embed": "^0.0.0-noproject.76",
         "@microbit/microbit-connection": "^1.0.0-beta.1",
         "@microbit/ml-header-generator": "^0.4.3",
         "@microbit/smoothie": "^1.37.0-microbit.2",
@@ -4254,9 +4254,9 @@
       }
     },
     "node_modules/@microbit/makecode-embed": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@microbit/makecode-embed/-/makecode-embed-0.5.0.tgz",
-      "integrity": "sha512-z37koTrEGQVq/zwI5DKfYrmPYUxHiJYFr+86OXCIsqctTRM4DLPm4NZOz9dKRPj6Bwv9uyqF4qvMxcKFFtfX0A==",
+      "version": "0.0.0-noproject.76",
+      "resolved": "https://registry.npmjs.org/@microbit/makecode-embed/-/makecode-embed-0.0.0-noproject.76.tgz",
+      "integrity": "sha512-iqOTBhIDSqY3Cdo1FbkUMYyfaKM8fiP0wZNV/iq8M63oFJKHZiGjlIyd1oiFNoeUtY1j81gcHUOOl/VbHWpN5A==",
       "license": "MIT",
       "dependencies": {
         "tslib": ">=2.0.0"

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@formatjs/intl-localematcher": "^0.8.0",
     "@microbit/capacitor-community-nordic-dfu": "^7.0.0-microbit.3",
     "@microbit/capacitor-sqlite-vanilla": "^0.1.0-alpha.5",
-    "@microbit/makecode-embed": "^0.5.0",
+    "@microbit/makecode-embed": "^0.0.0-noproject.76",
     "@microbit/microbit-connection": "^1.0.0-beta.1",
     "@microbit/ml-header-generator": "^0.4.3",
     "@microbit/smoothie": "^1.37.0-microbit.2",

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -8,6 +8,7 @@ import {
   MakeCodeFrameDriver,
 } from "@microbit/makecode-embed/react";
 import React, { forwardRef } from "react";
+import { getEditorVersionOverride } from "../editor-version";
 import { useProject } from "../hooks/project-hooks";
 import { getMakeCodeLang } from "../settings";
 import { useSettings } from "../store";
@@ -32,6 +33,7 @@ const Editor = forwardRef<MakeCodeFrameDriver, EditorProps>(function Editor(
       controller={2}
       lang={getMakeCodeLang(languageId)}
       loading="eager"
+      version={getEditorVersionOverride()}
       {...editorCallbacks}
       {...props}
     />

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -8,11 +8,9 @@ import {
   MakeCodeFrameDriver,
 } from "@microbit/makecode-embed/react";
 import React, { forwardRef } from "react";
-import { getEditorVersionOverride } from "../editor-version";
 import { useProject } from "../hooks/project-hooks";
 import { getMakeCodeLang } from "../settings";
 import { useSettings } from "../store";
-import { isNativePlatform } from "../platform";
 
 const controllerId = "MicrobitMachineLearningTool";
 
@@ -34,9 +32,6 @@ const Editor = forwardRef<MakeCodeFrameDriver, EditorProps>(function Editor(
       controller={2}
       lang={getMakeCodeLang(languageId)}
       loading="eager"
-      version={
-        getEditorVersionOverride() ?? (isNativePlatform() ? "beta" : undefined)
-      }
       {...editorCallbacks}
       {...props}
     />


### PR DESCRIPTION
We switched to MakeCode beta for our app testing because we needed https://github.com/microsoft/pxt/pull/11196 as iframe+tablet seems to make it much easier to reproduce https://github.com/microsoft/pxt-microbit/issues/6081 to the point where we felt it was unusable.

The temporary branch of makecode-embed works around the problem differently by using the noproject flag (like skillsmap seems to).

As this will resolve itself in this summer's MakeCode release we're not going to merge that change in makecode-embed — if MakeCode is visible at init time there's a notable visual glitch where the empty editor is rendered. Fortunately this does not apply to CreateAI.

makecode-embed change for reference: https://github.com/microbit-foundation/makecode-embed/pull/14