### PR TITLE
Return a string from the mark callback in the record hint

### DIFF
--- a/src/pages/DataSamplesPage.tsx
+++ b/src/pages/DataSamplesPage.tsx
@@ -315,12 +315,10 @@ const getHintText = (
     }
     case "record-action": {
       return isConnected
-        ? intl
-            .formatMessage(
-              { id: "record-hint-button-b" },
-              { mark: (chunks: string[]) => chunks }
-            )
-            .toString()
+        ? intl.formatMessage(
+            { id: "record-hint-button-b" },
+            { mark: (chunks: string[]) => chunks.join("") }
+          )
         : intl.formatMessage({ id: "record-hint" });
     }
     case "name-action-short":


### PR DESCRIPTION
react-intl 6.8 narrows the `formatMessage` overloads: a rich text callback returning an array no longer selects the string-returning one, so the result is `unknown` and the `.toString()` on it fails with `TS2571`. `record-hint-button-b` has a single `<mark>`, so joining the chunks gives the same output as the old array `.toString()`.

react-intl is `^6.6.8` here, so 6.8.9 is a lock-only update inside the pending third-party batch (#993). Simulating that batch against `main` — refresh every in-range dependency, Playwright excluded now that it is grouped separately — this is the only thing that breaks the build. It compiles against 6.6.8 too, so it can land ahead of the batch rather than inside it.