### PR TITLE
Update train model hint position

### DIFF
--- a/src/components/DataSamplesTableHints.tsx
+++ b/src/components/DataSamplesTableHints.tsx
@@ -405,7 +405,7 @@ export const TrainHint = () => {
       right={{ md: "unset", base: 0 }}
       left={{ base: "unset", md: 0 }}
       spacing={0}
-      zIndex={1}
+      zIndex={2}
       transform={{
         base: "translate(-80px, -85px)",
         md: "translate(-100%, 15px)",

--- a/src/components/DataSamplesTableHints.tsx
+++ b/src/components/DataSamplesTableHints.tsx
@@ -401,20 +401,24 @@ export const MoveMicrobitHint = () => {
 export const TrainHint = () => {
   return (
     <HStack
-      m={0}
       position="absolute"
-      right={0}
+      right={{ md: "unset", base: 0 }}
+      left={{ base: "unset", md: 0 }}
       spacing={0}
-      zIndex={2}
-      transform="translate(-80px, -85px)"
+      zIndex={1}
+      transform={{
+        base: "translate(-80px, -85px)",
+        md: "translate(-100%, 15px)",
+      }}
+      w="fit-content"
     >
       <HStack>
         <Box
           position="absolute"
           background="radial-gradient(50% 50% at 50% 50%, rgba(245,245,245,1) 75%, rgba(245,245,245,0) 100%);"
           transform="translate(-50px, 0)"
-          w="calc(100% + 50px)"
-          h="120%"
+          w={{ base: "calc(100% + 50px)", md: "calc(110%)" }}
+          h={{ base: "120%", md: "100%" }}
         />
         <EmojiAi boxSize={20} pb={3} animation={animations.spin} zIndex={3} />
         <VisuallyHidden>
@@ -422,7 +426,7 @@ export const TrainHint = () => {
             <FormattedMessage id="train-hint-label" />
           </Text>
         </VisuallyHidden>
-        <Text textAlign="center" zIndex={3} aria-hidden>
+        <Text textAlign="center" zIndex={3} aria-hidden w="max-content">
           <FormattedMessage
             id="train-hint"
             values={{
@@ -436,8 +440,11 @@ export const TrainHint = () => {
           />
         </Text>
         <EmojiArrow
-          mt={8}
-          transform="rotate(-120deg) scaleY(-1)"
+          mt={{ base: 8, md: 0 }}
+          transform={{
+            base: "rotate(-120deg) scaleY(-1)",
+            md: "scale(0.8, 0.8) rotate(140deg) translate(10px, 10px)",
+          }}
           transformOrigin="center"
           color="brand.500"
         />

--- a/src/components/DataSamplesTableHints.tsx
+++ b/src/components/DataSamplesTableHints.tsx
@@ -22,6 +22,7 @@ import moveMicrobitImage from "../images/move-microbit.svg";
 import { Action } from "../model";
 import Emoji, { animations, EmojiAi } from "./Emoji";
 import EmojiArrow from "./EmojiArrow";
+import StraightArrow from "./StraightArrow";
 import UpCurveArrow from "./UpCurveArrow";
 
 export const NameFirstActionHint = () => {
@@ -408,17 +409,19 @@ export const TrainHint = () => {
       zIndex={2}
       transform={{
         base: "translate(-80px, -85px)",
-        md: "translate(-100%, 15px)",
+        md: "translate(-100%, 2px)",
       }}
       w="fit-content"
+      pointerEvents="none"
     >
       <HStack>
         <Box
           position="absolute"
           background="radial-gradient(50% 50% at 50% 50%, rgba(245,245,245,1) 75%, rgba(245,245,245,0) 100%);"
           transform="translate(-50px, 0)"
-          w={{ base: "calc(100% + 50px)", md: "calc(110%)" }}
-          h={{ base: "120%", md: "100%" }}
+          w="calc(100% + 50px)"
+          h="120%"
+          display={{ base: "block", md: "none" }}
         />
         <EmojiAi boxSize={20} pb={3} animation={animations.spin} zIndex={3} />
         <VisuallyHidden>
@@ -440,13 +443,19 @@ export const TrainHint = () => {
           />
         </Text>
         <EmojiArrow
-          mt={{ base: 8, md: 0 }}
-          transform={{
-            base: "rotate(-120deg) scaleY(-1)",
-            md: "scale(0.8, 0.8) rotate(140deg) translate(10px, 10px)",
-          }}
+          display={{ base: "block", md: "none" }}
+          mt={8}
+          transform="rotate(-120deg) scaleY(-1)"
           transformOrigin="center"
           color="brand.500"
+        />
+        <StraightArrow
+          boxSize={10}
+          display={{ base: "none", md: "block" }}
+          // transform="scale(0.8, 0.8) rotate(160deg) translate(10px, -20px)"
+          transformOrigin="center"
+          color="brand.500"
+          mr="2"
         />
       </HStack>
     </HStack>

--- a/src/components/StraightArrow.tsx
+++ b/src/components/StraightArrow.tsx
@@ -1,0 +1,31 @@
+/**
+ * (c) 2026, Micro:bit Educational Foundation and contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+import { Icon, IconProps } from "@chakra-ui/react";
+
+const StraightArrow = (props: IconProps) => {
+  return (
+    <Icon viewBox="0 0 90 36" w="88px" h="36px" aria-hidden {...props}>
+      <path
+        d="M4.58415 18.4756H84.7559"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={8}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M72.0704 31.1611L84.7559 18.4756L72.0704 5.79009"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={8}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Icon>
+  );
+};
+
+export default StraightArrow;

--- a/src/pages/DataSamplesPage.tsx
+++ b/src/pages/DataSamplesPage.tsx
@@ -244,7 +244,8 @@ const DataSamplesPage = () => {
               {dataSamplesHint?.type === "add-action" && (
                 <AddActionHint action={actions[0]} />
               )}
-              <HStack>
+              <HStack position="relative">
+                {dataSamplesHint?.type === "train" && <TrainHint />}
                 {model ? (
                   <Button
                     onClick={handleNavigateToModel}
@@ -274,7 +275,6 @@ const DataSamplesPage = () => {
                   </Button>
                 )}
               </HStack>
-              {dataSamplesHint?.type === "train" && <TrainHint />}
               {dataSamplesHint?.type === "move-microbit" && (
                 <MoveMicrobitHint />
               )}


### PR DESCRIPTION
Minimises issue where the train model hint obscures data samples. 

On desktop, the hint is placed next to the "Train model" button so that it does not obscure data samples. 
On mobile/smaller screens, the hint is placed above the "Train model" button (same as current behaviour) as there is insufficient space between the "Add action" button and the "Train model" button to fit a hint.