### PR TITLE
Onboard Renovate

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -11,6 +11,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ startsWith(github.ref, 'refs/tags/v') && 'release' || github.ref }}
   cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/v') }}
 
+env:
+  # renovate: datasource=npm depName=npm
+  NPM_VERSION: "11"
+  # renovate: datasource=npm depName=@microbit-foundation/ml-trainer-microbit registryUrl=https://npm.pkg.github.com
+  ML_THEME_VERSION: 0.2.0-dev.143
+
 jobs:
   build-android:
     # Only run for apps releases, or pushes to main or branches whose name ends with -apps
@@ -30,7 +36,7 @@ jobs:
           cache: "npm"
           registry-url: "https://npm.pkg.github.com"
 
-      - run: npm install -g npm@11 --registry=https://registry.npmjs.org
+      - run: npm install -g npm@${{ env.NPM_VERSION }} --registry=https://registry.npmjs.org
 
       - uses: microbit-foundation/npm-package-versioner-action@v3
 
@@ -52,7 +58,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: echo "ML_THEME_VERSION=$(jq -r '.["theme-package-version"]' workflow-config.json)" >> $GITHUB_ENV
 
       - run: npm install --no-save @microbit-foundation/ml-trainer-microbit@${{ env.ML_THEME_VERSION }}
         if: github.repository_owner == 'microbit-foundation'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ startsWith(github.ref, 'refs/tags/v') && 'release' || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v') }}
 
+env:
+  # renovate: datasource=npm depName=npm
+  NPM_VERSION: "11"
+  # renovate: datasource=npm depName=@microbit-foundation/ml-trainer-microbit registryUrl=https://npm.pkg.github.com
+  ML_THEME_VERSION: 0.2.0-dev.143
+  # renovate: datasource=npm depName=@microbit-foundation/website-deploy-aws registryUrl=https://npm.pkg.github.com
+  DEPLOY_AWS_VERSION: "0.6"
+  # renovate: datasource=npm depName=@microbit-foundation/website-deploy-aws-config registryUrl=https://npm.pkg.github.com
+  DEPLOY_AWS_CONFIG_VERSION: "0.10"
+
 jobs:
   build:
     # Skip apps releases - handled by ios-build.yml and android-build.yml
@@ -37,13 +47,12 @@ jobs:
           node-version: 24
           cache: "npm"
           registry-url: "https://npm.pkg.github.com"
-      - run: npm install -g npm@11 --registry=https://registry.npmjs.org
+      - run: npm install -g npm@${{ env.NPM_VERSION }} --registry=https://registry.npmjs.org
       - uses: microbit-foundation/npm-package-versioner-action@v3
       - run: npm ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: echo "ML_THEME_VERSION=$(jq -r '.["theme-package-version"]' workflow-config.json)" >> $GITHUB_ENV
-      - run: npm install --no-save @microbit-foundation/ml-trainer-microbit@${{ env.ML_THEME_VERSION }} @microbit-foundation/website-deploy-aws@0.6 @microbit-foundation/website-deploy-aws-config@0.10
+      - run: npm install --no-save @microbit-foundation/ml-trainer-microbit@${{ env.ML_THEME_VERSION }} @microbit-foundation/website-deploy-aws@${{ env.DEPLOY_AWS_VERSION }} @microbit-foundation/website-deploy-aws-config@${{ env.DEPLOY_AWS_CONFIG_VERSION }}
         if: github.repository_owner == 'microbit-foundation'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -11,6 +11,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ startsWith(github.ref, 'refs/tags/v') && 'release' || github.ref }}
   cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/v') }}
 
+env:
+  # renovate: datasource=npm depName=npm
+  NPM_VERSION: "11"
+  # renovate: datasource=npm depName=@microbit-foundation/ml-trainer-microbit registryUrl=https://npm.pkg.github.com
+  ML_THEME_VERSION: 0.2.0-dev.143
+
 jobs:
   build-ios:
     # Only run for apps releases, or pushes to main or branches whose name ends with -apps
@@ -29,7 +35,7 @@ jobs:
           cache: "npm"
           registry-url: "https://npm.pkg.github.com"
 
-      - run: npm install -g npm@11 --registry=https://registry.npmjs.org
+      - run: npm install -g npm@${{ env.NPM_VERSION }} --registry=https://registry.npmjs.org
 
       - uses: microbit-foundation/npm-package-versioner-action@v3
 
@@ -55,7 +61,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: echo "ML_THEME_VERSION=$(jq -r '.["theme-package-version"]' workflow-config.json)" >> $GITHUB_ENV
 
       - run: npm install --no-save @microbit-foundation/ml-trainer-microbit@${{ env.ML_THEME_VERSION }}
         if: github.repository_owner == 'microbit-foundation'

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>microbit-foundation/renovate"]
+}

--- a/workflow-config.json
+++ b/workflow-config.json
@@ -1,3 +1,0 @@
-{
-  "theme-package-version": "0.2.0-dev.143"
-}


### PR DESCRIPTION
Extends the shared policy preset in microbit-foundation/renovate.

CI-installed npm packages (theme package, deploy tooling, npm itself) are pinned as workflow env vars with renovate marker comments, which the preset's customManagers:githubActionsVersions manager understands natively. Replaces workflow-config.json and its jq indirection; the theme pin is duplicated across the three workflows but Renovate updates every occurrence in one PR.