### PR TITLE
Centre the loading spinner

### DIFF
--- a/src/components/LoadingOverlay.tsx
+++ b/src/components/LoadingOverlay.tsx
@@ -20,8 +20,8 @@ const LoadingOverlay = ({ loading }: LoadingOverlayProps) => {
       contentCss={{
         background: "transparent",
         boxShadow: "none",
-        alignItems: "center",
-        justifyContent: "center",
+        width: "auto",
+        maxWidth: "none",
       }}
     >
       <Spinner


### PR DESCRIPTION
Fixes https://github.com/microbit-foundation/ml-trainer/issues/1024

The overlay already centres the dialog box (div with class `dialog__content`), but the box was full width (448px, the default md size) and its inner section aligns children to the start, so the spinner sat at the left edge of an invisible box.

Setting the box width to auto and removing the max width lets it shrink to the spinner, so the overlay's centring now centres the spinner itself.