### PR TITLE
Ensure all modals have headers

### DIFF
--- a/lang/ui.en-us.json
+++ b/lang/ui.en-us.json
@@ -5,7 +5,7 @@
   },
   "about": {
     "defaultMessage": "About",
-    "description": "Menu item link to view information about app; also the about dialog heading"
+    "description": "Menu item link to view information about app; also the accessible name of the about dialog"
   },
   "about-dialog-alt": {
     "defaultMessage": "micro:bit board showing a heart on the LED display",
@@ -865,7 +865,7 @@
   },
   "feedback": {
     "defaultMessage": "Feedback",
-    "description": "Action to open a feedback dialog; also the feedback dialog heading"
+    "description": "Action to open a feedback dialog; also the accessible name of the feedback dialog"
   },
   "fingerprint-acc-x-tooltip": {
     "defaultMessage": "Sum of x-direction data",

--- a/lang/ui.en-us.json
+++ b/lang/ui.en-us.json
@@ -5,7 +5,7 @@
   },
   "about": {
     "defaultMessage": "About",
-    "description": "Menu item link to view information about app"
+    "description": "Menu item link to view information about app; also the about dialog heading"
   },
   "about-dialog-alt": {
     "defaultMessage": "micro:bit board showing a heart on the LED display",
@@ -865,7 +865,7 @@
   },
   "feedback": {
     "defaultMessage": "Feedback",
-    "description": "Action to open a feedback dialog"
+    "description": "Action to open a feedback dialog; also the feedback dialog heading"
   },
   "fingerprint-acc-x-tooltip": {
     "defaultMessage": "Sum of x-direction data",

--- a/lang/ui.en.json
+++ b/lang/ui.en.json
@@ -5,7 +5,7 @@
   },
   "about": {
     "defaultMessage": "About",
-    "description": "Menu item link to view information about app; also the about dialog heading"
+    "description": "Menu item link to view information about app; also the accessible name of the about dialog"
   },
   "about-dialog-alt": {
     "defaultMessage": "micro:bit board showing a heart on the LED display",
@@ -865,7 +865,7 @@
   },
   "feedback": {
     "defaultMessage": "Feedback",
-    "description": "Action to open a feedback dialog; also the feedback dialog heading"
+    "description": "Action to open a feedback dialog; also the accessible name of the feedback dialog"
   },
   "fingerprint-acc-x-tooltip": {
     "defaultMessage": "Sum of x-direction data",

--- a/lang/ui.en.json
+++ b/lang/ui.en.json
@@ -5,7 +5,7 @@
   },
   "about": {
     "defaultMessage": "About",
-    "description": "Menu item link to view information about app"
+    "description": "Menu item link to view information about app; also the about dialog heading"
   },
   "about-dialog-alt": {
     "defaultMessage": "micro:bit board showing a heart on the LED display",
@@ -865,7 +865,7 @@
   },
   "feedback": {
     "defaultMessage": "Feedback",
-    "description": "Action to open a feedback dialog"
+    "description": "Action to open a feedback dialog; also the feedback dialog heading"
   },
   "fingerprint-acc-x-tooltip": {
     "defaultMessage": "Sum of x-direction data",

--- a/src/components/AboutDialog.tsx
+++ b/src/components/AboutDialog.tsx
@@ -20,7 +20,6 @@ import {
   ModalBody,
   ModalCloseButton,
   ModalFooter,
-  ModalHeader,
   Text,
   VisuallyHidden,
   VStack,
@@ -70,10 +69,8 @@ const AboutDialog = ({ isOpen, onClose, finalFocusRef }: AboutDialogProps) => {
       onClose={onClose}
       size={{ base: "full", md: "2xl" }}
       finalFocusRef={finalFocusRef}
+      aria-label={intl.formatMessage({ id: "about" })}
     >
-      <ModalHeader>
-        <FormattedMessage id="about" />
-      </ModalHeader>
       <ModalCloseButton />
       <ModalBody>
         <VStack gap={8} pl={5} pr={5} pt={5}>

--- a/src/components/AboutDialog.tsx
+++ b/src/components/AboutDialog.tsx
@@ -20,6 +20,7 @@ import {
   ModalBody,
   ModalCloseButton,
   ModalFooter,
+  ModalHeader,
   Text,
   VisuallyHidden,
   VStack,
@@ -70,8 +71,11 @@ const AboutDialog = ({ isOpen, onClose, finalFocusRef }: AboutDialogProps) => {
       size={{ base: "full", md: "2xl" }}
       finalFocusRef={finalFocusRef}
     >
+      <ModalHeader>
+        <FormattedMessage id="about" />
+      </ModalHeader>
+      <ModalCloseButton />
       <ModalBody>
-        <ModalCloseButton />
         <VStack gap={8} pl={5} pr={5} pt={5}>
           <HStack justifyContent="center" gap={8}>
             {OrgLogo && <OrgLogo color="black" h="55px" />}

--- a/src/components/FeedbackForm.tsx
+++ b/src/components/FeedbackForm.tsx
@@ -3,9 +3,9 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { Modal, ModalBody, ModalCloseButton, ModalHeader } from "@microbit/ui";
+import { Modal, ModalBody, ModalCloseButton } from "@microbit/ui";
 import { useEffect, useRef } from "react";
-import { FormattedMessage } from "react-intl";
+import { useIntl } from "react-intl";
 
 interface FeedbackFormProps {
   isOpen: boolean;
@@ -21,6 +21,7 @@ const FeedbackForm = ({
   onClose,
   finalFocusRef = undefined,
 }: FeedbackFormProps) => {
+  const intl = useIntl();
   const iframeRef = useRef<HTMLIFrameElement>(null);
   useEffect(() => {
     const listener = (message: MessageEvent) => {
@@ -47,10 +48,8 @@ const FeedbackForm = ({
       onClose={onClose}
       size={{ base: "full", md: "2xl" }}
       finalFocusRef={finalFocusRef}
+      aria-label={intl.formatMessage({ id: "feedback" })}
     >
-      <ModalHeader>
-        <FormattedMessage id="feedback" />
-      </ModalHeader>
       <ModalCloseButton />
       <ModalBody>
         <iframe

--- a/src/components/FeedbackForm.tsx
+++ b/src/components/FeedbackForm.tsx
@@ -3,8 +3,9 @@
  *
  * SPDX-License-Identifier: MIT
  */
-import { Modal, ModalBody, ModalCloseButton } from "@microbit/ui";
+import { Modal, ModalBody, ModalCloseButton, ModalHeader } from "@microbit/ui";
 import { useEffect, useRef } from "react";
+import { FormattedMessage } from "react-intl";
 
 interface FeedbackFormProps {
   isOpen: boolean;
@@ -47,6 +48,9 @@ const FeedbackForm = ({
       size={{ base: "full", md: "2xl" }}
       finalFocusRef={finalFocusRef}
     >
+      <ModalHeader>
+        <FormattedMessage id="feedback" />
+      </ModalHeader>
       <ModalCloseButton />
       <ModalBody>
         <iframe

--- a/src/components/LoadingOverlay.tsx
+++ b/src/components/LoadingOverlay.tsx
@@ -16,6 +16,7 @@ const LoadingOverlay = ({ loading }: LoadingOverlayProps) => {
       isDismissable={false}
       onClose={doNothing}
       isCentered
+      aria-label={intl.formatMessage({ id: "loading" })}
       contentCss={{
         background: "transparent",
         boxShadow: "none",


### PR DESCRIPTION
Only three modals to amend. 

The loading overlay now has a "loading" label in the modal and a "loading" label for the spinner (currently required).

See https://github.com/microbit-foundation/ui/issues/29