### PR TITLE
Only auto-select fully supported languages on native first run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,8 @@ jobs:
         with:
           args: npx playwright test
       - name: Store reports
-        if: (env.STAGE == 'REVIEW' || env.STAGE == 'STAGING' || env.STAGE == 'BETA') && failure()
+        # cancelled() so we get the report when e2e overruns the job timeout
+        if: (env.STAGE == 'REVIEW' || env.STAGE == 'STAGING' || env.STAGE == 'BETA') && (failure() || cancelled())
         uses: actions/upload-artifact@v7
         with:
           name: playwright-report

--- a/src/e2e/app/makecode-editor.ts
+++ b/src/e2e/app/makecode-editor.ts
@@ -29,13 +29,13 @@ export class MakeCodeEditor {
 
   async switchToJavaScript() {
     await this.iframe
-      .getByRole("option", { name: "Convert code to JavaScript" })
+      .getByRole("button", { name: "Convert code to JavaScript" })
       .click();
   }
 
   async switchToBlocks() {
     await this.iframe
-      .getByRole("option", { name: "Convert code to Blocks" })
+      .getByRole("button", { name: "Convert code to Blocks" })
       .click();
   }
 
@@ -52,9 +52,12 @@ export class MakeCodeEditor {
   }
 
   async clickDownload() {
-    // MakeCode in portrait tablet has a "Download" button with just a more verbose title attribute (no real accessible label)
+    // The accessible name is longer in MakeCode's compact layout.
+    // Anchored to avoid the adjacent "Download options" button.
     await this.iframe
-      .getByRole("menuitem", { name: /^Download( your code|$)/ })
+      .getByRole("button", {
+        name: /^Download( your code to the micro:bit)?$/,
+      })
       .click();
     return new DownloadDialogs(this.page);
   }

--- a/src/settings.test.ts
+++ b/src/settings.test.ts
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { matchLanguage } from "./settings";
+import { getDefaultLanguage, matchLanguage } from "./settings";
 
 describe("matchLanguage", () => {
   it("matches locales to supported languages", () => {
@@ -49,5 +49,37 @@ describe("matchLanguage", () => {
     // Fallback to English
     expect(matchLanguage(["xyz"])).toBe("en");
     expect(matchLanguage([])).toBe("en");
+  });
+});
+
+describe("getDefaultLanguage", () => {
+  it("matches OS languages against all languages on web", () => {
+    expect(getDefaultLanguage(null, ["ja"], false)).toBe("ja");
+    expect(getDefaultLanguage(null, ["de"], false)).toBe("de");
+  });
+  it("prefers the URL parameter on web", () => {
+    expect(getDefaultLanguage("ja", ["fr"], false)).toBe("ja");
+    expect(getDefaultLanguage("xyz", ["fr"], false)).toBe("fr");
+  });
+  it("auto-selects only fully supported languages on native", () => {
+    expect(getDefaultLanguage(null, ["fr-CA"], true)).toBe("fr");
+    expect(getDefaultLanguage(null, ["es-MX"], true)).toBe("es-ES");
+    // Partially supported languages fall back to English
+    expect(getDefaultLanguage(null, ["ja"], true)).toBe("en");
+    expect(getDefaultLanguage(null, ["de"], true)).toBe("en");
+    // ...but later fully supported preferences still win
+    expect(getDefaultLanguage(null, ["de", "fr"], true)).toBe("fr");
+  });
+  it("treats the URL parameter as another preference on native", () => {
+    expect(getDefaultLanguage("fr", ["en"], true)).toBe("fr");
+    expect(getDefaultLanguage("fr", ["nl"], true)).toBe("fr");
+    // A partially supported language via the URL falls through to the OS
+    // languages, then English
+    expect(getDefaultLanguage("ja", ["nl"], true)).toBe("nl");
+    expect(getDefaultLanguage("ja", ["en"], true)).toBe("en");
+  });
+  it("ignores an invalid URL parameter on native", () => {
+    expect(getDefaultLanguage("xyz", ["nl"], true)).toBe("nl");
+    expect(getDefaultLanguage("xyz", ["ja"], true)).toBe("en");
   });
 });

--- a/src/settings.tsx
+++ b/src/settings.tsx
@@ -6,6 +6,7 @@
  */
 import { match } from "@formatjs/intl-localematcher";
 import { DataSamplesView, TourTriggerName } from "./model";
+import { isNativePlatform } from "./platform";
 
 type Translation = "preview" | boolean;
 
@@ -281,8 +282,9 @@ export const getMakeCodeLang = (languageId: string): string =>
 /**
  * Languages with UI translations covering the native (iOS/Android) app's
  * additional strings. Other languages still appear in the picker on native,
- * but as 'partially supported' — missing strings fall back to English. Add
- * ids here as translations land.
+ * but as 'partially supported' — missing strings fall back to English —
+ * and are never auto-selected on first run. Add ids here as translations
+ * land.
  */
 export const nativeLanguageIds = ["en", "en-US", "nl", "fr", "pl", "es-ES"];
 
@@ -298,26 +300,58 @@ const isValidLanguageId = (langId: string): boolean => {
   }
 };
 
+// match() returns its default verbatim when nothing matches so a sentinel
+// lets us distinguish no-match from a real match of the default language.
+const noMatch = "x-no-match";
+
+const matchOrUndefined = (
+  requestedLanguages: readonly string[],
+  languageIds: string[]
+): string | undefined => {
+  const matched = match(
+    requestedLanguages.filter(isValidLanguageId),
+    languageIds,
+    noMatch
+  );
+  return matched === noMatch ? undefined : matched;
+};
+
 /**
  * Match the user's preferred languages (from browser/OS) to supported languages.
  */
 export const matchLanguage = (requestedLanguages: readonly string[]): string =>
-  match(
-    requestedLanguages.filter(isValidLanguageId),
-    supportedLanguageIds,
-    defaultLanguageId
-  );
+  matchOrUndefined(requestedLanguages, supportedLanguageIds) ??
+  defaultLanguageId;
 
 /**
- * Get the initial language, checking URL parameter first, then OS/browser preference.
+ * Get the initial language, checking URL parameter first, then OS/browser
+ * preference.
+ *
+ * On native, languages are only auto-selected if fully supported
+ * ({@link nativeLanguageIds}); for others we stay in English so the user
+ * makes an informed choice via the language dialog, which explains the
+ * level of support. The URL parameter (typically the site language passed
+ * along when following a link from microbit.org) is a hint rather than an
+ * explicit choice, so gets the same treatment.
+ *
+ * Parameters default from the environment and exist for testing.
  */
-export const getDefaultLanguage = (): string => {
-  const searchParams = new URLSearchParams(window.location.search);
-  const l = searchParams.get("l");
-  const requestedLanguages = l
-    ? [l, ...navigator.languages]
-    : navigator.languages;
-  return matchLanguage(requestedLanguages);
+export const getDefaultLanguage = (
+  languageParam: string | null = new URLSearchParams(
+    window.location.search
+  ).get("l"),
+  osLanguages: readonly string[] = navigator.languages,
+  native: boolean = isNativePlatform()
+): string => {
+  const requestedLanguages = languageParam
+    ? [languageParam, ...osLanguages]
+    : osLanguages;
+  if (!native) {
+    return matchLanguage(requestedLanguages);
+  }
+  return (
+    matchOrUndefined(requestedLanguages, nativeLanguageIds) ?? defaultLanguageId
+  );
 };
 
 export const defaultSettings: Settings = {


### PR DESCRIPTION
Since the app gained native-only strings, languages with complete web UI translations (ja, ko, ca, pt-BR, zh-TW) are only partially translated on native: the ~50 missing strings cluster in the connect/download flow, permission errors and troubleshooting, so an auto-matched user gets key functionality in English with no explanation.

Instead, limit first-run OS language matching on native to nativeLanguageIds. Users can still opt in to partially supported languages via the language dialog, which explains the level of support, ~~and the ?l= URL parameter is treated as an explicit choice so deep links may still select any language.~~ Web behaviour is unchanged.

This becomes a no-op as native translations land and can be removed once nativeLanguageIds covers all UI languages.