### PR TITLE
Add multi_json to Gemfile to fix app CI builds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source "https://rubygems.org"
 
 gem "fastlane"
+
+# Fix "multi_json is not part of the bundle" when CI resolves gems.
+gem "multi_json"


### PR DESCRIPTION
Android and iOS CI builds have been failing (e.g. [this Android build](https://github.com/microbit-foundation/ml-trainer/actions/runs/27148344453/job/80132255288), [this iOS build](https://github.com/microbit-foundation/ml-trainer/actions/runs/27148344114/job/80132254469)):

```
bundler: failed to load command: fastlane (/Users/runner/work/ml-trainer/ml-trainer/vendor/bundle/ruby/3.3.0/bin/fastlane)
/Users/runner/hostedtoolcache/Ruby/3.3.11/arm64/lib/ruby/3.3.0/bundler/rubygems_integration.rb:215:in `block (2 levels) in replace_gem': multi_json is not part of the bundle. Add it to your Gemfile. (Gem::LoadError)
```

This is due to an [upstream issue](https://redirect.github.com/actions/runner-images/issues/14186). Fastlane has also added [a CI fix for the issue](https://redirect.github.com/fastlane/fastlane/pull/30062).

To ensure that `multi_json` is part of the bundle, it has been added to the Gemfile.

