### PR TITLE
Add power-on workaround text to reset to Bluetooth mode dialog

### DIFF
--- a/lang/ui.ca.json
+++ b/lang/ui.ca.json
@@ -1707,6 +1707,10 @@
     "defaultMessage": "Reanomena el projecte",
     "description": "Heading for rename project dialog"
   },
+  "reset-to-bluetooth-mode-ab-power-on-subtitle": {
+    "defaultMessage": "If you cannot access the RESET button, hold A+B while you power on the micro:bit.",
+    "description": "Instructions to hold A and B buttons while powering on the micro:bit"
+  },
   "reset-to-bluetooth-mode-ab-subtitle": {
     "defaultMessage": "Hold A+B and press RESET. Keep holding A+B until the Bluetooth icon appears.",
     "description": "Instructions to hold A and B buttons while pressing reset on the micro:bit"

--- a/lang/ui.en-us.json
+++ b/lang/ui.en-us.json
@@ -1707,6 +1707,10 @@
     "defaultMessage": "Rename project",
     "description": "Heading for rename project dialog"
   },
+  "reset-to-bluetooth-mode-ab-power-on-subtitle": {
+    "defaultMessage": "If you cannot access the RESET button, hold A+B while you power on the micro:bit.",
+    "description": "Instructions to hold A and B buttons while powering on the micro:bit"
+  },
   "reset-to-bluetooth-mode-ab-subtitle": {
     "defaultMessage": "Hold A+B and press RESET. Keep holding A+B until the Bluetooth icon appears.",
     "description": "Instructions to hold A and B buttons while pressing reset on the micro:bit"

--- a/lang/ui.en.json
+++ b/lang/ui.en.json
@@ -1707,6 +1707,10 @@
     "defaultMessage": "Rename project",
     "description": "Heading for rename project dialog"
   },
+  "reset-to-bluetooth-mode-ab-power-on-subtitle": {
+    "defaultMessage": "If you cannot access the RESET button, hold A+B while you power on the micro:bit.",
+    "description": "Instructions to hold A and B buttons while powering on the micro:bit"
+  },
   "reset-to-bluetooth-mode-ab-subtitle": {
     "defaultMessage": "Hold A+B and press RESET. Keep holding A+B until the Bluetooth icon appears.",
     "description": "Instructions to hold A and B buttons while pressing reset on the micro:bit"

--- a/lang/ui.es-es.json
+++ b/lang/ui.es-es.json
@@ -1707,6 +1707,10 @@
     "defaultMessage": "Renombrar Proyecto",
     "description": "Heading for rename project dialog"
   },
+  "reset-to-bluetooth-mode-ab-power-on-subtitle": {
+    "defaultMessage": "If you cannot access the RESET button, hold A+B while you power on the micro:bit.",
+    "description": "Instructions to hold A and B buttons while powering on the micro:bit"
+  },
   "reset-to-bluetooth-mode-ab-subtitle": {
     "defaultMessage": "Mantén presionados A+B y presiona RESET. Sigue presionando A+B hasta que aparezca el icono de Bluetooth.",
     "description": "Instructions to hold A and B buttons while pressing reset on the micro:bit"

--- a/lang/ui.fr.json
+++ b/lang/ui.fr.json
@@ -1707,6 +1707,10 @@
     "defaultMessage": "Renommer le projet",
     "description": "Heading for rename project dialog"
   },
+  "reset-to-bluetooth-mode-ab-power-on-subtitle": {
+    "defaultMessage": "If you cannot access the RESET button, hold A+B while you power on the micro:bit.",
+    "description": "Instructions to hold A and B buttons while powering on the micro:bit"
+  },
   "reset-to-bluetooth-mode-ab-subtitle": {
     "defaultMessage": "Maintenez les touches A et B enfoncées et appuyez sur RESET. Maintenez les touches A et B enfoncées jusqu'à ce que l'icône Bluetooth apparaisse.",
     "description": "Instructions to hold A and B buttons while pressing reset on the micro:bit"

--- a/lang/ui.ja.json
+++ b/lang/ui.ja.json
@@ -1707,6 +1707,10 @@
     "defaultMessage": "プロジェクト名を変更",
     "description": "Heading for rename project dialog"
   },
+  "reset-to-bluetooth-mode-ab-power-on-subtitle": {
+    "defaultMessage": "If you cannot access the RESET button, hold A+B while you power on the micro:bit.",
+    "description": "Instructions to hold A and B buttons while powering on the micro:bit"
+  },
   "reset-to-bluetooth-mode-ab-subtitle": {
     "defaultMessage": "Hold A+B and press RESET. Keep holding A+B until the Bluetooth icon appears.",
     "description": "Instructions to hold A and B buttons while pressing reset on the micro:bit"

--- a/lang/ui.ko.json
+++ b/lang/ui.ko.json
@@ -1707,6 +1707,10 @@
     "defaultMessage": "프로젝트 이름 변경",
     "description": "Heading for rename project dialog"
   },
+  "reset-to-bluetooth-mode-ab-power-on-subtitle": {
+    "defaultMessage": "If you cannot access the RESET button, hold A+B while you power on the micro:bit.",
+    "description": "Instructions to hold A and B buttons while powering on the micro:bit"
+  },
   "reset-to-bluetooth-mode-ab-subtitle": {
     "defaultMessage": "Hold A+B and press RESET. Keep holding A+B until the Bluetooth icon appears.",
     "description": "Instructions to hold A and B buttons while pressing reset on the micro:bit"

--- a/lang/ui.lol.json
+++ b/lang/ui.lol.json
@@ -1707,6 +1707,10 @@
     "defaultMessage": "crwdns369387:0crwdne369387:0",
     "description": "Heading for rename project dialog"
   },
+  "reset-to-bluetooth-mode-ab-power-on-subtitle": {
+    "defaultMessage": "If you cannot access the RESET button, hold A+B while you power on the micro:bit.",
+    "description": "Instructions to hold A and B buttons while powering on the micro:bit"
+  },
   "reset-to-bluetooth-mode-ab-subtitle": {
     "defaultMessage": "crwdns369723:0crwdne369723:0",
     "description": "Instructions to hold A and B buttons while pressing reset on the micro:bit"

--- a/lang/ui.nl.json
+++ b/lang/ui.nl.json
@@ -1707,6 +1707,10 @@
     "defaultMessage": "Hernoem project",
     "description": "Heading for rename project dialog"
   },
+  "reset-to-bluetooth-mode-ab-power-on-subtitle": {
+    "defaultMessage": "If you cannot access the RESET button, hold A+B while you power on the micro:bit.",
+    "description": "Instructions to hold A and B buttons while powering on the micro:bit"
+  },
   "reset-to-bluetooth-mode-ab-subtitle": {
     "defaultMessage": "Houd A+B ingedrukt en druk op RESET. Blijf A+B ingedrukt houden totdat het Bluetooth pictogram verschijnt.",
     "description": "Instructions to hold A and B buttons while pressing reset on the micro:bit"

--- a/lang/ui.pl.json
+++ b/lang/ui.pl.json
@@ -1707,6 +1707,10 @@
     "defaultMessage": "Zmień nazwę projektu",
     "description": "Heading for rename project dialog"
   },
+  "reset-to-bluetooth-mode-ab-power-on-subtitle": {
+    "defaultMessage": "If you cannot access the RESET button, hold A+B while you power on the micro:bit.",
+    "description": "Instructions to hold A and B buttons while powering on the micro:bit"
+  },
   "reset-to-bluetooth-mode-ab-subtitle": {
     "defaultMessage": "Przytrzymaj A+B i naciśnij RESET. Przytrzymaj A+B aż do pojawienia się ikony Bluetooth.",
     "description": "Instructions to hold A and B buttons while pressing reset on the micro:bit"

--- a/lang/ui.pt-br.json
+++ b/lang/ui.pt-br.json
@@ -1707,6 +1707,10 @@
     "defaultMessage": "Renomear projeto",
     "description": "Heading for rename project dialog"
   },
+  "reset-to-bluetooth-mode-ab-power-on-subtitle": {
+    "defaultMessage": "If you cannot access the RESET button, hold A+B while you power on the micro:bit.",
+    "description": "Instructions to hold A and B buttons while powering on the micro:bit"
+  },
   "reset-to-bluetooth-mode-ab-subtitle": {
     "defaultMessage": "Segure A+B e pressione RESET. Continue segurando A+B até o ícone do Bluetooth aparecer.",
     "description": "Instructions to hold A and B buttons while pressing reset on the micro:bit"

--- a/lang/ui.zh-tw.json
+++ b/lang/ui.zh-tw.json
@@ -1707,6 +1707,10 @@
     "defaultMessage": "重新命名專案",
     "description": "Heading for rename project dialog"
   },
+  "reset-to-bluetooth-mode-ab-power-on-subtitle": {
+    "defaultMessage": "If you cannot access the RESET button, hold A+B while you power on the micro:bit.",
+    "description": "Instructions to hold A and B buttons while powering on the micro:bit"
+  },
   "reset-to-bluetooth-mode-ab-subtitle": {
     "defaultMessage": "Hold A+B and press RESET. Keep holding A+B until the Bluetooth icon appears.",
     "description": "Instructions to hold A and B buttons while pressing reset on the micro:bit"

--- a/src/components/PairingModeAnimation/ABLabelledMicrobitBoard.tsx
+++ b/src/components/PairingModeAnimation/ABLabelledMicrobitBoard.tsx
@@ -172,7 +172,7 @@ const ButtonLabel = forwardRef<ButtonLabelRef, ButtonLabelProps>(
           position="absolute"
           top="100%"
           w="15%"
-          h="190%"
+          h="195%"
           left="42.5%"
           backgroundColor={inactiveColor}
         />
@@ -180,7 +180,7 @@ const ButtonLabel = forwardRef<ButtonLabelRef, ButtonLabelProps>(
           position="absolute"
           top="100%"
           w="16%"
-          h="191%"
+          h="196%"
           left="42.5%"
           transformOrigin="bottom"
           transform={

--- a/src/components/PairingModeAnimation/index.tsx
+++ b/src/components/PairingModeAnimation/index.tsx
@@ -101,20 +101,20 @@ const PairingModeAnimation = ({ pairingMethod }: PairingModeAnimationProps) => {
       >
         {isTripleReset ? (
           <MicrobitBoardFront
-            boxSize={{ base: "50%", md: "25%" }}
+            boxSize={{ base: "50%", md: "27%" }}
             ref={microbitBoardFrontRef}
           />
         ) : (
           <ABLabelledMicrobitBoard
             activeColor="brand2.500"
             ref={microbitABBoardFrontRef}
-            w={{ base: "50%", md: "25%" }}
+            w={{ base: "50%", md: "27%" }}
           />
         )}
         <ResetPressedMicrobitBoard
           activeColor="brand2.500"
           ref={microbitBoardBackRef}
-          w={{ base: "50%", md: "25%" }}
+          w={{ base: "50%", md: "27%" }}
         />
       </Stack>
     </>

--- a/src/components/ResetToBluetoothModeDialog.tsx
+++ b/src/components/ResetToBluetoothModeDialog.tsx
@@ -58,9 +58,16 @@ const ResetToBluetoothModeDialog = ({
         }
       >
         <VStack gap={5} width="100%">
-          <Text alignSelf="left" width="100%">
-            <FormattedMessage id={subtitleId} />
-          </Text>
+          <VStack width="100%">
+            <Text alignSelf="left" width="100%">
+              <FormattedMessage id={subtitleId} />
+            </Text>
+            {!isTripleReset && (
+              <Text alignSelf="left" width="100%">
+                <FormattedMessage id="reset-to-bluetooth-mode-ab-power-on-subtitle" />
+              </Text>
+            )}
+          </VStack>
           <PairingModeAnimation pairingMethod={pairingMethod} />
         </VStack>
       </ConnectContainerDialog>

--- a/src/messages/ui.ca.json
+++ b/src/messages/ui.ca.json
@@ -3143,6 +3143,12 @@
       "value": "Reanomena el projecte"
     }
   ],
+  "reset-to-bluetooth-mode-ab-power-on-subtitle": [
+    {
+      "type": 0,
+      "value": "If you cannot access the RESET button, hold A+B while you power on the micro:bit."
+    }
+  ],
   "reset-to-bluetooth-mode-ab-subtitle": [
     {
       "type": 0,

--- a/src/messages/ui.en-us.json
+++ b/src/messages/ui.en-us.json
@@ -3161,6 +3161,12 @@
       "value": "Rename project"
     }
   ],
+  "reset-to-bluetooth-mode-ab-power-on-subtitle": [
+    {
+      "type": 0,
+      "value": "If you cannot access the RESET button, hold A+B while you power on the micro:bit."
+    }
+  ],
   "reset-to-bluetooth-mode-ab-subtitle": [
     {
       "type": 0,

--- a/src/messages/ui.en.json
+++ b/src/messages/ui.en.json
@@ -3161,6 +3161,12 @@
       "value": "Rename project"
     }
   ],
+  "reset-to-bluetooth-mode-ab-power-on-subtitle": [
+    {
+      "type": 0,
+      "value": "If you cannot access the RESET button, hold A+B while you power on the micro:bit."
+    }
+  ],
   "reset-to-bluetooth-mode-ab-subtitle": [
     {
       "type": 0,

--- a/src/messages/ui.es-es.json
+++ b/src/messages/ui.es-es.json
@@ -3173,6 +3173,12 @@
       "value": "Renombrar Proyecto"
     }
   ],
+  "reset-to-bluetooth-mode-ab-power-on-subtitle": [
+    {
+      "type": 0,
+      "value": "If you cannot access the RESET button, hold A+B while you power on the micro:bit."
+    }
+  ],
   "reset-to-bluetooth-mode-ab-subtitle": [
     {
       "type": 0,

--- a/src/messages/ui.fr.json
+++ b/src/messages/ui.fr.json
@@ -3157,6 +3157,12 @@
       "value": "Renommer le projet"
     }
   ],
+  "reset-to-bluetooth-mode-ab-power-on-subtitle": [
+    {
+      "type": 0,
+      "value": "If you cannot access the RESET button, hold A+B while you power on the micro:bit."
+    }
+  ],
   "reset-to-bluetooth-mode-ab-subtitle": [
     {
       "type": 0,

--- a/src/messages/ui.ja.json
+++ b/src/messages/ui.ja.json
@@ -3097,6 +3097,12 @@
       "value": "プロジェクト名を変更"
     }
   ],
+  "reset-to-bluetooth-mode-ab-power-on-subtitle": [
+    {
+      "type": 0,
+      "value": "If you cannot access the RESET button, hold A+B while you power on the micro:bit."
+    }
+  ],
   "reset-to-bluetooth-mode-ab-subtitle": [
     {
       "type": 0,

--- a/src/messages/ui.ko.json
+++ b/src/messages/ui.ko.json
@@ -3093,6 +3093,12 @@
       "value": "프로젝트 이름 변경"
     }
   ],
+  "reset-to-bluetooth-mode-ab-power-on-subtitle": [
+    {
+      "type": 0,
+      "value": "If you cannot access the RESET button, hold A+B while you power on the micro:bit."
+    }
+  ],
   "reset-to-bluetooth-mode-ab-subtitle": [
     {
       "type": 0,

--- a/src/messages/ui.lol.json
+++ b/src/messages/ui.lol.json
@@ -3039,6 +3039,12 @@
       "value": "crwdns369387:0crwdne369387:0"
     }
   ],
+  "reset-to-bluetooth-mode-ab-power-on-subtitle": [
+    {
+      "type": 0,
+      "value": "If you cannot access the RESET button, hold A+B while you power on the micro:bit."
+    }
+  ],
   "reset-to-bluetooth-mode-ab-subtitle": [
     {
       "type": 0,

--- a/src/messages/ui.nl.json
+++ b/src/messages/ui.nl.json
@@ -3173,6 +3173,12 @@
       "value": "Hernoem project"
     }
   ],
+  "reset-to-bluetooth-mode-ab-power-on-subtitle": [
+    {
+      "type": 0,
+      "value": "If you cannot access the RESET button, hold A+B while you power on the micro:bit."
+    }
+  ],
   "reset-to-bluetooth-mode-ab-subtitle": [
     {
       "type": 0,

--- a/src/messages/ui.pl.json
+++ b/src/messages/ui.pl.json
@@ -3173,6 +3173,12 @@
       "value": "Zmień nazwę projektu"
     }
   ],
+  "reset-to-bluetooth-mode-ab-power-on-subtitle": [
+    {
+      "type": 0,
+      "value": "If you cannot access the RESET button, hold A+B while you power on the micro:bit."
+    }
+  ],
   "reset-to-bluetooth-mode-ab-subtitle": [
     {
       "type": 0,

--- a/src/messages/ui.pt-br.json
+++ b/src/messages/ui.pt-br.json
@@ -3165,6 +3165,12 @@
       "value": "Renomear projeto"
     }
   ],
+  "reset-to-bluetooth-mode-ab-power-on-subtitle": [
+    {
+      "type": 0,
+      "value": "If you cannot access the RESET button, hold A+B while you power on the micro:bit."
+    }
+  ],
   "reset-to-bluetooth-mode-ab-subtitle": [
     {
       "type": 0,

--- a/src/messages/ui.zh-tw.json
+++ b/src/messages/ui.zh-tw.json
@@ -3165,6 +3165,12 @@
       "value": "重新命名專案"
     }
   ],
+  "reset-to-bluetooth-mode-ab-power-on-subtitle": [
+    {
+      "type": 0,
+      "value": "If you cannot access the RESET button, hold A+B while you power on the micro:bit."
+    }
+  ],
   "reset-to-bluetooth-mode-ab-subtitle": [
     {
       "type": 0,


### PR DESCRIPTION
- Explain that holding A+B while powering on works when the RESET button is inaccessible.
- Enlarge the animation slightly to keep the dialog balanced with the extra line of text.
