### PR TITLE
Remove advertising-ID permissions from Android manifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -90,4 +90,16 @@
     <!-- Foreground service permission for Nordic DFU library -->
     <!-- Note: Android 14+ (API 34+) requires specifying a foreground service type if using foreground services -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+
+    <!--
+      firebase-analytics injects the advertising-ID and Privacy Sandbox
+      ad-services permissions by default. We don't use AdMob, Google
+      Signals, or attribution APIs — analytics is gated behind explicit
+      consent with AdStorage/AdPersonalization/AdUserData never granted
+      (see src/logging/sink.ts). Strip the permissions so the merged
+      manifest matches the Play Console "no advertising ID" declaration.
+    -->
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove" />
+    <uses-permission android:name="android.permission.ACCESS_ADSERVICES_ATTRIBUTION" tools:node="remove" />
+    <uses-permission android:name="android.permission.ACCESS_ADSERVICES_AD_ID" tools:node="remove" />
 </manifest>


### PR DESCRIPTION
firebase-analytics 22+ injects AD_ID and the Privacy Sandbox ACCESS_ADSERVICES_* permissions by default. We don't use AdMob, Google Signals, or attribution APIs, so strip them via manifest merger so the Play Console "no advertising ID" declaration matches the merged manifest.