### PR TITLE
Stop Android system bars overlapping the app UI

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -10,7 +10,6 @@ android {
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
     implementation project(':capacitor-community-bluetooth-le')
-    implementation project(':capacitor-community-safe-area')
     implementation project(':capacitor-firebase-analytics')
     implementation project(':capacitor-app')
     implementation project(':capacitor-filesystem')

--- a/android/app/src/main/java/org/microbit/mltrainer/MainActivity.java
+++ b/android/app/src/main/java/org/microbit/mltrainer/MainActivity.java
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
 public class MainActivity extends BridgeActivity {
 
     /**
-     * Chromium WebView versions below this report env(safe-area-inset-*) as
+     * Chromium WebView versions below 140 report env(safe-area-inset-*) as
      * 0px, so we emulate the safe area with padding for them. At or above it,
      * the WebView reports the insets correctly and we pass them through.
      * See https://issues.chromium.org/issues/40699457
@@ -46,9 +46,7 @@ public class MainActivity extends BridgeActivity {
     }
 
     /**
-     * Styles the system bars for our light UI: dark icons on a white
-     * background. Replaces @capacitor-community/safe-area's
-     * setSystemBarsStyle(LIGHT) call.
+     * Styles the system bars (we no longer use @capacitor-community/safe-area).
      */
     private void setupSystemBarsStyle() {
         WindowInsetsControllerCompat controller =

--- a/android/app/src/main/java/org/microbit/mltrainer/MainActivity.java
+++ b/android/app/src/main/java/org/microbit/mltrainer/MainActivity.java
@@ -1,14 +1,29 @@
 package org.microbit.mltrainer;
 
+import android.content.pm.PackageInfo;
+import android.os.Build;
 import android.os.Bundle;
+import android.webkit.WebView;
 
 import androidx.activity.EdgeToEdge;
+import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 
 import com.getcapacitor.BridgeActivity;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class MainActivity extends BridgeActivity {
+
+    /**
+     * Chromium WebView versions below this report env(safe-area-inset-*) as
+     * 0px, so we emulate the safe area with padding for them. At or above it,
+     * the WebView reports the insets correctly and we pass them through.
+     * See https://issues.chromium.org/issues/40699457
+     */
+    private static final int SAFE_AREA_CORE_FIX_WEBVIEW_VERSION = 140;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -24,18 +39,68 @@ public class MainActivity extends BridgeActivity {
         // to make status/navigation bars transparent and allow content underneath.
         // The @capacitor-community/safe-area plugin handles icon colors via config.
         EdgeToEdge.enable(this);
-        // Prevent the keyboard from resizing the WebView (match iOS behavior).
-        // Must be set after EdgeToEdge.enable() as it installs its own insets
-        // listener that would otherwise override ours.
-        ViewCompat.setOnApplyWindowInsetsListener(
-            getWindow().getDecorView(),
-            (view, insets) -> {
-                // Strip out IME insets so the layout doesn't resize for the keyboard
-                return new WindowInsetsCompat.Builder(insets)
-                    .setInsets(WindowInsetsCompat.Type.ime(), androidx.core.graphics.Insets.NONE)
-                    .build();
-            }
-        );
+        setupSafeAreaInsets();
     }
 
+    /**
+     * Applies the safe area insets ourselves via a single window insets
+     * listener, adapted from @capacitor-community/safe-area.
+     *
+     * Owning the listener lets us:
+     *
+     * - Emulate the safe area for older Chromium WebViews (< v140) that report
+     *   env(safe-area-inset-*) as 0px, by padding the decorView and zeroing the
+     *   insets (and pass the insets through unchanged for newer WebViews).
+     * - Never offset for the on-screen keyboard. The keyboard overlays the
+     *   WebView; keyboard avoidance is handled in JS (see useKeyboardHeight).
+     *
+     * Must be called after EdgeToEdge.enable() and after the bridge has loaded
+     * its plugins, as both install their own listener that would otherwise
+     * override ours.
+     */
+    private void setupSafeAreaInsets() {
+        final int webViewMajorVersion = getWebViewMajorVersion();
+        // index.html always sets viewport-fit=cover, so newer WebViews can read
+        // the insets natively; only older WebViews need the padding fallback.
+        final boolean passthrough = webViewMajorVersion >= SAFE_AREA_CORE_FIX_WEBVIEW_VERSION;
+        final int barsTypeMask =
+            WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout();
+
+        ViewCompat.setOnApplyWindowInsetsListener(getWindow().getDecorView(), (view, insets) -> {
+            Insets bars = insets.getInsets(barsTypeMask);
+
+            // Strip the IME inset so neither the padding below nor the WebView's
+            // own viewport resizes the layout when the keyboard opens.
+            WindowInsetsCompat.Builder builder = new WindowInsetsCompat.Builder(insets)
+                .setInsets(WindowInsetsCompat.Type.ime(), Insets.NONE);
+
+            if (passthrough) {
+                view.setPadding(0, 0, 0, 0);
+                return builder.build();
+            }
+
+            // Older WebView: emulate the safe area by padding the decorView and
+            // reporting zeroed insets, since env(safe-area-inset-*) is broken.
+            view.setPadding(bars.left, bars.top, bars.right, bars.bottom);
+            return builder.setInsets(barsTypeMask, Insets.of(0, 0, 0, 0)).build();
+        });
+    }
+
+    /**
+     * Returns the major version of the system WebView (Chromium) package, or 0
+     * if it can't be determined (treated as an old WebView needing the
+     * padding fallback).
+     */
+    private int getWebViewMajorVersion() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            PackageInfo webViewPackage = WebView.getCurrentWebViewPackage();
+            if (webViewPackage != null && webViewPackage.versionName != null) {
+                Matcher matcher = Pattern.compile("(\\d+)").matcher(webViewPackage.versionName);
+                if (matcher.find()) {
+                    return Integer.parseInt(matcher.group(1));
+                }
+            }
+        }
+        return 0;
+    }
 }

--- a/android/app/src/main/java/org/microbit/mltrainer/MainActivity.java
+++ b/android/app/src/main/java/org/microbit/mltrainer/MainActivity.java
@@ -1,6 +1,7 @@
 package org.microbit.mltrainer;
 
 import android.content.pm.PackageInfo;
+import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
 import android.webkit.WebView;
@@ -8,7 +9,9 @@ import android.webkit.WebView;
 import androidx.activity.EdgeToEdge;
 import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
 
 import com.getcapacitor.BridgeActivity;
 
@@ -34,29 +37,43 @@ public class MainActivity extends BridgeActivity {
     @Override
     public void onStart() {
         super.onStart();
-        // Enable edge-to-edge mode for all Android versions.
-        // On API 35+ this is automatic, but older versions need this call
-        // to make status/navigation bars transparent and allow content underneath.
-        // The @capacitor-community/safe-area plugin handles icon colors via config.
+        // Enable edge-to-edge mode for all Android versions. On API 35+ this is
+        // automatic, but older versions need this call to make the status /
+        // navigation bars transparent and allow content underneath.
         EdgeToEdge.enable(this);
+        setupSystemBarsStyle();
         setupSafeAreaInsets();
     }
 
     /**
+     * Styles the system bars for our light UI: dark icons on a white
+     * background. Replaces @capacitor-community/safe-area's
+     * setSystemBarsStyle(LIGHT) call.
+     */
+    private void setupSystemBarsStyle() {
+        WindowInsetsControllerCompat controller =
+            WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
+        controller.setAppearanceLightStatusBars(true);
+        controller.setAppearanceLightNavigationBars(true);
+        // Shows behind the transparent bars (and in the padded safe area on
+        // older WebViews, see setupSafeAreaInsets).
+        getWindow().getDecorView().setBackgroundColor(Color.WHITE);
+    }
+
+    /**
      * Applies the safe area insets ourselves via a single window insets
-     * listener, adapted from @capacitor-community/safe-area.
+     * listener (we no longer use @capacitor-community/safe-area).
      *
-     * Owning the listener lets us:
+     * This does two things at once:
      *
-     * - Emulate the safe area for older Chromium WebViews (< v140) that report
+     * - Emulates the safe area for older Chromium WebViews (< v140) that report
      *   env(safe-area-inset-*) as 0px, by padding the decorView and zeroing the
-     *   insets (and pass the insets through unchanged for newer WebViews).
-     * - Never offset for the on-screen keyboard. The keyboard overlays the
+     *   insets (and passes the insets through unchanged for newer WebViews).
+     * - Never offsets for the on-screen keyboard. The keyboard overlays the
      *   WebView; keyboard avoidance is handled in JS (see useKeyboardHeight).
      *
-     * Must be called after EdgeToEdge.enable() and after the bridge has loaded
-     * its plugins, as both install their own listener that would otherwise
-     * override ours.
+     * Must be called after EdgeToEdge.enable(), which installs its own listener
+     * that would otherwise override ours.
      */
     private void setupSafeAreaInsets() {
         final int webViewMajorVersion = getWebViewMajorVersion();
@@ -84,6 +101,10 @@ public class MainActivity extends BridgeActivity {
             view.setPadding(bars.left, bars.top, bars.right, bars.bottom);
             return builder.setInsets(barsTypeMask, Insets.of(0, 0, 0, 0)).build();
         });
+
+        // Force an initial pass: unlike the plugin we don't install a
+        // WebViewClient that re-requests insets after the page loads.
+        ViewCompat.requestApplyInsets(getWindow().getDecorView());
     }
 
     /**

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -5,9 +5,6 @@ project(':capacitor-android').projectDir = new File('../node_modules/@capacitor/
 include ':capacitor-community-bluetooth-le'
 project(':capacitor-community-bluetooth-le').projectDir = new File('../node_modules/@capacitor-community/bluetooth-le/android')
 
-include ':capacitor-community-safe-area'
-project(':capacitor-community-safe-area').projectDir = new File('../node_modules/@capacitor-community/safe-area/android')
-
 include ':capacitor-firebase-analytics'
 project(':capacitor-firebase-analytics').projectDir = new File('../node_modules/@capacitor-firebase/analytics/android')
 

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -26,16 +26,6 @@ const config: CapacitorConfig = {
     adjustMarginsForEdgeToEdge: "disable",
   },
   plugins: {
-    SafeArea: {
-      // "DARK" = light/white icons for dark header background
-      // (confusing name - it refers to the background, not the icons)
-      statusBarStyle: "DARK",
-      navigationBarStyle: "LIGHT",
-    },
-    // Required by @capacitor-community/safe-area plugin from v8
-    SystemBars: {
-      insetsHandling: "disable",
-    },
     Keyboard: {
       // Prevent iOS from resizing the WebView when the keyboard opens.
       // We handle scroll-into-view manually via useKeyboardHeight.

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -12,7 +12,6 @@ def capacitor_pods
   pod 'Capacitor', :path => '../../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../../node_modules/@capacitor/ios'
   pod 'CapacitorCommunityBluetoothLe', :path => '../../node_modules/@capacitor-community/bluetooth-le'
-  pod 'CapacitorCommunitySafeArea', :path => '../../node_modules/@capacitor-community/safe-area'
   pod 'CapacitorFirebaseAnalytics', :path => '../../node_modules/@capacitor-firebase/analytics'
   pod 'CapacitorApp', :path => '../../node_modules/@capacitor/app'
   pod 'CapacitorFilesystem', :path => '../../node_modules/@capacitor/filesystem'

--- a/ios/App/Podfile.lock
+++ b/ios/App/Podfile.lock
@@ -5,8 +5,6 @@ PODS:
     - Capacitor
   - CapacitorCommunityBluetoothLe (7.3.2):
     - Capacitor
-  - CapacitorCommunitySafeArea (7.0.0):
-    - Capacitor
   - CapacitorCordova (7.4.5)
   - CapacitorFilesystem (7.1.6):
     - Capacitor
@@ -102,7 +100,6 @@ DEPENDENCIES:
   - "Capacitor (from `../../node_modules/@capacitor/ios`)"
   - "CapacitorApp (from `../../node_modules/@capacitor/app`)"
   - "CapacitorCommunityBluetoothLe (from `../../node_modules/@capacitor-community/bluetooth-le`)"
-  - "CapacitorCommunitySafeArea (from `../../node_modules/@capacitor-community/safe-area`)"
   - "CapacitorCordova (from `../../node_modules/@capacitor/ios`)"
   - "CapacitorFilesystem (from `../../node_modules/@capacitor/filesystem`)"
   - "CapacitorFirebaseAnalytics (from `../../node_modules/@capacitor-firebase/analytics`)"
@@ -135,8 +132,6 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/@capacitor/app"
   CapacitorCommunityBluetoothLe:
     :path: "../../node_modules/@capacitor-community/bluetooth-le"
-  CapacitorCommunitySafeArea:
-    :path: "../../node_modules/@capacitor-community/safe-area"
   CapacitorCordova:
     :path: "../../node_modules/@capacitor/ios"
   CapacitorFilesystem:
@@ -158,7 +153,6 @@ SPEC CHECKSUMS:
   Capacitor: 12914e6f1b7835e161a74ebd19cb361efa37a7dd
   CapacitorApp: 63b237168fc869e758481dba283315a85743ee78
   CapacitorCommunityBluetoothLe: 9aa29c1555fbe797e6b595db824c2acd39a5bdf5
-  CapacitorCommunitySafeArea: 211e919d3f0ff6020a3b2acb3b772fa30fb685ef
   CapacitorCordova: 31bbe4466000c6b86d9b7f1181ee286cff0205aa
   CapacitorFilesystem: 66f05ee0d8b1ccdc00d509091273a9b3b57c4a0b
   CapacitorFirebaseAnalytics: 27ad621b8f41c2cd2b2169f2db6f476cdac49011
@@ -180,6 +174,6 @@ SPEC CHECKSUMS:
   SentryCapacitor: 1d620200b850ef6f4e7056f5e20d7860e7c04572
   ZIPFoundation: b8c29ea7ae353b309bc810586181fd073cb3312c
 
-PODFILE CHECKSUM: 50cc5ba97adf86b9266d4ba623d5fbbce098eb6d
+PODFILE CHECKSUM: 29d696bc2bbc03ae11a4ec8f381a42af12266d5c
 
 COCOAPODS: 1.16.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "license": "MIT",
       "dependencies": {
         "@capacitor-community/bluetooth-le": "^7.3.0",
-        "@capacitor-community/safe-area": "^7.0.0-beta.5",
         "@capacitor-firebase/analytics": "^7.5.0",
         "@capacitor/android": "^7.4.4",
         "@capacitor/app": "^7.1.0",
@@ -406,15 +405,6 @@
       "dependencies": {
         "@types/web-bluetooth": "^0.0.20"
       },
-      "peerDependencies": {
-        "@capacitor/core": ">=7.0.0"
-      }
-    },
-    "node_modules/@capacitor-community/safe-area": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@capacitor-community/safe-area/-/safe-area-7.0.0.tgz",
-      "integrity": "sha512-+bze1ChJasYBvLtgp2mFeAHxiOmXqHvb1adtO0MbobZ/5WCrTsOi6ebECJkUpao4MJ4mqCBOus0jOXJXwx3YgA==",
-      "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=7.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
   },
   "dependencies": {
     "@capacitor-community/bluetooth-le": "^7.3.0",
-    "@capacitor-community/safe-area": "^7.0.0-beta.5",
     "@capacitor-firebase/analytics": "^7.5.0",
     "@capacitor/android": "^7.4.4",
     "@capacitor/app": "^7.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -378,16 +378,6 @@ const App = () => {
   // Detect safe area insets and set CSS variables for nav bar side only
   useSafeAreaInsets();
 
-  // Set status bar style on native platforms (LIGHT = dark icons for light backgrounds)
-  useEffect(() => {
-    if (isNativePlatform()) {
-      void import("@capacitor-community/safe-area").then(
-        ({ SafeArea, SystemBarsStyle }) =>
-          SafeArea.setSystemBarsStyle({ style: SystemBarsStyle.Light })
-      );
-    }
-  }, []);
-
   useEffect(() => {
     // Capability flags are user-scoped GA4 dimensions on the web build —
     // they describe the browser's WebUSB / WebBluetooth API surface, not


### PR DESCRIPTION
Fixes https://github.com/microbit-foundation/ml-trainer/issues/897

The overlap occurs for Chromium versions below 140. The safe area community plugin addresses this, however, our `setOnApplyWindowInsetsListener` that keeps the UI from resizing when the keyboard is opened stops the plugin from working. This is because our `setOnApplyWindowInsetsListener` overwrites the plugin's.

To address this, the safe area community plugin has been dropped and the fix for the safe area and the system bar styling have been moved to MainActivity.java. Now we only have one `setOnApplyWindowInsetsListener` that applies the fix for safe area and prevents UI from resizing when the keyboard is opened.