### PR TITLE
Make tooltip mobile/tablet SR supported

### DIFF
--- a/src/components/ClickableTooltip.tsx
+++ b/src/components/ClickableTooltip.tsx
@@ -3,29 +3,54 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { Flex, Tooltip, TooltipProps, useDisclosure } from "@chakra-ui/react";
-import { ReactNode, useCallback, useRef } from "react";
+import {
+  Box,
+  Button,
+  Flex,
+  Tooltip,
+  TooltipProps,
+  useDisclosure,
+} from "@chakra-ui/react";
+import { ReactNode, useCallback, useId, useRef } from "react";
 import { useIntl } from "react-intl";
 
-interface ClickableTooltipProps extends TooltipProps {
+interface ClickableTooltipProps extends Omit<TooltipProps, "label"> {
   children: ReactNode;
-  isFocusable?: boolean;
   titleId?: string;
+  label: ReactNode;
 }
 
 // Chakra Tooltip doesn't support triggering on mobile/tablets:
 // https://github.com/chakra-ui/chakra-ui/issues/2691
+//
+// Touch screen readers (iPadOS VoiceOver / Android TalkBack) never open the
+// tooltip, and even when opened its text is only associated with the trigger
+// while open (via aria-describedby that Chakra sets on its cloned child). So the
+// text is unreachable on tablets. We instead expose the same text on an
+// always-present node that is referenced from the real <button> trigger, so it
+// is part of the trigger's accessible name/description regardless of the visual
+// tooltip's open state.
+//
+// The trigger is a real <button> so it is focusable and operable (Enter/Space)
+// on every platform, rather than a role="button" span with none of the
+// behaviour. Chakra clones the outer <Flex> wrapper (which it needs for
+// positioning); that wrapper is a nameless, roleless span, so Chakra stamping
+// its own aria-describedby/handlers onto it is inert to assistive tech.
 
 const ClickableTooltip = ({
   children,
-  isFocusable = false,
   titleId,
-  isDisabled,
+  label: tooltipLabel,
   ...rest
 }: ClickableTooltipProps) => {
-  const label = useDisclosure();
+  const disclosure = useDisclosure();
   const intl = useIntl();
   const ref = useRef<HTMLDivElement>(null);
+  const descriptionId = useId();
+  // Distinguishes keyboard focus (should open) from pointer-driven focus (a
+  // tap/click, which toggles via onClick instead — otherwise a tap would open
+  // on focus and then immediately toggle closed).
+  const pointerDownRef = useRef(false);
   const handleMouseEnter = useCallback(() => {
     const focussedTooltips = Array.from(
       document.querySelectorAll(".focusable-tooltip")
@@ -33,50 +58,95 @@ const ClickableTooltip = ({
     if (
       focussedTooltips.every((tooltip) => tooltip !== document.activeElement)
     ) {
-      label.onOpen();
+      disclosure.onOpen();
     }
-  }, [label]);
+  }, [disclosure]);
   const handleMouseLeave = useCallback(() => {
-    if (
-      !isFocusable ||
-      (ref.current !== document.activeElement && isFocusable)
-    ) {
-      label.onClose();
+    // Keep it open while focus is inside the trigger.
+    if (!ref.current?.contains(document.activeElement)) {
+      disclosure.onClose();
     }
-  }, [isFocusable, label]);
+  }, [disclosure]);
+  const handlePointerDown = useCallback(() => {
+    pointerDownRef.current = true;
+  }, []);
+  const handleFocus = useCallback(() => {
+    if (!pointerDownRef.current) {
+      disclosure.onOpen();
+    }
+    pointerDownRef.current = false;
+  }, [disclosure]);
+  const handleBlur = useCallback(() => {
+    pointerDownRef.current = false;
+    disclosure.onClose();
+  }, [disclosure]);
+  const handleClick = useCallback(() => {
+    pointerDownRef.current = false;
+    disclosure.onToggle();
+  }, [disclosure]);
   const handleKeydown = useCallback(
-    (e: React.KeyboardEvent<HTMLDivElement>) => {
+    (e: React.KeyboardEvent<HTMLButtonElement>) => {
       if (e.key === "Escape") {
-        label.onClose();
+        disclosure.onClose();
       }
     },
-    [label]
+    [disclosure]
   );
+
+  // With a titleId we use a concise name plus the full label as the description;
+  // without one, the full label is the accessible name.
+  const nameProps = titleId
+    ? {
+        "aria-label": intl.formatMessage({ id: `${titleId}-tooltip-aria` }),
+        "aria-describedby": descriptionId,
+      }
+    : { "aria-labelledby": descriptionId };
+
   return (
-    <Tooltip isOpen={label.isOpen} {...rest} closeOnEsc={true}>
+    <Tooltip
+      isOpen={disclosure.isOpen}
+      label={
+        // Hide the transient Chakra popup from assistive tech; the sibling
+        // description node below is the always-present copy, so this avoids a
+        // second announcement via Chakra's open-state aria-describedby.
+        <Box aria-hidden={true}>{tooltipLabel}</Box>
+      }
+      {...rest}
+      closeOnEsc={true}
+    >
       <Flex
         as="span"
-        aria-label={
-          titleId
-            ? intl.formatMessage({ id: `${titleId}-tooltip-aria` })
-            : undefined
-        }
-        className={isFocusable ? "focusable-tooltip" : undefined}
-        onKeyDown={handleKeydown}
         ref={ref}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
-        onClick={label.onOpen}
-        tabIndex={isFocusable && !isDisabled ? 0 : undefined}
-        onFocus={isFocusable ? label.onOpen : undefined}
-        onBlur={isFocusable ? label.onClose : undefined}
-        _focusVisible={{
-          boxShadow: "outline",
-          outline: "none",
-        }}
-        borderRadius="50%"
       >
-        {children}
+        <Button
+          {...nameProps}
+          variant="unstyled"
+          className="focusable-tooltip"
+          onClick={handleClick}
+          onPointerDown={handlePointerDown}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onKeyDown={handleKeydown}
+          display="flex"
+          alignItems="stretch"
+          justifyContent="center"
+          w="100%"
+          h="100%"
+          minW={0}
+          cursor="pointer"
+          borderRadius="50%"
+          _focusVisible={{
+            boxShadow: "outline",
+            outline: "none",
+          }}
+        >
+          {children}
+        </Button>
+        <Box id={descriptionId} aria-hidden={true} srOnly>
+          {tooltipLabel}
+        </Box>
       </Flex>
     </Tooltip>
   );

--- a/src/components/ClickableTooltip.tsx
+++ b/src/components/ClickableTooltip.tsx
@@ -18,6 +18,13 @@ interface ClickableTooltipProps extends Omit<TooltipProps, "label"> {
   children: ReactNode;
   titleId?: string;
   label: ReactNode;
+  /**
+   * Render the tooltip as visual-only: a non-focusable trigger that
+   * shows the tooltip on hover/click not keyboard reachable. This is a 
+   * temporary escape hatch for RecordingFingerprint data features until an
+   * accessible solution is implemented.
+   */
+  visualOnly?: boolean;
 }
 
 // Chakra Tooltip doesn't support triggering on mobile/tablets:
@@ -26,23 +33,27 @@ interface ClickableTooltipProps extends Omit<TooltipProps, "label"> {
 // Touch screen readers (iPadOS VoiceOver / Android TalkBack) never open the
 // tooltip, and even when opened its text is only associated with the trigger
 // while open (via aria-describedby that Chakra sets on its cloned child). So the
-// text is unreachable on tablets. We instead expose the same text on an
-// always-present node that is referenced from the real <button> trigger, so it
-// is part of the trigger's accessible name/description regardless of the visual
-// tooltip's open state.
+// text is unreachable on tablets. For the default "button" trigger we instead
+// expose the same text on an always-present node referenced from the button, so
+// it is part of the trigger's accessible name/description regardless of the
+// visual tooltip's open state.
 //
-// The trigger is a real <button> so it is focusable and operable (Enter/Space)
-// on every platform, rather than a role="button" span with none of the
-// behaviour. Chakra clones the outer <Flex> wrapper (which it needs for
-// positioning); that wrapper is a nameless, roleless span, so Chakra stamping
-// its own aria-describedby/handlers onto it is inert to assistive tech.
+// A real <button> is focusable and operable (Enter/Space) on every platform,
+// rather than a role="button" span with none of the behaviour. Chakra clones
+// the outer <Flex> wrapper (which it needs for positioning); that wrapper is a
+// nameless, roleless span, so Chakra stamping its own aria-describedby/handlers
+// onto it is inert to assistive tech.
+//
+// The visualOnly prop opts out of all of the above (see its doc comment).
 
 const ClickableTooltip = ({
   children,
   titleId,
+  visualOnly = false,
   label: tooltipLabel,
   ...rest
 }: ClickableTooltipProps) => {
+  const isButton = !visualOnly;
   const disclosure = useDisclosure();
   const intl = useIntl();
   const ref = useRef<HTMLDivElement>(null);
@@ -93,9 +104,9 @@ const ClickableTooltip = ({
     [disclosure]
   );
 
-  // With a titleId we use a concise name plus the full label as the description;
-  // without one, the full label is the accessible name.
-  const nameProps = titleId
+  const nameProps = !isButton
+    ? {}
+    : titleId
     ? {
         "aria-label": intl.formatMessage({ id: `${titleId}-tooltip-aria` }),
         "aria-describedby": descriptionId,
@@ -106,10 +117,7 @@ const ClickableTooltip = ({
     <Tooltip
       isOpen={disclosure.isOpen}
       label={
-        // Hide the transient Chakra popup from assistive tech; the sibling
-        // description node below is the always-present copy, so this avoids a
-        // second announcement via Chakra's open-state aria-describedby.
-        <Box aria-hidden={true}>{tooltipLabel}</Box>
+        isButton ? <Box aria-hidden={true}>{tooltipLabel}</Box> : tooltipLabel
       }
       {...rest}
       closeOnEsc={true}
@@ -121,13 +129,14 @@ const ClickableTooltip = ({
         onMouseLeave={handleMouseLeave}
       >
         <Button
+          as={isButton ? "button" : "span"}
           {...nameProps}
           variant="unstyled"
-          className="focusable-tooltip"
+          className={isButton ? "focusable-tooltip" : undefined}
           onClick={handleClick}
           onPointerDown={handlePointerDown}
-          onFocus={handleFocus}
-          onBlur={handleBlur}
+          onFocus={isButton ? handleFocus : undefined}
+          onBlur={isButton ? handleBlur : undefined}
           onKeyDown={handleKeydown}
           display="flex"
           alignItems="stretch"
@@ -144,9 +153,11 @@ const ClickableTooltip = ({
         >
           {children}
         </Button>
-        <Box id={descriptionId} aria-hidden={true} srOnly>
-          {tooltipLabel}
-        </Box>
+        {isButton && (
+          <Box id={descriptionId} aria-hidden={true} srOnly>
+            {tooltipLabel}
+          </Box>
+        )}
       </Flex>
     </Tooltip>
   );

--- a/src/components/ClickableTooltip.tsx
+++ b/src/components/ClickableTooltip.tsx
@@ -20,7 +20,7 @@ interface ClickableTooltipProps extends Omit<TooltipProps, "label"> {
   label: ReactNode;
   /**
    * Render the tooltip as visual-only: a non-focusable trigger that
-   * shows the tooltip on hover/click not keyboard reachable. This is a 
+   * shows the tooltip on hover/click not keyboard reachable. This is a
    * temporary escape hatch for RecordingFingerprint data features until an
    * accessible solution is implemented.
    */

--- a/src/components/InfoToolTip.tsx
+++ b/src/components/InfoToolTip.tsx
@@ -17,7 +17,6 @@ const InfoToolTip = ({ titleId, descriptionId, ...rest }: InfoToolTipProps) => {
   const { appNameFull } = useDeployment();
   return (
     <ClickableTooltip
-      isFocusable
       titleId={titleId}
       hasArrow
       placement="right"

--- a/src/components/RecordingFingerprint.tsx
+++ b/src/components/RecordingFingerprint.tsx
@@ -39,6 +39,9 @@ const RecordingFingerprint = ({
     >
       {Object.keys(dataFeatures).map((k) => (
         <ClickableTooltip
+          // Temporary escape hatch from being a tab stop until an 
+          // accessible solution is implemented.
+          visualOnly
           placement="end-end"
           key={k}
           label={

--- a/src/components/RecordingFingerprint.tsx
+++ b/src/components/RecordingFingerprint.tsx
@@ -39,7 +39,7 @@ const RecordingFingerprint = ({
     >
       {Object.keys(dataFeatures).map((k) => (
         <ClickableTooltip
-          // Temporary escape hatch from being a tab stop until an 
+          // Temporary escape hatch from being a tab stop until an
           // accessible solution is implemented.
           visualOnly
           placement="end-end"

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -211,7 +211,6 @@ const ProjectRow = () => {
             </Heading>
             {!isNativePlatform() && (
               <ClickableTooltip
-                isFocusable
                 hasArrow
                 placement={tooltipPlacement}
                 label={


### PR DESCRIPTION
### Issue
The tooltip text was only associated with its trigger while the tooltip was open (via the aria-describedby Chakra sets on its cloned child), and the popup is rendered only while open. On iPad/Android tablets there is no hover to open it, so the text was never in the accessibility tree at the moment of focus and was never announced.

### What's changed

Expose the same text on an always-present node instead, referenced from the trigger so it is part of the trigger's accessible name/description regardless of the visual tooltip's open state:

- Trigger is now a real Button so it is focusable and operable (Enter/Space) on every platform. 
- The referenced node is an aria-hidden sibling of the button. With a titleId it is the description (aria-describedby) alongside a concise aria-label name without one it is the accessible name (aria-labelledby).
- Click toggles the tooltip.
- RecordingFingerprint remains inaccessible via visualOnly prop to mimic existing behaviour to avoid introducing a new tab stops.
