### PR TITLE
Memoise useGraphColors so its callers can rely on it

### DIFF
--- a/src/hooks/use-graph-colors.ts
+++ b/src/hooks/use-graph-colors.ts
@@ -3,31 +3,33 @@
  *
  * SPDX-License-Identifier: MIT
  */
+import { useMemo } from "react";
 import { GraphColorScheme } from "../settings";
 
-// eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix -- consumed as a hook; renaming its call sites is a separate change
 export const useGraphColors = (graphColorScheme: GraphColorScheme) => {
-  switch (graphColorScheme) {
-    case "color-blind-1": {
-      return {
-        x: "rgb(42, 146, 214)",
-        y: "rgb(205, 3, 101)",
-        z: "rgb(0, 0, 0)",
-      };
+  return useMemo(() => {
+    switch (graphColorScheme) {
+      case "color-blind-1": {
+        return {
+          x: "rgb(42, 146, 214)",
+          y: "rgb(205, 3, 101)",
+          z: "rgb(0, 0, 0)",
+        };
+      }
+      case "color-blind-2": {
+        return {
+          x: "rgb(42, 146, 214)",
+          y: "rgb(0, 160, 0)",
+          z: "rgb(0, 0, 0)",
+        };
+      }
+      default: {
+        return {
+          x: "rgb(255, 68, 68)",
+          y: "rgb(29, 157, 29)",
+          z: "rgb(0, 0, 191)",
+        };
+      }
     }
-    case "color-blind-2": {
-      return {
-        x: "rgb(42, 146, 214)",
-        y: "rgb(0, 160, 0)",
-        z: "rgb(0, 0, 0)",
-      };
-    }
-    default: {
-      return {
-        x: "rgb(255, 68, 68)",
-        y: "rgb(29, 157, 29)",
-        z: "rgb(0, 0, 191)",
-      };
-    }
-  }
+  }, [graphColorScheme]);
 };


### PR DESCRIPTION
useGraphColors returned a fresh object on every call, so RecordingGraph's effect saw a new colors identity each render and tore down and rebuilt its Chart.js chart every time. The other three callers sidestep this by depending on colors.x, colors.y and colors.z individually, which compare as strings.

Its sibling useGraphLineStyles is the same switch-over-a-scheme shape but wraps the switch in useMemo, which is why lineStyles is stable in that same dependency array while colors was not. Match it.

This is what the eslint-react no-unnecessary-use-prefix warning was pointing at in 44c6a478.