### PR TITLE
Move the Playwright image to the noble variant

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
       - run: npm run ci
       - name: Run Playwright tests
         if: env.STAGE == 'REVIEW' || env.STAGE == 'STAGING' || env.STAGE == 'BETA'
-        uses: docker://mcr.microsoft.com/playwright:v1.62.1-jammy
+        uses: docker://mcr.microsoft.com/playwright:v1.62.1-noble
         with:
           args: npx playwright test
       - name: Store reports


### PR DESCRIPTION
The suffix names the Ubuntu release the image is built on, and Renovate only offers tags whose suffix matches the one already there. So each repo tracks its own distro line indefinitely, and on the day a suffix stops being published that repo's image quietly stops updating while the npm half of the Playwright group carries on — which then fails with `Executable does not exist at /ms-playwright/...`.

jammy is 22.04 and the older of the two variants Playwright still publishes. python-editor-v3 is already on noble with an identical container-action step and passes, so this aligns the rest rather than trying anything new. The version is unchanged: only the distro moves here.

Part of aligning all four e2e repos on `-noble`, alongside microbit-foundation/renovate#5 which records the convention.

ml-trainer is already on v1.62.1, so this is the whole change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)