### PR TITLE
Pin Xcode 26 in the iOS build

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -35,8 +35,17 @@ jobs:
       # default Xcode over its lifetime, including across majors. Xcode 27
       # builds against the iOS 27 SDK, which refuses to launch an app that
       # hasn't adopted the UIScene lifecycle, so let that upgrade be a
-      # deliberate change here rather than an image refresh.
-      - run: sudo xcode-select -s /Applications/Xcode_26.app
+      # deliberate change here rather than an image refresh. The image only
+      # symlinks exact minors, so take the newest 26.x present.
+      - name: Pin Xcode 26
+        run: |
+          xcode="$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1)"
+          if [ -z "$xcode" ]; then
+            echo "::error::No Xcode 26.x on this runner image"
+            exit 1
+          fi
+          sudo xcode-select -s "$xcode"
+          xcodebuild -version
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -31,6 +31,13 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
+      # The runner image pins macOS, not Xcode: GitHub bumps an image's
+      # default Xcode over its lifetime, including across majors. Xcode 27
+      # builds against the iOS 27 SDK, which refuses to launch an app that
+      # hasn't adopted the UIScene lifecycle, so let that upgrade be a
+      # deliberate change here rather than an image refresh.
+      - run: sudo xcode-select -s /Applications/Xcode_26.app
+
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24


### PR DESCRIPTION
runs-on: macos-26 fixes the runner image but not the Xcode within it; GitHub moves an image's default Xcode over time, and has done so across majors before. A move to Xcode 27 would build against the iOS 27 SDK, which requires the UIScene lifecycle we haven't adopted yet, so the app would crash on launch. Pin it so that migration lands when we choose it.

See follow-up ticket #1029 