### PR TITLE
Filter out invalid language id

### DIFF
--- a/src/settings.tsx
+++ b/src/settings.tsx
@@ -289,11 +289,24 @@ export const nativeLanguageIds = ["en", "en-US"];
 const supportedLanguageIds = allLanguages.map((l) => l.id);
 const defaultLanguageId = allLanguages[0].id;
 
+const isValidLanguageId = (langId: string): boolean => {
+  try {
+    Intl.getCanonicalLocales(langId);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 /**
  * Match the user's preferred languages (from browser/OS) to supported languages.
  */
 export const matchLanguage = (requestedLanguages: readonly string[]): string =>
-  match(requestedLanguages, supportedLanguageIds, defaultLanguageId);
+  match(
+    requestedLanguages.filter(isValidLanguageId),
+    supportedLanguageIds,
+    defaultLanguageId
+  );
 
 /**
  * Get the initial language, checking URL parameter first, then OS/browser preference.


### PR DESCRIPTION
There have been errors due to invalid language id being used.

[See notes for details (private)](https://www.dropbox.com/scl/fi/voybiwfmbr4u8nconotc0/Untitled.paper?rlkey=rxgn494hry3ohm95snyootl8u&dl=0#:uid=275555905427434629404725&h2=RangeError:-Invalid-language-t)