### PR TITLE
Screen reader accessible bluetooth pairing pattern input

### DIFF
--- a/lang/ui.ca.json
+++ b/lang/ui.ca.json
@@ -431,6 +431,10 @@
     "defaultMessage": "El nombre de LEDs encesos a cada columna de la micro:bit, d'esquerra a dreta, són {numLedsOnCol1}, {numLedsOnCol2}, {numLedsOnCol3}, {numLedsOnCol4} i {numLedsOnCol5}.",
     "description": "Screen reader text for numeric pattern input"
   },
+  "connect-pattern-led-option-label": {
+    "defaultMessage": "Column {colNum}, {numLeds, plural, one {# LED lit} other {# LEDs lit}}",
+    "description": "Screen reader label for a pattern option, stating the column and how many LEDs would be lit in it"
+  },
   "connect-pattern-subtitle": {
     "defaultMessage": "Copia el patró que es mostra a la micro:bit.",
     "description": "Instruction for bluetooth pattern dialog"

--- a/lang/ui.en-us.json
+++ b/lang/ui.en-us.json
@@ -431,6 +431,10 @@
     "defaultMessage": "The number of LEDs lit in each column of the micro:bit display, from left to right, are {numLedsOnCol1}, {numLedsOnCol2}, {numLedsOnCol3}, {numLedsOnCol4}, and {numLedsOnCol5}.",
     "description": "Screen reader text for numeric pattern input"
   },
+  "connect-pattern-led-option-label": {
+    "defaultMessage": "Column {colNum}, {numLeds, plural, one {# LED lit} other {# LEDs lit}}",
+    "description": "Screen reader label for a pattern option, stating the column and how many LEDs would be lit in it"
+  },
   "connect-pattern-subtitle": {
     "defaultMessage": "Copy the pattern displayed on the micro:bit.",
     "description": "Instruction for bluetooth pattern dialog"

--- a/lang/ui.en.json
+++ b/lang/ui.en.json
@@ -431,6 +431,10 @@
     "defaultMessage": "The number of LEDs lit in each column of the micro:bit display, from left to right, are {numLedsOnCol1}, {numLedsOnCol2}, {numLedsOnCol3}, {numLedsOnCol4}, and {numLedsOnCol5}.",
     "description": "Screen reader text for numeric pattern input"
   },
+  "connect-pattern-led-option-label": {
+    "defaultMessage": "Column {colNum}, {numLeds, plural, one {# LED lit} other {# LEDs lit}}",
+    "description": "Screen reader label for a pattern option, stating the column and how many LEDs would be lit in it"
+  },
   "connect-pattern-subtitle": {
     "defaultMessage": "Copy the pattern displayed on the micro:bit.",
     "description": "Instruction for bluetooth pattern dialog"

--- a/lang/ui.es-es.json
+++ b/lang/ui.es-es.json
@@ -431,6 +431,10 @@
     "defaultMessage": "El número de LEDs encendidos en cada columna de la pantalla de la micro:bit, de izquierda a derecha, es {numLedsOnCol1}, {numLedsOnCol2}, {numLedsOnCol3}, {numLedsOnCol4} y {numLedsOnCol5}.",
     "description": "Screen reader text for numeric pattern input"
   },
+  "connect-pattern-led-option-label": {
+    "defaultMessage": "Column {colNum}, {numLeds, plural, one {# LED lit} other {# LEDs lit}}",
+    "description": "Screen reader label for a pattern option, stating the column and how many LEDs would be lit in it"
+  },
   "connect-pattern-subtitle": {
     "defaultMessage": "Copia el patrón que aparece en el micro:bit.",
     "description": "Instruction for bluetooth pattern dialog"

--- a/lang/ui.fr.json
+++ b/lang/ui.fr.json
@@ -431,6 +431,10 @@
     "defaultMessage": "Le nombre de LED allumées dans chaque colonne de l'écran micro:bit, de gauche à droite, est {numLedsOnCol1}, {numLedsOnCol2}, {numLedsOnCol3}, {numLedsOnCol4} et {numLedsOnCol5}.",
     "description": "Screen reader text for numeric pattern input"
   },
+  "connect-pattern-led-option-label": {
+    "defaultMessage": "Column {colNum}, {numLeds, plural, one {# LED lit} other {# LEDs lit}}",
+    "description": "Screen reader label for a pattern option, stating the column and how many LEDs would be lit in it"
+  },
   "connect-pattern-subtitle": {
     "defaultMessage": "Copiez le motif affiché sur le micro:bit.",
     "description": "Instruction for bluetooth pattern dialog"

--- a/lang/ui.ja.json
+++ b/lang/ui.ja.json
@@ -431,6 +431,10 @@
     "defaultMessage": "The number of LEDs lit in each column of the micro:bit display, from left to right, are {numLedsOnCol1}, {numLedsOnCol2}, {numLedsOnCol3}, {numLedsOnCol4}, and {numLedsOnCol5}.",
     "description": "Screen reader text for numeric pattern input"
   },
+  "connect-pattern-led-option-label": {
+    "defaultMessage": "Column {colNum}, {numLeds, plural, one {# LED lit} other {# LEDs lit}}",
+    "description": "Screen reader label for a pattern option, stating the column and how many LEDs would be lit in it"
+  },
   "connect-pattern-subtitle": {
     "defaultMessage": "micro:bitに表示されているパターンをコピーします。",
     "description": "Instruction for bluetooth pattern dialog"

--- a/lang/ui.ko.json
+++ b/lang/ui.ko.json
@@ -431,6 +431,10 @@
     "defaultMessage": "The number of LEDs lit in each column of the micro:bit display, from left to right, are {numLedsOnCol1}, {numLedsOnCol2}, {numLedsOnCol3}, {numLedsOnCol4}, and {numLedsOnCol5}.",
     "description": "Screen reader text for numeric pattern input"
   },
+  "connect-pattern-led-option-label": {
+    "defaultMessage": "Column {colNum}, {numLeds, plural, one {# LED lit} other {# LEDs lit}}",
+    "description": "Screen reader label for a pattern option, stating the column and how many LEDs would be lit in it"
+  },
   "connect-pattern-subtitle": {
     "defaultMessage": "micro:bit에 표시된 패턴을 복사합니다.",
     "description": "Instruction for bluetooth pattern dialog"

--- a/lang/ui.lol.json
+++ b/lang/ui.lol.json
@@ -431,6 +431,10 @@
     "defaultMessage": "crwdns369665:0{numLedsOnCol1}crwdnd369665:0{numLedsOnCol2}crwdnd369665:0{numLedsOnCol3}crwdnd369665:0{numLedsOnCol4}crwdnd369665:0{numLedsOnCol5}crwdne369665:0",
     "description": "Screen reader text for numeric pattern input"
   },
+  "connect-pattern-led-option-label": {
+    "defaultMessage": "Column {colNum}, {numLeds, plural, one {# LED lit} other {# LEDs lit}}",
+    "description": "Screen reader label for a pattern option, stating the column and how many LEDs would be lit in it"
+  },
   "connect-pattern-subtitle": {
     "defaultMessage": "crwdns362778:0crwdne362778:0",
     "description": "Instruction for bluetooth pattern dialog"

--- a/lang/ui.nl.json
+++ b/lang/ui.nl.json
@@ -431,6 +431,10 @@
     "defaultMessage": "Het aantal LED's in elke kolom van het micro:bit display, van links tot rechts. zijn {numLedsOnCol1}, {numLedsOnCol2}, {numLedsOnCol3}, {numLedsOnCol4} en {numLedsOnCol5}.",
     "description": "Screen reader text for numeric pattern input"
   },
+  "connect-pattern-led-option-label": {
+    "defaultMessage": "Column {colNum}, {numLeds, plural, one {# LED lit} other {# LEDs lit}}",
+    "description": "Screen reader label for a pattern option, stating the column and how many LEDs would be lit in it"
+  },
   "connect-pattern-subtitle": {
     "defaultMessage": "Kopieer het getoonde patroon op de micro:bit.",
     "description": "Instruction for bluetooth pattern dialog"

--- a/lang/ui.pl.json
+++ b/lang/ui.pl.json
@@ -431,6 +431,10 @@
     "defaultMessage": "Liczba włączonych diod LED w każdej kolumnie wyświetlacza micro:bita, od lewej do prawej, jest {numLedsOnCol1}, {numLedsOnCol2}, {numLedsOnCol3}, {numLedsOnCol4} i {numLedsOnCol5}.",
     "description": "Screen reader text for numeric pattern input"
   },
+  "connect-pattern-led-option-label": {
+    "defaultMessage": "Column {colNum}, {numLeds, plural, one {# LED lit} other {# LEDs lit}}",
+    "description": "Screen reader label for a pattern option, stating the column and how many LEDs would be lit in it"
+  },
   "connect-pattern-subtitle": {
     "defaultMessage": "Skopiuj wzór wyświetlany na micro:bicie.",
     "description": "Instruction for bluetooth pattern dialog"

--- a/lang/ui.pt-br.json
+++ b/lang/ui.pt-br.json
@@ -431,6 +431,10 @@
     "defaultMessage": "The number of LEDs lit in each column of the micro:bit display, from left to right, are {numLedsOnCol1}, {numLedsOnCol2}, {numLedsOnCol3}, {numLedsOnCol4}, and {numLedsOnCol5}.",
     "description": "Screen reader text for numeric pattern input"
   },
+  "connect-pattern-led-option-label": {
+    "defaultMessage": "Column {colNum}, {numLeds, plural, one {# LED lit} other {# LEDs lit}}",
+    "description": "Screen reader label for a pattern option, stating the column and how many LEDs would be lit in it"
+  },
   "connect-pattern-subtitle": {
     "defaultMessage": "Copie o padrão exibido no micro:bit.",
     "description": "Instruction for bluetooth pattern dialog"

--- a/lang/ui.zh-tw.json
+++ b/lang/ui.zh-tw.json
@@ -431,6 +431,10 @@
     "defaultMessage": "The number of LEDs lit in each column of the micro:bit display, from left to right, are {numLedsOnCol1}, {numLedsOnCol2}, {numLedsOnCol3}, {numLedsOnCol4}, and {numLedsOnCol5}.",
     "description": "Screen reader text for numeric pattern input"
   },
+  "connect-pattern-led-option-label": {
+    "defaultMessage": "Column {colNum}, {numLeds, plural, one {# LED lit} other {# LEDs lit}}",
+    "description": "Screen reader label for a pattern option, stating the column and how many LEDs would be lit in it"
+  },
   "connect-pattern-subtitle": {
     "defaultMessage": "複製 micro:bit 上顯示的圖案。",
     "description": "Instruction for bluetooth pattern dialog"

--- a/src/components/BluetoothPatternInput.tsx
+++ b/src/components/BluetoothPatternInput.tsx
@@ -37,7 +37,7 @@ interface BluetoothPatternInputProps {
 
 const matrixDim = 5;
 const cellSize = "44px";
-const cellGap = 1.5
+const cellGap = 1.5;
 
 const BluetoothPatternInput = ({
   onChange,
@@ -182,10 +182,18 @@ const PatternColumn = ({
           {...getRadioProps({ value: rowIdx.toString() })}
           isOn={isOn}
           isHighlighted={highlighted[rowIdx]}
-          label={intl.formatMessage(
-            { id: "connect-pattern-led-option-label" },
-            { colNum, numLeds: matrixDim - rowIdx }
-          )}
+          label={
+            // TODO: Remove web fallback use the label version once it is 
+            // translated on the web for the supported languages.
+            isNativePlatform()
+              ? intl.formatMessage(
+                  {
+                    id: "connect-pattern-led-option-label",
+                  },
+                  { colNum, numLeds: matrixDim - rowIdx }
+                )
+              : `${matrixDim - rowIdx}`
+          }
           testId={`bluetooth-pattern-led-${colIdx}-${matrixDim - rowIdx}`}
           onMouseEnter={() => onHighlight(colIdx, rowIdx)}
           onMouseLeave={onClearHighlight}

--- a/src/components/BluetoothPatternInput.tsx
+++ b/src/components/BluetoothPatternInput.tsx
@@ -78,8 +78,11 @@ const BluetoothPatternInput = ({
   return (
     <HStack gap={1} alignItems="flex-start">
       {matrixColumns.map((cells, colIdx) => {
-        const letter =
-          nativePlatform && microbitName ? microbitName[colIdx] : undefined;
+        const letter = nativePlatform
+          ? microbitName
+            ? microbitName[colIdx]
+            : ""
+          : undefined;
         return isEditable ? (
           <PatternColumn
             key={colIdx}

--- a/src/components/BluetoothPatternInput.tsx
+++ b/src/components/BluetoothPatternInput.tsx
@@ -183,7 +183,7 @@ const PatternColumn = ({
           isOn={isOn}
           isHighlighted={highlighted[rowIdx]}
           label={
-            // TODO: Remove web fallback use the label version once it is 
+            // TODO: Remove web fallback use the label version once it is
             // translated on the web for the supported languages.
             isNativePlatform()
               ? intl.formatMessage(

--- a/src/components/BluetoothPatternInput.tsx
+++ b/src/components/BluetoothPatternInput.tsx
@@ -36,7 +36,8 @@ interface BluetoothPatternInputProps {
 }
 
 const matrixDim = 5;
-const cellSize = "35px";
+const cellSize = "44px";
+const cellGap = 1.5
 
 const BluetoothPatternInput = ({
   onChange,
@@ -76,7 +77,7 @@ const BluetoothPatternInput = ({
   const isEditable = !!onChange;
 
   return (
-    <HStack gap={1} alignItems="flex-start">
+    <HStack gap={cellGap} alignItems="flex-start">
       {matrixColumns.map((cells, colIdx) => {
         const letter = nativePlatform
           ? microbitName
@@ -166,7 +167,7 @@ const PatternColumn = ({
 
   return (
     <VStack
-      gap={1}
+      gap={cellGap}
       {...getRootProps()}
       role="radiogroup"
       aria-label={intl.formatMessage(

--- a/src/components/BluetoothPatternInput.tsx
+++ b/src/components/BluetoothPatternInput.tsx
@@ -186,6 +186,7 @@ const PatternColumn = ({
             { id: "connect-pattern-led-option-label" },
             { colNum, numLeds: matrixDim - rowIdx }
           )}
+          testId={`bluetooth-pattern-led-${colIdx}-${matrixDim - rowIdx}`}
           onMouseEnter={() => onHighlight(colIdx, rowIdx)}
           onMouseLeave={onClearHighlight}
           onReactivate={
@@ -208,6 +209,7 @@ interface PatternLedOptionProps extends UseRadioProps {
   isOn: boolean;
   isHighlighted: boolean;
   label: string;
+  testId: string;
   onMouseEnter: () => void;
   onMouseLeave: () => void;
   onReactivate?: () => void;
@@ -217,6 +219,7 @@ const PatternLedOption = ({
   isOn,
   isHighlighted,
   label,
+  testId,
   onMouseEnter,
   onMouseLeave,
   onReactivate,
@@ -228,6 +231,7 @@ const PatternLedOption = ({
   return (
     <Box
       as="label"
+      data-testid={testId}
       w={cellSize}
       h={cellSize}
       cursor="pointer"

--- a/src/components/BluetoothPatternInput.tsx
+++ b/src/components/BluetoothPatternInput.tsx
@@ -5,18 +5,16 @@
  */
 import {
   Box,
-  Button,
-  FormControl,
-  FormLabel,
-  Grid,
-  GridItem,
-  NumberInput,
-  NumberInputField,
+  HStack,
   Text,
+  useRadio,
+  useRadioGroup,
+  UseRadioProps,
   VisuallyHidden,
+  VStack,
 } from "@chakra-ui/react";
-import React, { useCallback, useState } from "react";
-import { FormattedMessage } from "react-intl";
+import { useCallback, useState } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
 import {
   generateMatrix,
   getHighlightedColumns,
@@ -38,6 +36,7 @@ interface BluetoothPatternInputProps {
 }
 
 const matrixDim = 5;
+const cellSize = "35px";
 
 const BluetoothPatternInput = ({
   onChange,
@@ -51,118 +50,66 @@ const BluetoothPatternInput = ({
     generateMatrix(matrixDim, false)
   );
   const matrixColumns = transformMatrixToColumns(pattern, matrixDim);
-  const [inputValues, setInputValues] = useState<string[]>(
-    matrixColumns.map((cols) => cols.filter((c) => c).length.toString())
-  );
 
   const clearHighlighted = useCallback(() => {
     setHighlighted(generateMatrix(matrixDim, false));
   }, []);
 
+  const highlightCell = useCallback(
+    (colIdx: number, rowIdx: number) => {
+      setHighlighted(getHighlightedColumns(matrixColumns, { colIdx, rowIdx }));
+    },
+    [matrixColumns]
+  );
+
   const updateMatrix = useCallback(
     (colIdx: number, rowIdx: number) => {
+      clearHighlighted();
       const columns = updateMatrixColumns(matrixColumns, { colIdx, rowIdx });
       const matrix = transformColumnsToMatrix(columns) as boolean[];
       onChange && onChange(microbitPatternToName(matrix));
     },
-    [matrixColumns, onChange]
-  );
-
-  const columnInputOnChange = useCallback(
-    (colIdx: number): ((value: string) => void) => {
-      return (value) => {
-        const colValue = value === "" ? 0 : parseInt(value);
-        if (isNaN(colValue) || colValue > 5 || colValue < 0) {
-          // Do nothing when input value is not valid.
-          return;
-        }
-        setInputValues(inputValues.map((v, i) => (i === colIdx ? value : v)));
-        updateMatrix(colIdx, matrixDim - colValue);
-      };
-    },
-    [inputValues, updateMatrix]
+    [clearHighlighted, matrixColumns, onChange]
   );
 
   const nativePlatform = isNativePlatform();
   const isEditable = !!onChange;
 
   return (
-    <Grid
-      templateColumns="repeat(5, 35px)"
-      templateRows={`repeat(${nativePlatform ? 7 : 6}, 35px)`}
-      gap={1}
-    >
-      {matrixColumns.map((cells, colIdx) => (
-        <React.Fragment key={colIdx}>
-          {cells.map((c, rowIdx) => (
-            <GridItem
-              colSpan={1}
-              rowStart={rowIdx + 1}
-              key={`col-${colIdx}-cell-${rowIdx}`}
-            >
-              <PatternBox
-                onClick={() => {
-                  clearHighlighted();
-                  const numSelectedInCol = cells.filter(Boolean).length;
-                  const isTopSelectedCellInCol =
-                    rowIdx + numSelectedInCol === matrixDim;
-                  // If top selected cell in column, deselect it.
-                  if (isTopSelectedCellInCol) {
-                    updateMatrix(colIdx, rowIdx + 1);
-                    return;
-                  }
-                  updateMatrix(colIdx, rowIdx);
-                }}
-                onMouseEnter={() => {
-                  setHighlighted(
-                    getHighlightedColumns(matrixColumns, { colIdx, rowIdx })
-                  );
-                }}
-                onMouseLeave={clearHighlighted}
-                isOn={c}
-                isHighlighted={highlighted[colIdx][rowIdx]}
-                editable={isEditable}
-              />
-            </GridItem>
-          ))}
-          {nativePlatform && (
-            <GridItem
-              rowStart={6}
-              textAlign="center"
-              key={`col-${colIdx}-pattern-letter`}
-              aria-hidden
-            >
-              <Text>{microbitName ? microbitName[colIdx] : " "}</Text>
-            </GridItem>
-          )}
-          <GridItem key={`col-${colIdx}-pattern-input`}>
-            {isEditable && (
-              <PatternColumnInput
-                isInvalid={invalid}
-                onChange={columnInputOnChange(colIdx)}
-                colIdx={colIdx}
-                value={inputValues[colIdx]}
-              />
-            )}
-          </GridItem>
-        </React.Fragment>
-      ))}
-      {nativePlatform && (
+    <HStack gap={1} alignItems="flex-start">
+      {matrixColumns.map((cells, colIdx) => {
+        const letter =
+          nativePlatform && microbitName ? microbitName[colIdx] : undefined;
+        return isEditable ? (
+          <PatternColumn
+            key={colIdx}
+            colIdx={colIdx}
+            cells={cells}
+            letter={letter}
+            invalid={invalid}
+            highlighted={highlighted[colIdx]}
+            onSelect={updateMatrix}
+            onHighlight={highlightCell}
+            onClearHighlight={clearHighlighted}
+          />
+        ) : (
+          <ReadonlyPatternColumn key={colIdx} cells={cells} letter={letter} />
+        );
+      })}
+      {nativePlatform && !isEditable && (
         <VisuallyHidden>
-          {!isEditable && (
-            <Text>
-              <FormattedMessage
-                id="connect-pattern-label"
-                values={{
-                  numLedsOnCol1: inputValues[0],
-                  numLedsOnCol2: inputValues[1],
-                  numLedsOnCol3: inputValues[2],
-                  numLedsOnCol4: inputValues[3],
-                  numLedsOnCol5: inputValues[4],
-                }}
-              />
-            </Text>
-          )}
+          <Text>
+            <FormattedMessage
+              id="connect-pattern-label"
+              values={{
+                numLedsOnCol1: matrixColumns[0].filter(Boolean).length,
+                numLedsOnCol2: matrixColumns[1].filter(Boolean).length,
+                numLedsOnCol3: matrixColumns[2].filter(Boolean).length,
+                numLedsOnCol4: matrixColumns[3].filter(Boolean).length,
+                numLedsOnCol5: matrixColumns[4].filter(Boolean).length,
+              }}
+            />
+          </Text>
           <Text>
             <FormattedMessage
               id="microbit-name-label"
@@ -171,87 +118,171 @@ const BluetoothPatternInput = ({
           </Text>
         </VisuallyHidden>
       )}
-    </Grid>
+    </HStack>
   );
 };
 
-interface PatternBoxProps {
+interface PatternColumnProps {
+  colIdx: number;
+  cells: boolean[];
+  letter: string | undefined;
+  invalid: boolean;
+  highlighted: boolean[];
+  onSelect: (colIdx: number, rowIdx: number) => void;
+  onHighlight: (colIdx: number, rowIdx: number) => void;
+  onClearHighlight: () => void;
+}
+
+/**
+ * A single column of the pairing pattern, presented as a radio group where each
+ * LED is an option. Selecting an LED lights it and every LED below it, so the
+ * checked option is the topmost lit LED and communicates how many LEDs are lit.
+ */
+const PatternColumn = ({
+  colIdx,
+  cells,
+  letter,
+  invalid,
+  highlighted,
+  onSelect,
+  onHighlight,
+  onClearHighlight,
+}: PatternColumnProps) => {
+  const intl = useIntl();
+  const colNum = colIdx + 1;
+  const numLit = cells.filter(Boolean).length;
+  // The topmost lit LED is the checked option; nothing is checked when the
+  // column is empty (a not-yet-entered column).
+  const topLitRowIdx = numLit > 0 ? matrixDim - numLit : -1;
+
+  const { getRootProps, getRadioProps } = useRadioGroup({
+    name: `bluetooth-pattern-column-${colIdx}`,
+    value: numLit > 0 ? topLitRowIdx.toString() : "",
+    onChange: (value: string) => onSelect(colIdx, parseInt(value)),
+  });
+
+  return (
+    <VStack
+      gap={1}
+      {...getRootProps()}
+      role="radiogroup"
+      aria-label={intl.formatMessage(
+        { id: "connect-pattern-input-label" },
+        { colNum }
+      )}
+      aria-invalid={invalid || undefined}
+    >
+      {cells.map((isOn, rowIdx) => (
+        <PatternLedOption
+          key={rowIdx}
+          {...getRadioProps({ value: rowIdx.toString() })}
+          isOn={isOn}
+          isHighlighted={highlighted[rowIdx]}
+          label={intl.formatMessage(
+            { id: "connect-pattern-led-option-label" },
+            { colNum, numLeds: matrixDim - rowIdx }
+          )}
+          onMouseEnter={() => onHighlight(colIdx, rowIdx)}
+          onMouseLeave={onClearHighlight}
+          // Re-activating the checked (topmost lit) LED turns it off, matching
+          // the previous click-to-toggle behaviour. Selecting any other LED
+          // fires the radio group's onChange instead.
+          onReactivate={
+            isOn && rowIdx === topLitRowIdx
+              ? () => onSelect(colIdx, rowIdx + 1)
+              : undefined
+          }
+        />
+      ))}
+      {letter !== undefined && (
+        <Text h={cellSize} lineHeight={cellSize} aria-hidden>
+          {letter}
+        </Text>
+      )}
+    </VStack>
+  );
+};
+
+interface PatternLedOptionProps extends UseRadioProps {
   isOn: boolean;
-  onClick: () => void;
+  isHighlighted: boolean;
+  label: string;
   onMouseEnter: () => void;
   onMouseLeave: () => void;
-  isHighlighted: boolean;
-  editable: boolean;
+  onReactivate?: () => void;
 }
 
-const PatternBox = ({
+const PatternLedOption = ({
   isOn,
-  onClick,
+  isHighlighted,
+  label,
   onMouseEnter,
   onMouseLeave,
-  isHighlighted,
-  editable,
-}: PatternBoxProps) => {
-  return editable ? (
-    <Button
-      size="sm"
-      w="100%"
-      h="100%"
-      as="div"
-      variant="led"
-      onClick={onClick}
+  onReactivate,
+  ...radioProps
+}: PatternLedOptionProps) => {
+  const { getInputProps, getRadioProps } = useRadio(radioProps);
+  const input = getInputProps();
+  const box = getRadioProps();
+  return (
+    <Box
+      as="label"
+      w={cellSize}
+      h={cellSize}
+      cursor="pointer"
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
-      bgColor={isOn ? "brand2.500" : "gray.300"}
-      borderWidth={isHighlighted && !isOn ? 3 : 0}
-      borderColor={isHighlighted ? (isOn ? "white" : "brand2.500") : undefined}
-      opacity={isHighlighted && isOn ? 0.25 : 1}
-    />
-  ) : (
-    <Box
-      w="100%"
-      h="100%"
-      bgColor={isOn ? "brand2.500" : "gray.300"}
-      borderRadius={5}
-    />
+    >
+      <input
+        {...input}
+        aria-label={label}
+        onClick={(e) => {
+          input.onClick?.(e);
+          onReactivate?.();
+        }}
+      />
+      <Box
+        {...box}
+        w="100%"
+        h="100%"
+        borderRadius={5}
+        bgColor={isOn ? "brand2.500" : "gray.300"}
+        borderWidth={isHighlighted && !isOn ? 3 : 0}
+        borderColor={
+          isHighlighted ? (isOn ? "white" : "brand2.500") : undefined
+        }
+        opacity={isHighlighted && isOn ? 0.25 : 1}
+        _focusVisible={{ boxShadow: "outline" }}
+      />
+    </Box>
   );
 };
 
-interface PatternColumnInputProps {
-  colIdx: number;
-  value: string;
-  isInvalid: boolean;
-  onChange: (value: string) => void;
+interface ReadonlyPatternColumnProps {
+  cells: boolean[];
+  letter: string | undefined;
 }
 
-const PatternColumnInput = ({
-  colIdx,
-  value,
-  isInvalid,
-  onChange,
-}: PatternColumnInputProps) => {
-  return (
-    <FormControl isInvalid={isInvalid}>
-      <VisuallyHidden>
-        <FormLabel>
-          <FormattedMessage
-            id="connect-pattern-input-label"
-            values={{ colNum: colIdx + 1 }}
-          />
-        </FormLabel>
-      </VisuallyHidden>
-      <NumberInput
-        isRequired
-        value={value}
-        min={0}
-        max={5}
-        size="sm"
-        onChange={onChange}
-      >
-        <NumberInputField p={1} m={0} opacity={0} _focus={{ opacity: 1 }} />
-      </NumberInput>
-    </FormControl>
-  );
-};
+const ReadonlyPatternColumn = ({
+  cells,
+  letter,
+}: ReadonlyPatternColumnProps) => (
+  <VStack gap={1} aria-hidden>
+    {cells.map((isOn, rowIdx) => (
+      <Box
+        key={rowIdx}
+        w={cellSize}
+        h={cellSize}
+        borderRadius={5}
+        bgColor={isOn ? "brand2.500" : "gray.300"}
+      />
+    ))}
+    {letter !== undefined && (
+      <Text h={cellSize} lineHeight={cellSize}>
+        {letter}
+      </Text>
+    )}
+  </VStack>
+);
 
 export default BluetoothPatternInput;

--- a/src/components/BluetoothPatternInput.tsx
+++ b/src/components/BluetoothPatternInput.tsx
@@ -187,9 +187,6 @@ const PatternColumn = ({
           )}
           onMouseEnter={() => onHighlight(colIdx, rowIdx)}
           onMouseLeave={onClearHighlight}
-          // Re-activating the checked (topmost lit) LED turns it off, matching
-          // the previous click-to-toggle behaviour. Selecting any other LED
-          // fires the radio group's onChange instead.
           onReactivate={
             isOn && rowIdx === topLitRowIdx
               ? () => onSelect(colIdx, rowIdx + 1)

--- a/src/components/EnterBluetoothPatternDialog.tsx
+++ b/src/components/EnterBluetoothPatternDialog.tsx
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { Text, VStack } from "@chakra-ui/react";
+import { Text, VisuallyHidden, VStack } from "@chakra-ui/react";
 import { useCallback, useState } from "react";
 import { FormattedMessage } from "react-intl";
 import { blank } from "../bt-pattern-utils";
@@ -81,13 +81,14 @@ const EnterBluetoothPatternDialog = ({
             microbitName={value}
           />
           <VStack>
-            <Text
-              textColor="red"
-              opacity={showInvalid ? 1 : 0}
-              aria-hidden={!showInvalid}
-            >
+            <Text textColor="red" opacity={showInvalid ? 1 : 0} aria-hidden>
               <FormattedMessage id="connect-bluetooth-invalid-pattern" />
             </Text>
+            <VisuallyHidden role="alert">
+              {showInvalid && (
+                <FormattedMessage id="connect-bluetooth-invalid-pattern" />
+              )}
+            </VisuallyHidden>
           </VStack>
         </VStack>
       </VStack>

--- a/src/e2e/app/bluetooth-pattern.ts
+++ b/src/e2e/app/bluetooth-pattern.ts
@@ -1,0 +1,57 @@
+/**
+ * (c) 2026, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { type Page } from "@playwright/test";
+
+const numCols = 5;
+
+/**
+ * Test id of the pattern option that lights `numLeds` LEDs in the given column
+ * (0-based), matching `data-testid` in BluetoothPatternInput. Uses test ids
+ * rather than labels since the accessible copy may change.
+ */
+const ledOptionTestId = (colIdx: number, numLeds: number): string =>
+  `bluetooth-pattern-led-${colIdx}-${numLeds}`;
+
+/**
+ * Select the pattern option that lights `numLeds` LEDs in the given column
+ * (0-based). Each column is a radio group and each LED is an option; a count of
+ * 0 leaves the column unset. The radio input is visually hidden, so the test id
+ * sits on the wrapping label, which toggles it when clicked.
+ */
+export const selectPatternColumn = async (
+  page: Page,
+  colIdx: number,
+  numLeds: number
+): Promise<void> => {
+  if (numLeds <= 0) {
+    return;
+  }
+  await page.getByTestId(ledOptionTestId(colIdx, numLeds)).click();
+};
+
+/**
+ * Get the number of lit LEDs in each of the five pattern columns as strings
+ * (e.g. ["1", "2", "3", "4", "5"]), or "0" for an unset column.
+ */
+export const getPatternColumnValues = async (
+  page: Page
+): Promise<string[]> => {
+  const values: string[] = [];
+  for (let colIdx = 0; colIdx < numCols; colIdx++) {
+    let value = "0";
+    for (let numLeds = 1; numLeds <= numCols; numLeds++) {
+      const radio = page
+        .getByTestId(ledOptionTestId(colIdx, numLeds))
+        .getByRole("radio");
+      if (await radio.isChecked()) {
+        value = numLeds.toString();
+        break;
+      }
+    }
+    values.push(value);
+  }
+  return values;
+};

--- a/src/e2e/app/bluetooth-pattern.ts
+++ b/src/e2e/app/bluetooth-pattern.ts
@@ -36,9 +36,7 @@ export const selectPatternColumn = async (
  * Get the number of lit LEDs in each of the five pattern columns as strings
  * (e.g. ["1", "2", "3", "4", "5"]), or "0" for an unset column.
  */
-export const getPatternColumnValues = async (
-  page: Page
-): Promise<string[]> => {
+export const getPatternColumnValues = async (page: Page): Promise<string[]> => {
   const values: string[] = [];
   for (let colIdx = 0; colIdx < numCols; colIdx++) {
     let value = "0";

--- a/src/e2e/app/bluetooth-pattern.ts
+++ b/src/e2e/app/bluetooth-pattern.ts
@@ -20,6 +20,10 @@ const ledOptionTestId = (colIdx: number, numLeds: number): string =>
  * (0-based). Each column is a radio group and each LED is an option; a count of
  * 0 leaves the column unset. The radio input is visually hidden, so the test id
  * sits on the wrapping label, which toggles it when clicked.
+ *
+ * The selection is idempotent: the dialog may arrive pre-populated (the name is
+ * derived from the flashed device id), and clicking an already-selected option
+ * would toggle it off. So we only click when it isn't already selected.
  */
 export const selectPatternColumn = async (
   page: Page,
@@ -29,7 +33,11 @@ export const selectPatternColumn = async (
   if (numLeds <= 0) {
     return;
   }
-  await page.getByTestId(ledOptionTestId(colIdx, numLeds)).click();
+  const option = page.getByTestId(ledOptionTestId(colIdx, numLeds));
+  const radio = option.getByRole("radio");
+  if (!(await radio.isChecked())) {
+    await option.click();
+  }
 };
 
 /**

--- a/src/e2e/app/connection-dialogs.ts
+++ b/src/e2e/app/connection-dialogs.ts
@@ -11,6 +11,10 @@ import {
   MockBluetoothConnection,
 } from "../../device/mockBluetooth";
 import { MockRadioBridgeConnection } from "../../device/mockRadioBridge";
+import {
+  getPatternColumnValues,
+  selectPatternColumn,
+} from "./bluetooth-pattern";
 
 export type RadioDisconnectType = "bridge" | "remote";
 
@@ -215,24 +219,16 @@ export class ConnectionDialogs {
   async enterBluetoothPattern() {
     const numCols = 5;
     for (let i = 0; i < numCols; i++) {
-      const n = (i + 1).toString();
-      await this.page.getByLabel(`Column ${n} - number of LEDs lit`).fill(n);
+      await selectPatternColumn(this.page, i, i + 1);
     }
   }
 
   /**
-   * Get the current values in the bluetooth pattern column inputs.
+   * Get the number of lit LEDs in each bluetooth pattern column.
    * Useful for verifying a stored pattern is pre-populated.
    */
   async getBluetoothPatternValues(): Promise<string[]> {
-    const values: string[] = [];
-    for (let i = 0; i < 5; i++) {
-      const input = this.page.getByLabel(
-        `Column ${i + 1} - number of LEDs lit`
-      );
-      values.push(await input.inputValue());
-    }
-    return values;
+    return getPatternColumnValues(this.page);
   }
 
   /**

--- a/src/e2e/app/download-dialogs.ts
+++ b/src/e2e/app/download-dialogs.ts
@@ -10,6 +10,7 @@ import {
   ConnectBehavior,
   MockBluetoothConnection,
 } from "../../device/mockBluetooth";
+import { selectPatternColumn } from "./bluetooth-pattern";
 
 export const downloadDialogTitles: {
   browserDefault: Record<string, string>;
@@ -138,9 +139,7 @@ export class DownloadDialogs {
 
   async enterBluetoothPatternValues(values: number[]) {
     for (let i = 0; i < values.length; i++) {
-      await this.page
-        .getByLabel(`Column ${i + 1} - number of LEDs lit`)
-        .fill(values[i].toString());
+      await selectPatternColumn(this.page, i, values[i]);
     }
   }
 

--- a/src/messages/ui.ca.json
+++ b/src/messages/ui.ca.json
@@ -823,6 +823,50 @@
       "value": "."
     }
   ],
+  "connect-pattern-led-option-label": [
+    {
+      "type": 0,
+      "value": "Column "
+    },
+    {
+      "type": 1,
+      "value": "colNum"
+    },
+    {
+      "type": 0,
+      "value": ", "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " LED lit"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " LEDs lit"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "numLeds"
+    }
+  ],
   "connect-pattern-subtitle": [
     {
       "type": 0,

--- a/src/messages/ui.en-us.json
+++ b/src/messages/ui.en-us.json
@@ -827,6 +827,50 @@
       "value": "."
     }
   ],
+  "connect-pattern-led-option-label": [
+    {
+      "type": 0,
+      "value": "Column "
+    },
+    {
+      "type": 1,
+      "value": "colNum"
+    },
+    {
+      "type": 0,
+      "value": ", "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " LED lit"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " LEDs lit"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "numLeds"
+    }
+  ],
   "connect-pattern-subtitle": [
     {
       "type": 0,

--- a/src/messages/ui.en.json
+++ b/src/messages/ui.en.json
@@ -827,6 +827,50 @@
       "value": "."
     }
   ],
+  "connect-pattern-led-option-label": [
+    {
+      "type": 0,
+      "value": "Column "
+    },
+    {
+      "type": 1,
+      "value": "colNum"
+    },
+    {
+      "type": 0,
+      "value": ", "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " LED lit"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " LEDs lit"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "numLeds"
+    }
+  ],
   "connect-pattern-subtitle": [
     {
       "type": 0,

--- a/src/messages/ui.es-es.json
+++ b/src/messages/ui.es-es.json
@@ -827,6 +827,50 @@
       "value": "."
     }
   ],
+  "connect-pattern-led-option-label": [
+    {
+      "type": 0,
+      "value": "Column "
+    },
+    {
+      "type": 1,
+      "value": "colNum"
+    },
+    {
+      "type": 0,
+      "value": ", "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " LED lit"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " LEDs lit"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "numLeds"
+    }
+  ],
   "connect-pattern-subtitle": [
     {
       "type": 0,

--- a/src/messages/ui.fr.json
+++ b/src/messages/ui.fr.json
@@ -819,6 +819,50 @@
       "value": "."
     }
   ],
+  "connect-pattern-led-option-label": [
+    {
+      "type": 0,
+      "value": "Column "
+    },
+    {
+      "type": 1,
+      "value": "colNum"
+    },
+    {
+      "type": 0,
+      "value": ", "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " LED lit"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " LEDs lit"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "numLeds"
+    }
+  ],
   "connect-pattern-subtitle": [
     {
       "type": 0,

--- a/src/messages/ui.ja.json
+++ b/src/messages/ui.ja.json
@@ -811,6 +811,50 @@
       "value": "."
     }
   ],
+  "connect-pattern-led-option-label": [
+    {
+      "type": 0,
+      "value": "Column "
+    },
+    {
+      "type": 1,
+      "value": "colNum"
+    },
+    {
+      "type": 0,
+      "value": ", "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " LED lit"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " LEDs lit"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "numLeds"
+    }
+  ],
   "connect-pattern-subtitle": [
     {
       "type": 0,

--- a/src/messages/ui.ko.json
+++ b/src/messages/ui.ko.json
@@ -807,6 +807,50 @@
       "value": "."
     }
   ],
+  "connect-pattern-led-option-label": [
+    {
+      "type": 0,
+      "value": "Column "
+    },
+    {
+      "type": 1,
+      "value": "colNum"
+    },
+    {
+      "type": 0,
+      "value": ", "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " LED lit"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " LEDs lit"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "numLeds"
+    }
+  ],
   "connect-pattern-subtitle": [
     {
       "type": 0,

--- a/src/messages/ui.lol.json
+++ b/src/messages/ui.lol.json
@@ -807,6 +807,50 @@
       "value": "crwdne369665:0"
     }
   ],
+  "connect-pattern-led-option-label": [
+    {
+      "type": 0,
+      "value": "Column "
+    },
+    {
+      "type": 1,
+      "value": "colNum"
+    },
+    {
+      "type": 0,
+      "value": ", "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " LED lit"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " LEDs lit"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "numLeds"
+    }
+  ],
   "connect-pattern-subtitle": [
     {
       "type": 0,

--- a/src/messages/ui.nl.json
+++ b/src/messages/ui.nl.json
@@ -831,6 +831,50 @@
       "value": "."
     }
   ],
+  "connect-pattern-led-option-label": [
+    {
+      "type": 0,
+      "value": "Column "
+    },
+    {
+      "type": 1,
+      "value": "colNum"
+    },
+    {
+      "type": 0,
+      "value": ", "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " LED lit"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " LEDs lit"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "numLeds"
+    }
+  ],
   "connect-pattern-subtitle": [
     {
       "type": 0,

--- a/src/messages/ui.pl.json
+++ b/src/messages/ui.pl.json
@@ -827,6 +827,50 @@
       "value": "."
     }
   ],
+  "connect-pattern-led-option-label": [
+    {
+      "type": 0,
+      "value": "Column "
+    },
+    {
+      "type": 1,
+      "value": "colNum"
+    },
+    {
+      "type": 0,
+      "value": ", "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " LED lit"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " LEDs lit"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "numLeds"
+    }
+  ],
   "connect-pattern-subtitle": [
     {
       "type": 0,

--- a/src/messages/ui.pt-br.json
+++ b/src/messages/ui.pt-br.json
@@ -827,6 +827,50 @@
       "value": "."
     }
   ],
+  "connect-pattern-led-option-label": [
+    {
+      "type": 0,
+      "value": "Column "
+    },
+    {
+      "type": 1,
+      "value": "colNum"
+    },
+    {
+      "type": 0,
+      "value": ", "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " LED lit"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " LEDs lit"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "numLeds"
+    }
+  ],
   "connect-pattern-subtitle": [
     {
       "type": 0,

--- a/src/messages/ui.zh-tw.json
+++ b/src/messages/ui.zh-tw.json
@@ -835,6 +835,50 @@
       "value": "."
     }
   ],
+  "connect-pattern-led-option-label": [
+    {
+      "type": 0,
+      "value": "Column "
+    },
+    {
+      "type": 1,
+      "value": "colNum"
+    },
+    {
+      "type": 0,
+      "value": ", "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " LED lit"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " LEDs lit"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "numLeds"
+    }
+  ],
   "connect-pattern-subtitle": [
     {
       "type": 0,


### PR DESCRIPTION
This reworks each column into a radio group so the existing click-to-toggle experience is preserved for sighted/pointer users while screen-reader users can use the same UI.

### What changed

- Each column is now a radiogroup; each LED is a radio option. A pattern column is fully described by how many LEDs are lit from the bottom (1-5), so each column reads as "pick how many lights are on". 
- Removed the old number input fields in favour of using the radio options.
- Increased Bluetooth cell hit targets to 44px by 44px to satisfy [WCAG AAA min target size](https://www.w3.org/WAI/WCAG22/Understanding/target-size-enhanced.html).
- New string `connect-pattern-input-label` for radio option labels (a fallback of just using the number is used to avoid web translation regression).
- Keyboard navigation on the browser is now done via tabbing to different columns and using the up and down arrow keys to select different options.
- Click-to-toggle is unchanged.
- Invalid-pattern error is now announced (aria live region).
- Updated E2E test.

