### PR TITLE
Avoid using aspect-ratio CSS property

### DIFF
--- a/src/components/NativeBluetoothConnectBatteryDialog.tsx
+++ b/src/components/NativeBluetoothConnectBatteryDialog.tsx
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { Image, Text, VStack } from "@microbit/ui";
+import { AspectRatio, Image, Text, VStack } from "@microbit/ui";
 import { FormattedMessage } from "react-intl";
 import microbitWithBatteryPack from "../images/microbit-with-battery-pack.svg";
 import ConnectContainerDialog, {
@@ -37,13 +37,9 @@ const NativeBluetoothConnectBatteryDialog = ({
         <Text width="100%">
           <FormattedMessage id="connect-native-start-battery-check" />
         </Text>
-        <Image
-          src={microbitWithBatteryPack}
-          alt=""
-          width="22rem"
-          aspectRatio={250 / 148}
-          my={3.5}
-        />
+        <AspectRatio width="22rem" maxWidth="100%" ratio={250 / 148} my={3.5}>
+          <Image src={microbitWithBatteryPack} alt="" />
+        </AspectRatio>
       </VStack>
     </ConnectContainerDialog>
   );

--- a/src/components/PlugMicrobitAnimation/index.tsx
+++ b/src/components/PlugMicrobitAnimation/index.tsx
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { Box, css, Image } from "@microbit/ui";
+import { AspectRatio, Box, css, Image } from "@microbit/ui";
 import connectorImage from "../../images/micro-usb-connector.png";
 import microbitImage from "../../images/microbit.png";
 import { useAnimation } from "../AnimationProvider";
@@ -45,12 +45,12 @@ const PlugMicrobitAnimation = ({
       style={{ width }}
     >
       <Box position="relative" width="100%">
-        <Box
+        <AspectRatio
+          ratio={1}
           position="absolute"
           left="40%"
           top="16%"
           width="23%"
-          aspectRatio="1"
           transform="translate(-75%, -75%)"
           borderRadius="full"
           backgroundImage="radial-gradient(closest-side, rgba(255, 199, 0, 0.55) 50%, transparent)"

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -189,16 +189,28 @@ export const SettingsDialog = ({
               <Text>
                 <FormattedMessage id="graph-preview" />
               </Text>
-              {/* Native aspect-ratio rather than the AspectRatio pattern: the
-                  pattern's `&>*` child selector loses to RecordingGraph's own
-                  position style, leaving its padding spacer above an in-flow
-                  child. */}
-              <Box w="full" css={{ aspectRatio: "526 / 92" }}>
+              {/* The AspectRatio pattern's `&>*` child selector loses to
+                  RecordingGraph's own position style, so this uses the same
+                  ::before percentage-padding spacer and positions the graph
+                  via its own props. */}
+              <Box
+                w="full"
+                position="relative"
+                _before={{
+                  content: '""',
+                  display: "block",
+                  height: 0,
+                  paddingBottom: `${(92 / 526) * 100}%`,
+                }}
+              >
                 <RecordingGraph
                   responsive
                   data={previewGraphData}
                   role="img"
+                  position="absolute"
+                  inset={0}
                   w="full"
+                  h="full"
                   aria-label={intl.formatMessage({
                     id: "recording-graph-label",
                   })}

--- a/src/tours.tsx
+++ b/src/tours.tsx
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { HStack, Icon, Image, Stack, Text } from "@microbit/ui";
+import { AspectRatio, HStack, Icon, Image, Stack, Text } from "@microbit/ui";
 import { RiInformationLine } from "react-icons/ri";
 import { FormattedMessage, useIntl } from "react-intl";
 import makecodeBackImage from "./images/makecode-back.png";
@@ -37,13 +37,12 @@ const LiveGraphStep = () => {
       <Text>
         <FormattedMessage id="tour-dataSamples-liveGraph-content" />
       </Text>
-      <Image
-        src={accelerometerImage}
-        w="150px"
-        aspectRatio={500 / 482}
-        flexShrink={0}
-        alt={intl.formatMessage({ id: "accelerometer-image-alt" })}
-      />
+      <AspectRatio w="150px" ratio={500 / 482} flexShrink={0}>
+        <Image
+          src={accelerometerImage}
+          alt={intl.formatMessage({ id: "accelerometer-image-alt" })}
+        />
+      </AspectRatio>
     </HStack>
   );
 };
@@ -62,15 +61,13 @@ const MakeCodeStep = () => {
           <br />
           <FormattedMessage id="tour-makecode-intro-content3" />
         </Text>
-        <Image
-          src={makecodeBackImage}
-          w="50px"
-          aspectRatio={1}
-          flexShrink={0}
-          borderRadius="sm"
-          mx={3}
-          alt={intl.formatMessage({ id: "makecode-back-alt" })}
-        />
+        <AspectRatio w="50px" ratio={1} flexShrink={0} mx={3}>
+          <Image
+            src={makecodeBackImage}
+            borderRadius="sm"
+            alt={intl.formatMessage({ id: "makecode-back-alt" })}
+          />
+        </AspectRatio>
       </HStack>
     </Stack>
   );


### PR DESCRIPTION
Not supported in Safari 14. Switch to the AspectRatio component, which uses percentage-based padding. The settings dialog graph preview uses an equivalent ::before spacer directly, as the pattern's child styles conflict with RecordingGraph's own.

See https://github.com/microbit-foundation/ui/issues/72