### PR TITLE
Fix post add action focus

### DIFF
--- a/src/components/ActionNameCard.tsx
+++ b/src/components/ActionNameCard.tsx
@@ -75,9 +75,9 @@ const ActionNameCard = ({
   }, [value.id, viewMode]);
 
   // Avoid autofocus on mobile/native as it triggers the keyboard
-  const allowAutoFocus =
-    useBreakpointValue({ base: false, md: true }) && !isNativePlatform();
-
+  const isDesktop =
+    useBreakpointValue({ base: false, md: true }, { ssr: false }) &&
+    !isNativePlatform();
   const debouncedSetActionName = useMemo(
     () =>
       debounce(
@@ -186,6 +186,7 @@ const ActionNameCard = ({
               <LedIconPicker
                 actionName={value.name}
                 onIconSelected={handleIconSelected}
+                autoFocus={!isDesktop && localName.length === 0}
               >
                 <LedIconSvg icon={icon} />
               </LedIconPicker>
@@ -195,7 +196,7 @@ const ActionNameCard = ({
           </HStack>
           <Input
             id={actionNameInputId(value)}
-            autoFocus={allowAutoFocus && localName.length === 0}
+            autoFocus={isDesktop && localName.length === 0}
             isTruncated
             readOnly={viewMode !== ActionCardNameViewMode.Editable}
             value={localName}

--- a/src/components/LedIconPicker.tsx
+++ b/src/components/LedIconPicker.tsx
@@ -25,12 +25,14 @@ interface LedIconPicker {
   actionName: string;
   onIconSelected: (icon: MakeCodeIcon) => void;
   children: React.ReactElement;
+  autoFocus?: boolean;
 }
 
 const LedIconPicker = ({
   actionName,
   onIconSelected,
   children,
+  autoFocus = false,
 }: LedIconPicker) => {
   const intl = useIntl();
   const handleClick = useCallback(
@@ -64,6 +66,7 @@ const LedIconPicker = ({
                     })
               }
               _focusVisible={{ boxShadow: "outline", outline: "none" }}
+              autoFocus={autoFocus}
               cursor="pointer"
             >
               {children}


### PR DESCRIPTION
This fixes the issue of focus gets lost after adding an action regardless of platform.

- For desktop, autofocus on name input field for new action.
- For mobile/native, we autofocus on LED icon for new action. We cannot focus on the “Add action” button because it is disabled. This avoids the keyboard from getting triggered.