### PR TITLE
Drop unused eslint-plugin-react-refresh

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -33,7 +33,6 @@ module.exports = {
     project: ["./tsconfig.json", "./tsconfig.node.json"],
     tsconfigRootDir: __dirname,
   },
-  plugins: ["react-refresh"],
   settings: {
     react: {
       version: "18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,6 @@
         "eslint": "^8.57.0",
         "eslint-plugin-react": "^7.34.0",
         "eslint-plugin-react-hooks": "^4.6.0",
-        "eslint-plugin-react-refresh": "^0.4.6",
         "jsdom": "^24.0.0",
         "lightningcss": "^1.31.1",
         "patch-package": "^8.0.1",
@@ -7243,15 +7242,6 @@
       },
       "peerDependencies": {
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
-      }
-    },
-    "node_modules/eslint-plugin-react-refresh": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.7.tgz",
-      "integrity": "sha512-yrj+KInFmwuQS2UQcg1SF83ha1tuHC1jMQbRNyuWtlEzzKRDgAl7L4Yp4NlDUZTZNlWvHEzOtJhMi40R7JxcSw==",
-      "dev": true,
-      "peerDependencies": {
-        "eslint": ">=7"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "eslint": "^8.57.0",
     "eslint-plugin-react": "^7.34.0",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-react-refresh": "^0.4.6",
     "jsdom": "^24.0.0",
     "lightningcss": "^1.31.1",
     "patch-package": "^8.0.1",


### PR DESCRIPTION
The plugin is registered in `.eslintrc.cjs` but no `react-refresh/*` rule is ever enabled, so it has no effect. It came in with the Vite React TS template, which enables `only-export-components`; we dropped the rule and kept the plugin.

Removing it also unblocks Renovate. `eslint-plugin-react-refresh@0.5.0` moved its peer range to eslint 9/10 while we are still on eslint 8, and the resulting `ERESOLVE` makes Renovate's lockfile generation fail. It then commits the `package.json` edits alone, which silently strands every lock-only update in the grouped PR (#993) and breaks `npm ci` in CI.

If we want the rule rather than the removal, that is a separate piece of work: enabling `only-export-components` today reports 36 violations, and 0.5.x needs the eslint 9 flat config migration first.