### PR TITLE
Tweak Settings dialog initial focus

### DIFF
--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -23,7 +23,7 @@ import {
   useDisclosure,
   VStack,
 } from "@chakra-ui/react";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { useDeployment } from "../deployment";
 import { isNativePlatform } from "../platform";
@@ -57,6 +57,10 @@ export const SettingsDialog = ({
   // active surface; the web build defers to the shared-assets cookie
   // modal accessed via the nav-drawer "Manage cookies" link.
   const showAnalyticsToggle = isNativePlatform();
+  // Focus the heading rather than the first form control on open. Otherwise
+  // the graph colour scheme <select> takes focus and on mobile that opens its
+  // picker as soon as the dialog appears.
+  const initialFocusRef = useRef<HTMLHeadingElement>(null);
   const resetConfirmDialog = useDisclosure();
   const handleResetToDefault = useCallback(() => {
     resetConfirmDialog.onOpen();
@@ -120,10 +124,17 @@ export const SettingsDialog = ({
         onClose={onClose}
         size={{ base: "full", md: "xl" }}
         finalFocusRef={finalFocusRef}
+        initialFocusRef={initialFocusRef}
       >
         <ModalOverlay>
           <ModalContent>
-            <ModalHeader fontSize="lg" fontWeight="bold">
+            <ModalHeader
+              ref={initialFocusRef}
+              tabIndex={-1}
+              _focus={{ outline: "none", boxShadow: "none" }}
+              fontSize="lg"
+              fontWeight="bold"
+            >
               <FormattedMessage id="settings" />
             </ModalHeader>
             <ModalBody>


### PR DESCRIPTION
Fixes https://github.com/microbit-foundation/ml-trainer/issues/891

Change initial focus to be the dialog heading instead of the first dropdown option. This prevents the opening of the first dropdown when the dialog appears on mobile.

**Preview**

https://github.com/user-attachments/assets/67d2b69e-7731-480d-a1ea-254e8d510e3d


