### PR TITLE
Drop the no-op isRound prop from icon buttons

### DIFF
--- a/src/components/ActionBar/ActionBarMenuButton.tsx
+++ b/src/components/ActionBar/ActionBarMenuButton.tsx
@@ -31,7 +31,6 @@ export const ActionBarMenuButton = forwardRef<
       ref={ref}
       variant="plain"
       size="lg"
-      isRound
       css={{
         display: hidden ? "none" : undefined,
         color: "white",

--- a/src/components/DataSamplesMenu.tsx
+++ b/src/components/DataSamplesMenu.tsx
@@ -123,7 +123,6 @@ const DataSamplesMenu = () => {
             id: "data-actions-menu",
           })}
           variant="ghost"
-          isRound
           css={{ color: "gray.800" }}
         >
           <Icon as={MdMoreVert} css={{ width: 7, height: 7 }} />


### PR DESCRIPTION
It is being removed from @microbit/ui: the 2rem button radius already clamps to a full round at every size, so the prop changed nothing here. No visual change.

See microbit-foundation/ui#4