### PR TITLE
Fix the missing tour spotlight cut out

### DIFF
--- a/src/pages/Tour.tsx
+++ b/src/pages/Tour.tsx
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: MIT
  */
 import { useCallback, useRef } from "react";
-import { Dialog, Popover as RACPopover } from "react-aria-components";
+import {
+  Dialog,
+  Heading as RACHeading,
+  Popover as RACPopover,
+} from "react-aria-components";
 import { FormattedMessage, useIntl } from "react-intl";
 import {
   Button,
@@ -193,7 +197,9 @@ const Tour = () => {
         {/* Chakra's popper arrow: white, shadowless, 16px base. */}
         <PopoverArrow size={16} css={{ "& svg": { fill: "white" } }} />
         <Dialog className={popoverDialogClass}>
-          <div className={popoverHeaderClass}>{step.title}</div>
+          <RACHeading slot="title" className={popoverHeaderClass}>
+            {step.title}
+          </RACHeading>
           <div className={popoverBodyClass}>{step.content}</div>
           <div className={popoverFooterClass}>{footer}</div>
         </Dialog>

--- a/src/pages/Tour.tsx
+++ b/src/pages/Tour.tsx
@@ -58,12 +58,13 @@ const Tour = () => {
   const anchored = !!step?.selector && !isSmallScreen;
   const spotlightPadding = step?.spotlightStyle?.padding ?? 5;
 
-  // The spotlighted element the popover anchors to. Assigned during render so
-  // it's set before the (remounted, keyed) popover measures it on mount.
-  const anchorRef = useRef<HTMLElement | null>(null);
-  anchorRef.current = step?.selector
+  // The spotlighted element the popover anchors to. Looked up during render so
+  // it's known before the (remounted, keyed) popover measures it on mount.
+  const anchorEl = step?.selector
     ? document.querySelector<HTMLElement>(step.selector)
     : null;
+  const anchorRef = useRef<HTMLElement | null>(null);
+  anchorRef.current = anchorEl;
 
   // Let focus move to the body so the next Tab enters the page from the top.
   // react-aria restores focus on unmount only when focus is still inside the
@@ -134,19 +135,22 @@ const Tour = () => {
   // backdrops flashes; TourOverlay dims (and spotlights) instead.
   const useTourOverlay = Boolean(step.selector) || steps.length > 1;
 
+  // Rendered first in both branches below so it isn't remounted between steps.
+  const tourOverlay = (
+    <TourOverlay
+      reference={anchorEl}
+      padding={spotlightPadding}
+      paddingTop={step.spotlightStyle?.paddingTop}
+      paddingBottom={step.spotlightStyle?.paddingBottom}
+      paddingRight={step.spotlightStyle?.paddingRight}
+      paddingLeft={step.spotlightStyle?.paddingLeft}
+    />
+  );
+
   if (!anchored) {
     return (
       <>
-        {useTourOverlay && (
-          <TourOverlay
-            referenceRef={anchorRef as React.MutableRefObject<HTMLElement>}
-            padding={spotlightPadding}
-            paddingTop={step.spotlightStyle?.paddingTop}
-            paddingBottom={step.spotlightStyle?.paddingBottom}
-            paddingRight={step.spotlightStyle?.paddingRight}
-            paddingLeft={step.spotlightStyle?.paddingLeft}
-          />
-        )}
+        {useTourOverlay && tourOverlay}
         <Modal
           isOpen={isOpen}
           onClose={() => {}}
@@ -172,14 +176,7 @@ const Tour = () => {
 
   return (
     <>
-      <TourOverlay
-        referenceRef={anchorRef as React.MutableRefObject<HTMLElement>}
-        padding={spotlightPadding}
-        paddingTop={step.spotlightStyle?.paddingTop}
-        paddingBottom={step.spotlightStyle?.paddingBottom}
-        paddingRight={step.spotlightStyle?.paddingRight}
-        paddingLeft={step.spotlightStyle?.paddingLeft}
-      />
+      {tourOverlay}
       <RACPopover
         // Remount per step so the popover re-measures its new anchor.
         key={step.selector}

--- a/src/pages/TourOverlay.tsx
+++ b/src/pages/TourOverlay.tsx
@@ -22,6 +22,9 @@ const TourOverlay = ({ reference, ...clipStyle }: TourOverlayProps) => {
   const [overlay, cutOut] = useRects(reference);
   return createPortal(
     <svg
+      // Purely decorative: the spotlight can't be conveyed to assistive
+      // technology, so the step's dialog names its target instead.
+      aria-hidden="true"
       className={css({
         zIndex: "overlay",
         position: "fixed",

--- a/src/pages/TourOverlay.tsx
+++ b/src/pages/TourOverlay.tsx
@@ -3,20 +3,23 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { MutableRefObject, RefObject, useLayoutEffect, useState } from "react";
+import { useLayoutEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { css } from "@microbit/ui";
 
 interface TourOverlayProps extends SpotlightStyle {
-  referenceRef: MutableRefObject<HTMLElement | undefined>;
+  /**
+   * The element to spotlight, or null for no cut out.
+   */
+  reference: HTMLElement | null;
 }
 
 /**
  * A replacement for the modal backdrop that cuts out a section to highlight
  * some of the background. Suitable for onboarding tours.
  */
-const TourOverlay = ({ referenceRef, ...clipStyle }: TourOverlayProps) => {
-  const [overlay, cutOut] = useRects(referenceRef);
+const TourOverlay = ({ reference, ...clipStyle }: TourOverlayProps) => {
+  const [overlay, cutOut] = useRects(reference);
   return createPortal(
     <svg
       className={css({
@@ -63,27 +66,29 @@ interface Rect {
   y: number;
 }
 
-const useRects = (ref: RefObject<HTMLElement | undefined>): Rect[] => {
+// Measure the element on each change of step, not just on mount: the overlay
+// stays mounted for the whole tour so the spotlight has to follow the element.
+const useRects = (element: HTMLElement | null): Rect[] => {
   const [rects, setRects] = useState<Rect[]>([]);
   useLayoutEffect(() => {
-    // Scroll ref element into view before calculating rect.
-    ref.current?.scrollIntoView({ behavior: "instant", inline: "nearest" });
-    const resizeObserver = new ResizeObserver(() => {
-      if (ref.current) {
-        setRects([
-          document.body.getBoundingClientRect(),
-          ref.current.getBoundingClientRect(),
-        ]);
-      }
-    });
-    if (ref.current) {
-      resizeObserver.observe(ref.current);
-      resizeObserver.observe(document.body);
+    if (!element) {
+      setRects((previous) => (previous.length === 0 ? previous : []));
+      return;
     }
+    // Scroll the element into view before calculating rect.
+    element.scrollIntoView({ behavior: "instant", inline: "nearest" });
+    const resizeObserver = new ResizeObserver(() => {
+      setRects([
+        document.body.getBoundingClientRect(),
+        element.getBoundingClientRect(),
+      ]);
+    });
+    resizeObserver.observe(element);
+    resizeObserver.observe(document.body);
     return () => {
       resizeObserver.disconnect();
     };
-  }, [ref]);
+  }, [element]);
   return rects;
 };
 


### PR DESCRIPTION
Under Chakra, TourOverlay was a child of a Modal keyed on step.selector, so
it remounted on every step and re-ran the layout effect that measures the
spotlighted element. It now sits outside the keyed popover in the same tree
position for every step, so it mounts once per tour -- on the first step,
whose anchor is null -- and useRects' effect depended only on the ref object,
which never changes identity. No ResizeObserver was ever registered, so no
clipPath was emitted and the backdrop rect rendered unclipped: the page dimmed
as normal but nothing was ever spotlighted.

Pass the element rather than a ref and key the effect on it so the overlay
re-measures when the step's target changes. Share one element between the two
render branches to keep it in the same position, so it still isn't remounted
(which would flash an unclipped backdrop).

Steps with no selector still dim without a cut out, as before.

Closes #962 