### PR TITLE
Remove Chakra migration residue

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -16,7 +16,6 @@ module.exports = {
   ignorePatterns: [
     "dist",
     "styled-system",
-    "src/shared-ui/chakra-tokens.ts",
     ".eslintrc.cjs",
     "deployment.cjs",
     "bin/**/*.js",
@@ -43,7 +42,7 @@ module.exports = {
   rules: {
     // More trouble than it's worth
     "react/no-unescaped-entities": "off",
-    // False positives from library imports from Chakra UI
+    // False positives from library imports
     "@typescript-eslint/unbound-method": "off",
     "@typescript-eslint/no-misused-promises": [
       "error",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,8 @@
 
 ## Styling / branded builds / verification
 
-This app uses react-aria-components + Panda CSS via `@microbit/ui`
-(migrated from Chakra UI, July 2026). **Read the gotcha catalog in
-`../ui/docs/migration-playbook.md` before styling/theming/UI work.**
+This app uses react-aria-components + Panda CSS via `@microbit/ui`.
+**Read `../ui/docs/hints.md` before styling/theming/UI work.**
 
 - **Branded build locally**: build the sibling `../ml-trainer-microbit`
   package (`npm run build` there → `dist/panda-preset.js`) and make it
@@ -15,7 +14,7 @@ This app uses react-aria-components + Panda CSS via `@microbit/ui`
   to `../ui/packages/ui`; a plain `npm i` restores the registry version.
 - **After changing or (re)linking either sibling package, do a _clean_
   Panda regen**: `rm -rf styled-system && npm run panda`. Incremental
-  codegen doesn't detect external preset changes (playbook gotcha #27).
+  codegen doesn't detect external preset changes.
   Restart the dev server too, and `rm -rf node_modules/.vite`: Vite serves
   the old pre-bundle of the package otherwise, and a new export fails as
   "does not provide an export named X" on a blank page.

--- a/panda.config.ts
+++ b/panda.config.ts
@@ -6,7 +6,7 @@ import { appPreset } from "./src/deployment/default/panda-preset";
 // alias swap in vite.config.ts. When the private package is installed it
 // overrides brand tokens (colours, fonts) and brand recipe variants; otherwise
 // the OSS default preset stands alone. The two are merged by Panda at codegen
-// time — the build-time equivalent of Chakra's runtime theme swap.
+// time.
 //
 // Panda loads this config as CommonJS, so `require` is the real (sync) require;
 // Node 24 resolves the ESM private package through it.
@@ -29,8 +29,7 @@ export default defineConfig({
   // injects it into the cascade-layer declaration in src/layers.css.
   jsxFramework: "react",
   // Drop Panda's default theme preset; the preset stack below supplies the
-  // full token system (ported from Chakra). preset-base still provides the
-  // utilities.
+  // full token system. preset-base still provides the utilities.
   eject: true,
   // Later presets override earlier ones: @microbit/ui's base preset (the
   // complete design system + recipes, with OSS default brand values), this

--- a/src/components/AboutDialog.tsx
+++ b/src/components/AboutDialog.tsx
@@ -58,7 +58,7 @@ const AboutDialog = ({ isOpen, onClose, finalFocusRef }: AboutDialogProps) => {
         setHasCopied(true);
         setTimeout(() => setHasCopied(false), 1500);
       },
-      // E.g. permission denied; give no feedback, like Chakra's useClipboard.
+      // E.g. permission denied; give no feedback.
       () => {}
     );
   }, [clipboardVersion]);
@@ -114,8 +114,8 @@ const AboutDialog = ({ isOpen, onClose, finalFocusRef }: AboutDialogProps) => {
               </AspectRatio>
             </Box>
             <VStack alignItems="center" justifyContent="center" gap={4}>
-              {/* One-off Chakra-style table (size sm); not worth a primitive
-                  for a single two-cell layout. */}
+              {/* One-off table styling; not worth a primitive for a single
+                  two-cell layout. */}
               <table className={css({ borderCollapse: "collapse" })}>
                 <caption
                   className={css({

--- a/src/components/AppLogo.tsx
+++ b/src/components/AppLogo.tsx
@@ -27,7 +27,7 @@ const AppLogo = ({ color = "#FFF", css: cssProp }: AppLogoProps) => {
       {OrgLogo && (
         <>
           <OrgLogo />
-          {/* Chakra's vertical Divider with borderWidth 1px (so ~2px wide). */}
+          {/* Vertical divider; 1px border on both sides, so ~2px wide. */}
           <div
             aria-hidden
             className={css({

--- a/src/components/BlocksLoadingSkeleton.tsx
+++ b/src/components/BlocksLoadingSkeleton.tsx
@@ -5,7 +5,7 @@
  */
 import { Box, css, VStack } from "@microbit/ui";
 
-/** Pulsing line placeholder standing in for Chakra's SkeletonText. */
+/** Pulsing skeleton lines shown while the blocks preview loads. */
 const BlocksLoadingSkeleton = () => (
   <VStack w="xs" gap={5} alignItems="stretch" aria-hidden>
     {Array.from(Array(5)).map((_, idx) => (

--- a/src/components/BluetoothPatternInput.tsx
+++ b/src/components/BluetoothPatternInput.tsx
@@ -244,7 +244,7 @@ const PatternLedOption = ({
   // the click reaches the React root), which would otherwise revert the
   // change. onReactivate is only wired on the currently-checked option, so
   // selection clicks don't trigger it; keyboard activation of a checked radio
-  // also fires a click, matching the Chakra behaviour.
+  // also fires a click, so it is handled too.
   const wrapperRef = useRef<HTMLDivElement>(null);
   const onReactivateRef = useRef(onReactivate);
   onReactivateRef.current = onReactivate;

--- a/src/components/ButtonWithLoading.tsx
+++ b/src/components/ButtonWithLoading.tsx
@@ -11,15 +11,14 @@ import { Button, ButtonProps, css, Spinner } from "@microbit/ui";
 export interface ButtonWithLoadingProps
   extends Omit<ButtonProps, "children" | "onPress"> {
   isLoading?: boolean;
-  /** Click handler (onPress naming kept off the API to ease migration). */
+  /** Click handler. */
   onClick?: () => void;
   children: ReactNode;
 }
 
 /**
  * Button that swaps its label for a centred spinner while loading, keeping
- * its width (the label stays in the layout, hidden), like Chakra's
- * `isLoading`.
+ * its width (the label stays in the layout, hidden).
  */
 export const ButtonWithLoading = forwardRef<
   HTMLButtonElement,

--- a/src/components/Carousel/CarouselButton.tsx
+++ b/src/components/Carousel/CarouselButton.tsx
@@ -38,8 +38,7 @@ const CarouselButton = React.forwardRef(function CarouselButton(
           border: "none",
           borderRadius: 0,
           bg: "rgba(245, 245, 245, 0.5)",
-          // Was the Chakra-era off-palette slate #556C84 (5.4:1); the
-          // nearest ink stop by lightness (the icons follow currentColor).
+          // The icons follow currentColor.
           color: "gray.500",
           cursor: "pointer",
           transition: "background-color 0.2s ease",

--- a/src/components/EditableName.tsx
+++ b/src/components/EditableName.tsx
@@ -34,7 +34,7 @@ interface EditableNameProps {
   onEditRef?: MutableRefObject<(() => void) | undefined>;
 }
 
-// Shared by both variants' single-css()-call styles (gotcha #8).
+// Shared by both variants' single-css()-call styles.
 const previewButtonBase: SystemStyleObject = {
   display: "flex",
   h: 10,
@@ -46,8 +46,8 @@ const previewButtonBase: SystemStyleObject = {
 };
 
 /**
- * The editable project name. Replaces Chakra's Editable: a preview button
- * that swaps to an input; Enter/blur commits, Escape reverts.
+ * The editable project name: a preview button that swaps to an input;
+ * Enter/blur commits, Escape reverts.
  */
 const EditableName = ({
   suffix,
@@ -77,7 +77,7 @@ const EditableName = ({
 
   useEffect(() => {
     if (editing) {
-      // Select-all like Chakra's Editable, so typing replaces the name.
+      // Select all so typing replaces the name.
       inputRef.current?.focus();
       inputRef.current?.select();
     }

--- a/src/components/Emoji.tsx
+++ b/src/components/Emoji.tsx
@@ -7,7 +7,7 @@ type Side = "left" | "right";
 interface EmojiProps {
   leftEye?: Eye;
   rightEye?: Eye;
-  /** Box size on the spacing scale; the Chakra call sites used 16 and 20. */
+  /** Box size on the spacing scale. */
   size?: "16" | "20";
   className?: string;
 }

--- a/src/components/HowItWorksAnimation/Layout.tsx
+++ b/src/components/HowItWorksAnimation/Layout.tsx
@@ -75,8 +75,7 @@ const Layout = forwardRef<LayoutRef, LayoutProps>(function Layout(
         alignItems="center"
         // "0%" not 0: a percentage is treated as auto in the row's intrinsic
         // width calculation, so the collapsed item still props up the row and
-        // the left stack's 45% resolves against the full-size row (Chakra's
-        // width={0} meant 0%).
+        // the left stack's 45% resolves against the full-size row.
         width={centerLeftDuration ? "0%" : undefined}
         style={{
           transition: centerLeftDuration

--- a/src/components/HowItWorksAnimation/StepFlow.tsx
+++ b/src/components/HowItWorksAnimation/StepFlow.tsx
@@ -110,8 +110,8 @@ const StepFlow = forwardRef<StepFlowRef>(function StepFlow(_, stepFlowRef) {
           left: "44%",
           width: "3em",
           top: "30%",
-          // Faithful to Chakra incl. the bogus base "active" colour (the
-          // browser drops it and the arrow inherits the text colour below md).
+          // The base "active" value is not a real colour: the browser drops
+          // it and the arrow inherits the text colour below md (intentional).
           color:
             arrowState === "hidden"
               ? "transparent"
@@ -128,8 +128,8 @@ const StepFlow = forwardRef<StepFlowRef>(function StepFlow(_, stepFlowRef) {
           width: "3em",
           bottom: "-22%",
           transform: "rotate(180deg)",
-          // Faithful to Chakra incl. the bogus base "active" colour (the
-          // browser drops it and the arrow inherits the text colour below md).
+          // The base "active" value is not a real colour: the browser drops
+          // it and the arrow inherits the text colour below md (intentional).
           color:
             arrowState === "hidden"
               ? "transparent"
@@ -148,8 +148,8 @@ const StepFlow = forwardRef<StepFlowRef>(function StepFlow(_, stepFlowRef) {
           left: "-2em",
           width: "2em",
           transform: "rotate(-90deg)",
-          // Faithful to Chakra incl. the bogus base "active" colour (the
-          // browser drops it and the arrow inherits the text colour below md).
+          // The base "active" value is not a real colour: the browser drops
+          // it and the arrow inherits the text colour below md (intentional).
           color:
             arrowState === "hidden"
               ? "transparent"
@@ -167,8 +167,8 @@ const StepFlow = forwardRef<StepFlowRef>(function StepFlow(_, stepFlowRef) {
           right: "-2em",
           width: "2em",
           transform: "rotate(90deg)",
-          // Faithful to Chakra incl. the bogus base "active" colour (the
-          // browser drops it and the arrow inherits the text colour below md).
+          // The base "active" value is not a real colour: the browser drops
+          // it and the arrow inherits the text colour below md (intentional).
           color:
             arrowState === "hidden"
               ? "transparent"

--- a/src/components/HowItWorksAnimation/StepTickPill.tsx
+++ b/src/components/HowItWorksAnimation/StepTickPill.tsx
@@ -77,7 +77,7 @@ const StepTickPill = forwardRef<StepTickPillRef, StepTickPillProps>(
           borderRadius="full"
         >
           <Grid
-            // Panda's Grid pattern defaults gap to 8px; Chakra's had none.
+            // Panda's Grid pattern defaults gap to 8px; none wanted here.
             gap={0}
             gridTemplateColumns="1fr 2fr 1fr"
             backgroundColor={state.active ? "brand2.500" : "transparent"}

--- a/src/components/LedIconPicker.tsx
+++ b/src/components/LedIconPicker.tsx
@@ -67,7 +67,7 @@ const LedIconPicker = ({
         })}
       >
         {children}
-        {/* Decorative ghost-button look (Chakra had IconButton as="div"). */}
+        {/* Decorative ghost-button look. */}
         <span
           className={cx(
             button({ variant: "ghost", size: "sm" }),

--- a/src/components/PlugMicrobitAnimation/index.tsx
+++ b/src/components/PlugMicrobitAnimation/index.tsx
@@ -75,9 +75,8 @@ const PlugMicrobitAnimation = ({
             ),
           }}
         />
-        {/* Plain img: width/height must stay HTML attributes (intrinsic size,
-            Chakra's htmlWidth/htmlHeight); on styled Image they'd be style
-            props. */}
+        {/* Plain img: width/height must stay HTML attributes (intrinsic
+            size); on styled Image they'd be style props. */}
         <img
           src={microbitImage}
           alt=""

--- a/src/components/ProjectPreview.tsx
+++ b/src/components/ProjectPreview.tsx
@@ -128,7 +128,6 @@ const ProjectLoadDetails = ({
           data-testid="name-text"
           value={name}
           placeholder={nameLabel}
-          // Chakra's size="lg" input.
           css={{ minW: "25ch", height: 12, fontSize: "lg", borderRadius: "md" }}
           onChange={(e) => setName(e.currentTarget.value)}
         />

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -70,9 +70,8 @@ export const SettingsDialog = ({
   // active surface; the web build defers to the shared-assets cookie
   // modal accessed via the nav-drawer "Manage cookies" link.
   const showAnalyticsToggle = isNativePlatform();
-  // Unlike Chakra, react-aria focuses the dialog itself on open (not the
-  // first form control), so no initial-focus hack is needed to stop the
-  // first <select> opening its picker on mobile.
+  // react-aria focuses the dialog itself on open (not the first form
+  // control), which stops the first <select> opening its picker on mobile.
   const [isResetConfirmOpen, setResetConfirmOpen] = useState(false);
   const handleResetToDefault = useCallback(() => {
     setResetConfirmOpen(true);
@@ -191,9 +190,9 @@ export const SettingsDialog = ({
                 <FormattedMessage id="graph-preview" />
               </Text>
               {/* Native aspect-ratio rather than the AspectRatio pattern: the
-                  pattern's `&>*` child selector loses to the (still-Chakra)
-                  RecordingGraph's own position style, leaving its padding
-                  spacer above an in-flow child. */}
+                  pattern's `&>*` child selector loses to RecordingGraph's own
+                  position style, leaving its padding spacer above an in-flow
+                  child. */}
               <Box w="full" css={{ aspectRatio: "526 / 92" }}>
                 <RecordingGraph
                   responsive

--- a/src/components/SortInput.tsx
+++ b/src/components/SortInput.tsx
@@ -32,12 +32,12 @@ const SortInput = ({
         value={value}
         onChange={onSelectChange}
         aria-label={intl.formatMessage({ id: "sort-select-label" })}
-        // Matches the Chakra-era look; the adjacent sort-order button keeps
-        // the control from reading as a plain text field.
+        // The adjacent sort-order button keeps the control from reading as a
+        // plain text field.
         hideChevron
         disabled={hasSearchQuery}
         // flex/minW let the select shrink below its longest option when space
-        // is tight, clipping the text like Chakra's Select did.
+        // is tight, clipping the text.
         css={{ fontSize: "lg", background: "white", flex: 1, minW: 0 }}
       >
         {hasSearchQuery ? (

--- a/src/e2e/app/download-dialogs.ts
+++ b/src/e2e/app/download-dialogs.ts
@@ -93,7 +93,7 @@ export class DownloadDialogs {
   }
 
   async checkDontShowAgain() {
-    // Click on the label text instead of the checkbox input due to Chakra UI styling
+    // Click the label text rather than the checkbox input.
     await this.page.getByText("Don't show this again").click();
   }
 

--- a/src/hooks/use-element-size.ts
+++ b/src/hooks/use-element-size.ts
@@ -7,11 +7,10 @@ import { RefObject, useLayoutEffect, useState } from "react";
 
 /**
  * Observed border-box size of an element, or undefined before first measure.
- * Replaces Chakra's useSize.
  *
- * Measures synchronously in a layout effect (like Chakra's) so consumers
- * re-render with the real size before other effects run — LiveGraph relies on
- * its canvas having final dimensions before the chart paints its only frame.
+ * Measures synchronously in a layout effect so consumers re-render with the
+ * real size before other effects run — LiveGraph relies on its canvas having
+ * final dimensions before the chart paints its only frame.
  */
 export const useElementSize = (
   ref: RefObject<HTMLElement>

--- a/src/layers.css
+++ b/src/layers.css
@@ -6,14 +6,12 @@
  * Establishes the app-wide cascade layer order before any other stylesheet
  * declares layers (the first @layer statement fixes relative order for the
  * whole document). `vendor` holds third-party CSS (see Carousel/swiper.css)
- * so that it beats Panda's preflight reset but loses to app styling —
- * matching the pre-Panda cascade, where the reset came first and app styles
- * were injected last. The other names are Panda's own layers.
+ * so that it beats Panda's preflight reset but loses to app styling.
+ * The other names are Panda's own layers.
  */
 @layer reset, vendor, base, tokens, recipes, utilities;
 
-/* Required since @microbit/ui 0.1.0-alpha.7: Chakra-parity
- * border-color/word-wrap defaults, kept in the bottom layer so the
- * production cascade-layer flattening can't boost them above CSS it
- * doesn't process (playbook gotcha #28). */
+/* @microbit/ui's border-color/word-wrap defaults, kept in the bottom
+ * layer so the production cascade-layer flattening can't boost them
+ * above CSS it doesn't process. */
 @import "@microbit/ui/reset.css" layer(reset);

--- a/src/pages/Tour.tsx
+++ b/src/pages/Tour.tsx
@@ -27,8 +27,7 @@ import TourOverlay from "./TourOverlay";
 // Default distance or margin between the reference and popover.
 const gutterDefault = 8;
 
-// Chakra's popper-positioned ModalContent had no shadow (it overrode
-// boxShadow to none) and the standard modal white box.
+// The standard modal white box, deliberately without a shadow.
 const popoverDialogClass = css({
   bg: "white",
   borderRadius: "md",
@@ -194,7 +193,6 @@ const Tour = () => {
         }
         className={css({ zIndex: "modal" })}
       >
-        {/* Chakra's popper arrow: white, shadowless, 16px base. */}
         <PopoverArrow size={16} css={{ "& svg": { fill: "white" } }} />
         <Dialog className={popoverDialogClass}>
           <RACHeading slot="title" className={popoverHeaderClass}>


### PR DESCRIPTION
The migration is complete: swept Chakra/gotcha/playbook references from comments and docs, normalised agent notes to plain app/tooling notes (pointing at ui's docs/hints.md), and removed fidelity leftovers.