### PR TITLE
Remove editor-not-ready reload on app resume

### DIFF
--- a/src/hooks/project-hooks.tsx
+++ b/src/hooks/project-hooks.tsx
@@ -562,7 +562,6 @@ export const ProjectProvider = ({
     [downloadActions, saveHex]
   );
 
-  const isEditorReady = useStore((s) => s.isEditorReady);
   // Native app URL open handler (e.g. opening a .hex file).
   useEffect(() => {
     if (Capacitor.isNativePlatform()) {
@@ -602,26 +601,11 @@ export const ProjectProvider = ({
         }
       );
 
-      const resumeListener = CapacitorApp.addListener("resume", () => {
-        if (!isEditorReady) {
-          logging.log("Editor not ready when resuming app, reloading...");
-          window.location.reload();
-        }
-      });
-
       return () => {
         void appUrlListener.then((l) => l.remove());
-        void resumeListener.then((l) => l.remove());
       };
     }
-  }, [
-    driverRef,
-    editorReady,
-    importProjectFromHexText,
-    isEditorReady,
-    logging,
-    setLoadingOverlayVisible,
-  ]);
+  }, [importProjectFromHexText, setLoadingOverlayVisible]);
 
   const value = useMemo(
     () => ({


### PR DESCRIPTION
The resume handler reloaded the app when the editor wasn't ready. It was a recovery for a MakeCode editor loading issue (https://github.com/microbit-foundation/ml-trainer/issues/765) that has since been fixed (via https://github.com/microbit-foundation/ml-trainer/pull/888), so it's no longer needed (tested on iPad to ensure it is not needed).

The resume handler also occasionally broke deep links: on a warm-start deep link, appUrlOpen navigates to the target route and "resume" fires right after. If MakeCode is not ready, the resume causes a reload, which races the navigation and resets the app to the home page. This issue can be reproduced by opening the app, quickly pressing a project idea card to open it in the browser, and then quickly pressing "Open in CreateAI" to return to the app. Removing the resume handler fixes the issue where the app opens, but doesn't navigate to the /import page.