### PR TITLE
Fix shrunken hand in the how-it-works Use step

### DIFF
--- a/src/components/HowItWorksAnimation/Layout.tsx
+++ b/src/components/HowItWorksAnimation/Layout.tsx
@@ -73,7 +73,11 @@ const Layout = forwardRef<LayoutRef, LayoutProps>(function Layout(
       {/* Middle */}
       <Stack
         alignItems="center"
-        width={centerLeftDuration ? 0 : undefined}
+        // "0%" not 0: a percentage is treated as auto in the row's intrinsic
+        // width calculation, so the collapsed item still props up the row and
+        // the left stack's 45% resolves against the full-size row (Chakra's
+        // width={0} meant 0%).
+        width={centerLeftDuration ? "0%" : undefined}
         style={{
           transition: centerLeftDuration
             ? `width ${centerLeftDuration}s ease`
@@ -84,7 +88,8 @@ const Layout = forwardRef<LayoutRef, LayoutProps>(function Layout(
       </Stack>
       {/* Right */}
       <Stack
-        width={centerLeftDuration ? 0 : undefined}
+        // "0%" not 0 — see the middle stack's comment.
+        width={centerLeftDuration ? "0%" : undefined}
         style={{
           transition: centerLeftDuration
             ? `width ${centerLeftDuration}s ease`


### PR DESCRIPTION
Chakra's width={0} rendered width: 0% (numbers <= 1 are fractions), and a percentage width is treated as auto in the row's intrinsic width calculation, so the collapsed middle/right stacks still propped up the row. The Panda port's width: 0px let the row collapse to the wrist svg's 300px default intrinsic width, shrinking the hand by ~55%. Use "0%" to restore the Chakra behaviour.

Verified headlessly against createai.microbit.org: Use-step row/left/hand computed widths now match production exactly (669.9/301.5/150.7px).