### PR TITLE
Use latest makecode-embed version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@formatjs/intl-localematcher": "^0.8.0",
         "@microbit/capacitor-community-nordic-dfu": "^8.0.0-microbit.1",
         "@microbit/capacitor-sqlite-vanilla": "^0.1.0",
-        "@microbit/makecode-embed": "^0.0.0-noproject.76",
+        "@microbit/makecode-embed": "^0.6.0",
         "@microbit/microbit-connection": "^1.0.0",
         "@microbit/ml-header-generator": "^0.4.3",
         "@microbit/ml4f": "^2.0.0-beta.0",
@@ -2755,9 +2755,9 @@
       }
     },
     "node_modules/@microbit/makecode-embed": {
-      "version": "0.0.0-noproject.76",
-      "resolved": "https://registry.npmjs.org/@microbit/makecode-embed/-/makecode-embed-0.0.0-noproject.76.tgz",
-      "integrity": "sha512-iqOTBhIDSqY3Cdo1FbkUMYyfaKM8fiP0wZNV/iq8M63oFJKHZiGjlIyd1oiFNoeUtY1j81gcHUOOl/VbHWpN5A==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@microbit/makecode-embed/-/makecode-embed-0.6.0.tgz",
+      "integrity": "sha512-5UnYZP4gFf1HX2EeM8JiZgtirW1N85EHSQHdtyIHTbD6FlJIN2owmC67g3ylK52Q/N1jEZso5lpLLoSIP9xkGg==",
       "license": "MIT",
       "dependencies": {
         "tslib": ">=2.0.0"

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@formatjs/intl-localematcher": "^0.8.0",
     "@microbit/capacitor-community-nordic-dfu": "^8.0.0-microbit.1",
     "@microbit/capacitor-sqlite-vanilla": "^0.1.0",
-    "@microbit/makecode-embed": "^0.0.0-noproject.76",
+    "@microbit/makecode-embed": "^0.6.0",
     "@microbit/microbit-connection": "^1.0.0",
     "@microbit/ml-header-generator": "^0.4.3",
     "@microbit/ml4f": "^2.0.0-beta.0",


### PR DESCRIPTION
Reverting temporary use of makecode-embed from https://github.com/microbit-foundation/ml-trainer/pull/888.

https://github.com/microsoft/pxt-microbit/issues/6081 is no longer an issue in live MakeCode.

Tested locally on iPad by opening/importing hex files in the app (cold start) multiple times and opening the MakeCode editor after a cold start multiple times.