### PR TITLE
Add broadcast channel shim to fix iOS <15.4 crash

### DIFF
--- a/src/broadcast-channel.ts
+++ b/src/broadcast-channel.ts
@@ -9,6 +9,19 @@ export interface BroadcastChannelData {
   projectIds: string[];
   settings?: boolean;
 }
+class NoOpBroadcastChannel {
+  constructor() {}
+  postMessage(_data: unknown) {}
+  addEventListener(_type: string, _handler: (e: MessageEvent) => void) {}
+  removeEventListener(_type: string, _handler: (e: MessageEvent) => void) {}
+  close() {}
+}
 
 // Used to keep project state synced between open tabs / windows.
-export const broadcastChannel = new BroadcastChannel("ml");
+// Broadcast channel is not supported for older browsers/iOS versions, so a
+// no-op version is used to avoid throwing an error.
+// TODO: Revisit making project state syncing work for older web browsers.
+export const broadcastChannel =
+  typeof BroadcastChannel === "undefined"
+    ? new NoOpBroadcastChannel()
+    : new BroadcastChannel("ml");


### PR DESCRIPTION
The app crashes for iOS versions earlier than 15.4 because `BroadcastChannel` is not supported in those versions. A no-op version is implemented and used for those instances to avoid the crash.

`BroadcastChannel` is used to sync project state between web tabs/windows. It doesn’t matter if it doesn’t work for native apps. However, this may be an issue for web users that use Safari versions earlier than 15.4. This can be revisited later on.